### PR TITLE
feat: wire up Supabase (schema, RLS, seed, email/password auth)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 # Supabase project credentials (wired up starting Round 2).
+# NEXT_PUBLIC_SUPABASE_ANON_KEY takes the publishable key (sb_publishable_...)
+# from Project Settings > API in the Supabase dashboard.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Set to "true" once Google OAuth is configured in the Supabase dashboard
+# (Authentication > Providers > Google). Leave unset/false until then.
+NEXT_PUBLIC_ENABLE_GOOGLE_AUTH=

--- a/app/app/actions.ts
+++ b/app/app/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export async function logout() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/login");
+}

--- a/app/app/exercises/page.tsx
+++ b/app/app/exercises/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Exercises — Coach Zone",
+};
+
+export default function ExercisesPlaceholder() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-6 text-center text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Exercises are coming in Round 3
+      </h1>
+      <p className="mt-3 max-w-sm text-neutral-600 dark:text-neutral-400">
+        This is where you&rsquo;ll browse the official exercise library and
+        build your own drills.
+      </p>
+      <Link
+        href="/app"
+        className="mt-8 rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+      >
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { logout } from "./actions";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Coach Zone",
+};
+
+const navItems = [
+  {
+    href: "/app/exercises",
+    title: "Exercises",
+    description: "Browse the official library and build your own drills.",
+  },
+  {
+    href: "/app/workouts",
+    title: "Workouts",
+    description: "Plan training sessions and share them with your team.",
+  },
+];
+
+export default async function AppHomePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Middleware protects this route, so user is always set here. Fall back
+  // defensively in case the profiles row hasn't been created yet.
+  const { data: profile } = user
+    ? await supabase
+        .from("profiles")
+        .select("display_name")
+        .eq("id", user.id)
+        .single()
+    : { data: null };
+
+  const displayName =
+    profile?.display_name ?? user?.email?.split("@")[0] ?? "Coach";
+
+  return (
+    <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
+        <span className="text-lg font-semibold tracking-tight">Coach Zone</span>
+        <form action={logout}>
+          <button
+            type="submit"
+            className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Log out
+          </button>
+        </form>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+          Welcome, {displayName}
+        </h1>
+        <p className="mt-3 text-neutral-600 dark:text-neutral-400">
+          Here&rsquo;s your Coach Zone home base.
+        </p>
+
+        <div className="mt-10 grid gap-6 sm:grid-cols-2">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="rounded-2xl border border-neutral-200 p-6 transition-colors hover:border-emerald-600/50 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-900"
+            >
+              <h2 className="text-lg font-semibold">{item.title}</h2>
+              <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+                {item.description}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/app/workouts/page.tsx
+++ b/app/app/workouts/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Workouts — Coach Zone",
+};
+
+export default function WorkoutsPlaceholder() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-6 text-center text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Workouts are coming in Round 4
+      </h1>
+      <p className="mt-3 max-w-sm text-neutral-600 dark:text-neutral-400">
+        This is where you&rsquo;ll assemble training sessions and share them
+        with your team.
+      </p>
+      <Link
+        href="/app"
+        className="mt-8 rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+      >
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// OAuth (Google) callback. Dormant until Google sign-in is enabled: see
+// GoogleAuthButton and the setup instructions.
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/app";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      return NextResponse.redirect(new URL(next, request.url));
+    }
+  }
+
+  const redirectUrl = new URL("/login", request.url);
+  redirectUrl.searchParams.set("error", "oauth_failed");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,0 +1,31 @@
+import type { EmailOtpType } from "@supabase/supabase-js";
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// Hit by the links in Supabase's "Confirm signup" and "Reset Password" email
+// templates, which must be set to point here with token_hash/type/next
+// query params (see the setup instructions) instead of the default
+// ConfirmationURL - that default doesn't play well with cookie-based SSR
+// sessions.
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+  const next = searchParams.get("next") ?? "/app";
+
+  if (tokenHash && type) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash: tokenHash,
+    });
+
+    if (!error) {
+      return NextResponse.redirect(new URL(next, request.url));
+    }
+  }
+
+  const redirectUrl = new URL("/login", request.url);
+  redirectUrl.searchParams.set("error", "confirmation_failed");
+  return NextResponse.redirect(redirectUrl);
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { AuthShell } from "@/components/auth/AuthShell";
+import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Reset password — Coach Zone",
+};
+
+export default function ForgotPasswordPage() {
+  return (
+    <AuthShell
+      title="Reset your password"
+      subtitle="Enter your email and we'll send you a reset link."
+    >
+      <ForgotPasswordForm />
+    </AuthShell>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,21 +1,33 @@
-import Link from "next/link";
+import type { Metadata } from "next";
+import { AuthShell } from "@/components/auth/AuthShell";
+import { LoginForm } from "@/components/auth/LoginForm";
 
-export default function LoginPlaceholder() {
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Log in — Coach Zone",
+};
+
+const QUERY_ERROR_MESSAGES: Record<string, string> = {
+  confirmation_failed:
+    "That confirmation link is invalid or has expired. Try logging in, or sign up again to get a new one.",
+  oauth_failed: "Google sign-in didn't complete. Please try again.",
+};
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+  const initialError = error ? QUERY_ERROR_MESSAGES[error] : undefined;
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-6 text-center text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-      <h1 className="text-2xl font-semibold tracking-tight">
-        Login is coming soon
-      </h1>
-      <p className="mt-3 max-w-sm text-neutral-600 dark:text-neutral-400">
-        Authentication lands in Round 2. For now, this is just a placeholder for
-        the &ldquo;Log in&rdquo; button.
-      </p>
-      <Link
-        href="/"
-        className="mt-8 rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
-      >
-        Back to home
-      </Link>
-    </div>
+    <AuthShell
+      title="Welcome back"
+      subtitle="Log in to plan your next training session."
+    >
+      <LoginForm initialError={initialError} />
+    </AuthShell>
   );
 }

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { AuthShell } from "@/components/auth/AuthShell";
+import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Set new password — Coach Zone",
+};
+
+export default async function ResetPasswordPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Reached without a valid recovery session: the link was already used,
+  // expired, or the user navigated here directly.
+  if (!user) {
+    return (
+      <AuthShell
+        title="Link expired"
+        subtitle="This password reset link is invalid or has expired."
+      >
+        <Link
+          href="/forgot-password"
+          className="block w-full rounded-full bg-emerald-600 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Request a new link
+        </Link>
+      </AuthShell>
+    );
+  }
+
+  return (
+    <AuthShell
+      title="Set a new password"
+      subtitle="Choose a new password for your account."
+    >
+      <ResetPasswordForm />
+    </AuthShell>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { AuthShell } from "@/components/auth/AuthShell";
+import { SignupForm } from "@/components/auth/SignupForm";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Sign up — Coach Zone",
+};
+
+export default function SignupPage() {
+  return (
+    <AuthShell
+      title="Create your account"
+      subtitle="Build your exercise library and start planning sessions."
+    >
+      <SignupForm />
+    </AuthShell>
+  );
+}

--- a/components/auth/AuthShell.tsx
+++ b/components/auth/AuthShell.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export function AuthShell({
+  title,
+  subtitle,
+  children,
+  footer,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <header className="mx-auto w-full max-w-6xl px-6 py-6">
+        <Link href="/" className="text-lg font-semibold tracking-tight">
+          Coach Zone
+        </Link>
+      </header>
+
+      <main className="flex flex-1 items-center justify-center px-6 pb-16">
+        <div className="w-full max-w-sm">
+          <div className="text-center">
+            <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+            {subtitle && (
+              <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+                {subtitle}
+              </p>
+            )}
+          </div>
+
+          <div className="mt-8">{children}</div>
+
+          {footer && (
+            <p className="mt-6 text-center text-sm text-neutral-600 dark:text-neutral-400">
+              {footer}
+            </p>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/components/auth/ForgotPasswordForm.tsx
+++ b/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type FormEvent } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { getAuthErrorMessage } from "@/lib/supabase/errors";
+import { FormField } from "./FormField";
+import { SubmitButton } from "./SubmitButton";
+import { FormBanner } from "./FormBanner";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState("");
+  const [fieldError, setFieldError] = useState<string | undefined>();
+  const [formError, setFormError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    if (!EMAIL_PATTERN.test(email)) {
+      setFieldError("Please enter a valid email address.");
+      return;
+    }
+    setFieldError(undefined);
+
+    setLoading(true);
+    const supabase = createClient();
+    const { error } = await supabase.auth.resetPasswordForEmail(email);
+    setLoading(false);
+
+    if (error) {
+      setFormError(getAuthErrorMessage(error));
+      return;
+    }
+
+    // Supabase never reveals whether the email is registered, so we always
+    // show the same generic confirmation regardless of the outcome.
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <div className="space-y-4 text-center">
+        <FormBanner
+          variant="success"
+          message="If an account exists for that email, we've sent a password reset link."
+        />
+        <Link
+          href="/login"
+          className="inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Back to log in
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
+      <FormBanner variant="error" message={formError} />
+
+      <FormField
+        id="email"
+        label="Email"
+        type="email"
+        autoComplete="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        error={fieldError}
+      />
+
+      <SubmitButton loading={loading} loadingText="Sending link…">
+        Send reset link
+      </SubmitButton>
+
+      <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+        Remembered your password?{" "}
+        <Link
+          href="/login"
+          className="font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Log in
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/components/auth/FormBanner.tsx
+++ b/components/auth/FormBanner.tsx
@@ -1,0 +1,23 @@
+export function FormBanner({
+  variant,
+  message,
+}: {
+  variant: "error" | "success";
+  message?: string | null;
+}) {
+  if (!message) return null;
+
+  const styles =
+    variant === "error"
+      ? "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-400"
+      : "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-400";
+
+  return (
+    <div
+      role={variant === "error" ? "alert" : "status"}
+      className={`mb-4 rounded-lg border px-3 py-2 text-sm ${styles}`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/components/auth/FormField.tsx
+++ b/components/auth/FormField.tsx
@@ -1,0 +1,38 @@
+import type { InputHTMLAttributes } from "react";
+
+interface FormFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+}
+
+export function FormField({ label, error, id, ...inputProps }: FormFieldProps) {
+  const errorId = error ? `${id}-error` : undefined;
+
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium">
+        {label}
+      </label>
+      <input
+        id={id}
+        aria-invalid={error ? "true" : "false"}
+        aria-describedby={errorId}
+        className={`mt-1.5 w-full rounded-lg border bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:bg-neutral-900 ${
+          error
+            ? "border-red-400 dark:border-red-500"
+            : "border-neutral-300 dark:border-neutral-700"
+        }`}
+        {...inputProps}
+      />
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          className="mt-1.5 text-sm text-red-600 dark:text-red-400"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/auth/GoogleAuthButton.tsx
+++ b/components/auth/GoogleAuthButton.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+
+// Google OAuth needs a client ID/secret configured in the Supabase dashboard
+// (Authentication > Providers > Google), which requires a Google Cloud
+// Console project that doesn't exist yet. This flag keeps the code path
+// ready without exposing a button that would just fail.
+const GOOGLE_AUTH_ENABLED =
+  process.env.NEXT_PUBLIC_ENABLE_GOOGLE_AUTH === "true";
+
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className="h-4 w-4 shrink-0">
+      <path
+        fill="#4285F4"
+        d="M23.49 12.27c0-.79-.07-1.54-.19-2.27H12v4.51h6.47c-.29 1.48-1.14 2.73-2.4 3.58v3h3.86c2.26-2.09 3.56-5.17 3.56-8.82z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 24c3.24 0 5.95-1.08 7.93-2.91l-3.86-3c-1.08.72-2.45 1.15-4.07 1.15-3.13 0-5.78-2.11-6.73-4.96H1.29v3.09C3.26 21.3 7.31 24 12 24z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.27 14.28A7.19 7.19 0 0 1 4.9 12c0-.79.14-1.56.37-2.28V6.63H1.29A11.96 11.96 0 0 0 0 12c0 1.93.46 3.76 1.29 5.37z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 4.77c1.76 0 3.34.6 4.58 1.79l3.43-3.43C17.94 1.19 15.24 0 12 0 7.31 0 3.26 2.7 1.29 6.63l3.98 3.09C6.22 6.88 8.87 4.77 12 4.77z"
+      />
+    </svg>
+  );
+}
+
+export function GoogleAuthButton() {
+  async function handleClick() {
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    });
+  }
+
+  if (!GOOGLE_AUTH_ENABLED) {
+    return (
+      <div>
+        <button
+          type="button"
+          disabled
+          aria-disabled="true"
+          title="Google sign-in isn't configured yet"
+          className="flex w-full cursor-not-allowed items-center justify-center gap-2 rounded-full border border-neutral-200 px-4 py-2.5 text-sm font-medium text-neutral-400 dark:border-neutral-800 dark:text-neutral-600"
+        >
+          <GoogleIcon />
+          Continue with Google
+        </button>
+        <p className="mt-1.5 text-center text-xs text-neutral-500 dark:text-neutral-500">
+          Not yet configured
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex w-full items-center justify-center gap-2 rounded-full border border-neutral-300 px-4 py-2.5 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+    >
+      <GoogleIcon />
+      Continue with Google
+    </button>
+  );
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { getAuthErrorMessage } from "@/lib/supabase/errors";
+import { FormField } from "./FormField";
+import { SubmitButton } from "./SubmitButton";
+import { FormBanner } from "./FormBanner";
+import { GoogleAuthButton } from "./GoogleAuthButton";
+
+interface FieldErrors {
+  email?: string;
+  password?: string;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function LoginForm({ initialError }: { initialError?: string | null }) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(
+    initialError ?? null,
+  );
+  const [loading, setLoading] = useState(false);
+
+  function validate(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (!EMAIL_PATTERN.test(email)) {
+      errors.email = "Please enter a valid email address.";
+    }
+    if (!password) {
+      errors.password = "Please enter your password.";
+    }
+    return errors;
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    setLoading(true);
+    const supabase = createClient();
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (error) {
+      setLoading(false);
+      setFormError(getAuthErrorMessage(error));
+      return;
+    }
+
+    router.push("/app");
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
+      <FormBanner variant="error" message={formError} />
+
+      <GoogleAuthButton />
+
+      <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-500">
+        <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
+        or log in with email
+        <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+
+      <FormField
+        id="email"
+        label="Email"
+        type="email"
+        autoComplete="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        error={fieldErrors.email}
+      />
+      <div>
+        <FormField
+          id="password"
+          label="Password"
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={fieldErrors.password}
+        />
+        <div className="mt-1.5 text-right">
+          <Link
+            href="/forgot-password"
+            className="text-sm font-medium text-emerald-600 hover:text-emerald-500"
+          >
+            Forgot password?
+          </Link>
+        </div>
+      </div>
+
+      <SubmitButton loading={loading} loadingText="Logging in…">
+        Log in
+      </SubmitButton>
+
+      <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+        Don&rsquo;t have an account?{" "}
+        <Link
+          href="/signup"
+          className="font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Sign up
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/components/auth/ResetPasswordForm.tsx
+++ b/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { getAuthErrorMessage } from "@/lib/supabase/errors";
+import { FormField } from "./FormField";
+import { SubmitButton } from "./SubmitButton";
+import { FormBanner } from "./FormBanner";
+
+interface FieldErrors {
+  password?: string;
+  confirmPassword?: string;
+}
+
+export function ResetPasswordForm() {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function validate(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (password.length < 6) {
+      errors.password = "Password must be at least 6 characters.";
+    }
+    if (confirmPassword !== password) {
+      errors.confirmPassword = "Passwords don't match.";
+    }
+    return errors;
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    setLoading(true);
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({ password });
+
+    if (error) {
+      setLoading(false);
+      setFormError(getAuthErrorMessage(error));
+      return;
+    }
+
+    router.push("/app");
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
+      <FormBanner variant="error" message={formError} />
+
+      <FormField
+        id="password"
+        label="New password"
+        type="password"
+        autoComplete="new-password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        error={fieldErrors.password}
+      />
+      <FormField
+        id="confirmPassword"
+        label="Confirm new password"
+        type="password"
+        autoComplete="new-password"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        error={fieldErrors.confirmPassword}
+      />
+
+      <SubmitButton loading={loading} loadingText="Saving…">
+        Save new password
+      </SubmitButton>
+    </form>
+  );
+}

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { getAuthErrorMessage } from "@/lib/supabase/errors";
+import { FormField } from "./FormField";
+import { SubmitButton } from "./SubmitButton";
+import { FormBanner } from "./FormBanner";
+import { GoogleAuthButton } from "./GoogleAuthButton";
+
+interface FieldErrors {
+  fullName?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function SignupForm() {
+  const router = useRouter();
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [confirmationSentTo, setConfirmationSentTo] = useState<string | null>(
+    null,
+  );
+
+  function validate(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (!fullName.trim()) errors.fullName = "Please enter your name.";
+    if (!EMAIL_PATTERN.test(email)) {
+      errors.email = "Please enter a valid email address.";
+    }
+    if (password.length < 6) {
+      errors.password = "Password must be at least 6 characters.";
+    }
+    if (confirmPassword !== password) {
+      errors.confirmPassword = "Passwords don't match.";
+    }
+    return errors;
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    setLoading(true);
+    const supabase = createClient();
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { full_name: fullName.trim() } },
+    });
+    setLoading(false);
+
+    if (error) {
+      setFormError(getAuthErrorMessage(error));
+      return;
+    }
+
+    // Supabase returns a user with an empty identities array (no error) when
+    // the email already belongs to a confirmed account - a deliberate
+    // anti-enumeration behavior, not a real new signup.
+    if (data.user && data.user.identities?.length === 0) {
+      setFormError(
+        "An account with this email may already exist. Try logging in or resetting your password.",
+      );
+      return;
+    }
+
+    if (data.session) {
+      router.push("/app");
+      router.refresh();
+      return;
+    }
+
+    setConfirmationSentTo(email);
+  }
+
+  if (confirmationSentTo) {
+    return (
+      <div className="space-y-4 text-center">
+        <FormBanner
+          variant="success"
+          message={`We've sent a confirmation link to ${confirmationSentTo}. Open it to activate your account.`}
+        />
+        <Link
+          href="/login"
+          className="inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Back to log in
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
+      <FormBanner variant="error" message={formError} />
+
+      <GoogleAuthButton />
+
+      <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-500">
+        <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
+        or sign up with email
+        <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+
+      <FormField
+        id="fullName"
+        label="Full name"
+        type="text"
+        autoComplete="name"
+        value={fullName}
+        onChange={(e) => setFullName(e.target.value)}
+        error={fieldErrors.fullName}
+      />
+      <FormField
+        id="email"
+        label="Email"
+        type="email"
+        autoComplete="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        error={fieldErrors.email}
+      />
+      <FormField
+        id="password"
+        label="Password"
+        type="password"
+        autoComplete="new-password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        error={fieldErrors.password}
+      />
+      <FormField
+        id="confirmPassword"
+        label="Confirm password"
+        type="password"
+        autoComplete="new-password"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        error={fieldErrors.confirmPassword}
+      />
+
+      <SubmitButton loading={loading} loadingText="Creating account…">
+        Create account
+      </SubmitButton>
+
+      <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+        Already have an account?{" "}
+        <Link
+          href="/login"
+          className="font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Log in
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/components/auth/SubmitButton.tsx
+++ b/components/auth/SubmitButton.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export function SubmitButton({
+  loading,
+  loadingText,
+  children,
+}: {
+  loading?: boolean;
+  loadingText?: string;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={loading}
+      className="w-full rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {loading ? (loadingText ?? "Please wait…") : children}
+    </button>
+  );
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,9 @@
+import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "./types";
+
+export function createClient() {
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}

--- a/lib/supabase/errors.ts
+++ b/lib/supabase/errors.ts
@@ -1,0 +1,62 @@
+import { isAuthError } from "@supabase/supabase-js";
+
+const MESSAGES_BY_CODE: Record<string, string> = {
+  user_already_exists:
+    "An account with this email already exists. Try logging in instead.",
+  email_exists:
+    "An account with this email already exists. Try logging in instead.",
+  invalid_credentials: "Incorrect email or password.",
+  email_not_confirmed:
+    "Please confirm your email address before logging in. Check your inbox for the confirmation link.",
+  email_address_invalid: "Please enter a valid email address.",
+  email_address_not_authorized: "This email address isn't allowed to sign up.",
+  signup_disabled: "Sign-ups are currently disabled.",
+  user_banned:
+    "This account has been disabled. Contact support if you think this is a mistake.",
+  weak_password: "Password must be at least 6 characters.",
+  same_password:
+    "Your new password must be different from your current password.",
+  over_email_send_rate_limit:
+    "Too many attempts. Please wait a moment and try again.",
+  over_request_rate_limit:
+    "Too many attempts. Please wait a moment and try again.",
+  validation_failed: "Please check the form for errors and try again.",
+  session_not_found: "Your session has expired. Please log in again.",
+  user_not_found: "Incorrect email or password.",
+};
+
+const MESSAGES_BY_TEXT: Array<[RegExp, string]> = [
+  [/already registered/i, MESSAGES_BY_CODE.user_already_exists],
+  [/invalid login credentials/i, MESSAGES_BY_CODE.invalid_credentials],
+  [/email not confirmed/i, MESSAGES_BY_CODE.email_not_confirmed],
+  [/password should be at least/i, MESSAGES_BY_CODE.weak_password],
+  [/session missing/i, MESSAGES_BY_CODE.session_not_found],
+  [/rate limit/i, MESSAGES_BY_CODE.over_email_send_rate_limit],
+];
+
+const FALLBACK_MESSAGE = "Something went wrong. Please try again.";
+
+/**
+ * Maps a Supabase Auth error to a short, user-facing message. Never returns
+ * the raw error message/stack, since those can leak implementation details.
+ *
+ * Auth errors aren't all AuthApiError (HTTP responses) - client-thrown
+ * variants like AuthWeakPasswordError or AuthSessionMissingError extend the
+ * base AuthError instead, so we check broadly with isAuthError.
+ */
+export function getAuthErrorMessage(error: unknown): string {
+  if (!error) return FALLBACK_MESSAGE;
+
+  if (isAuthError(error)) {
+    const code = error.code;
+    if (code && MESSAGES_BY_CODE[code]) {
+      return MESSAGES_BY_CODE[code];
+    }
+
+    for (const [pattern, message] of MESSAGES_BY_TEXT) {
+      if (pattern.test(error.message)) return message;
+    }
+  }
+
+  return FALLBACK_MESSAGE;
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,0 +1,57 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+import type { Database } from "./types";
+
+const AUTH_ONLY_PATHS = new Set(["/login", "/signup"]);
+
+function isProtectedPath(pathname: string) {
+  return pathname === "/app" || pathname.startsWith("/app/");
+}
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  // Must be getUser(), not getSession(): getSession() only reads the cookie
+  // and can't be trusted for authorization decisions, while getUser()
+  // revalidates the token against the Supabase Auth server.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { pathname } = request.nextUrl;
+
+  if (!user && isProtectedPath(pathname)) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/login";
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  if (user && AUTH_ONLY_PATHS.has(pathname)) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/app";
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  return supabaseResponse;
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,30 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { Database } from "./types";
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            // Called from a Server Component during render, where cookies
+            // can't be set. Safe to ignore because middleware refreshes the
+            // session on every request.
+          }
+        },
+      },
+    },
+  );
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -1,0 +1,220 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Difficulty = 1 | 2 | 3 | 4 | 5;
+
+export type WorkoutSection = "warmup" | "main" | "positional" | "cooldown";
+
+export interface Database {
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string;
+          display_name: string;
+          club_name: string | null;
+          avatar_url: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id: string;
+          display_name: string;
+          club_name?: string | null;
+          avatar_url?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          display_name?: string;
+          club_name?: string | null;
+          avatar_url?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
+      categories: {
+        Row: {
+          id: number;
+          slug: string;
+          name_pl: string;
+          name_en: string;
+        };
+        Insert: {
+          id?: number;
+          slug: string;
+          name_pl: string;
+          name_en: string;
+        };
+        Update: {
+          id?: number;
+          slug?: string;
+          name_pl?: string;
+          name_en?: string;
+        };
+        Relationships: [];
+      };
+      exercises: {
+        Row: {
+          id: string;
+          author_id: string | null;
+          category_id: number;
+          title: string;
+          description: string | null;
+          steps: string[];
+          duration_min: number | null;
+          difficulty: Difficulty | null;
+          equipment: string[];
+          media_url: string | null;
+          is_public: boolean;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          author_id?: string | null;
+          category_id: number;
+          title: string;
+          description?: string | null;
+          steps?: string[];
+          duration_min?: number | null;
+          difficulty?: Difficulty | null;
+          equipment?: string[];
+          media_url?: string | null;
+          is_public?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          author_id?: string | null;
+          category_id?: number;
+          title?: string;
+          description?: string | null;
+          steps?: string[];
+          duration_min?: number | null;
+          difficulty?: Difficulty | null;
+          equipment?: string[];
+          media_url?: string | null;
+          is_public?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "exercises_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "exercises_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "categories";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      workouts: {
+        Row: {
+          id: string;
+          owner_id: string;
+          title: string;
+          team_name: string | null;
+          scheduled_for: string | null;
+          notes: string | null;
+          share_id: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          owner_id: string;
+          title: string;
+          team_name?: string | null;
+          scheduled_for?: string | null;
+          notes?: string | null;
+          share_id?: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          owner_id?: string;
+          title?: string;
+          team_name?: string | null;
+          scheduled_for?: string | null;
+          notes?: string | null;
+          share_id?: string;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "workouts_owner_id_fkey";
+            columns: ["owner_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      workout_items: {
+        Row: {
+          id: string;
+          workout_id: string;
+          exercise_id: string;
+          section: WorkoutSection;
+          position: number;
+          duration_min: number | null;
+          assigned_to: string | null;
+        };
+        Insert: {
+          id?: string;
+          workout_id: string;
+          exercise_id: string;
+          section: WorkoutSection;
+          position: number;
+          duration_min?: number | null;
+          assigned_to?: string | null;
+        };
+        Update: {
+          id?: string;
+          workout_id?: string;
+          exercise_id?: string;
+          section?: WorkoutSection;
+          position?: number;
+          duration_min?: number | null;
+          assigned_to?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "workout_items_workout_id_fkey";
+            columns: ["workout_id"];
+            isOneToOne: false;
+            referencedRelation: "workouts";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workout_items_exercise_id_fkey";
+            columns: ["exercise_id"];
+            isOneToOne: false;
+            referencedRelation: "exercises";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+    };
+    Views: Record<string, never>;
+    Functions: {
+      get_shared_workout: {
+        Args: { p_share_id: string };
+        Returns: Json;
+      };
+    };
+    Enums: Record<string, never>;
+  };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@supabase/ssr": "^0.12.0",
+    "@supabase/supabase-js": "^2.110.1",
     "next": "15.5.20",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@supabase/ssr':
+        specifier: ^0.12.0
+        version: 0.12.0(@supabase/supabase-js@2.110.1)
+      '@supabase/supabase-js':
+        specifier: ^2.110.1
+        version: 2.110.1
       next:
         specifier: 15.5.20
         version: 15.5.20(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -382,6 +388,38 @@ packages:
 
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@supabase/auth-js@2.110.1':
+    resolution: {integrity: sha512-8EJUoRoqzAYWkieHrLCrGrxs3cBbRB94xK8GzHe0aSLlSa4mt1enYLCiMgLiKJOF8GNYeX6PLTBNef0XAhILgw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/functions-js@2.110.1':
+    resolution: {integrity: sha512-Pm9HD9Qth6zQO0aOGZ3DxYb6QlCzrkTkP6eUEOvhTlbvcvYRDSCZXIJ5dkDLpqxD+gdrXfWDFOpU9BpRKYjsIQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
+
+  '@supabase/postgrest-js@2.110.1':
+    resolution: {integrity: sha512-BILNhS40oGlP2bn/VJjh/1hCyrWNMmpGZGcCrPvqd5R3s8gf8Bd5qyKoHZdMwTKynGCuJGjagRXa069abhibMw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/realtime-js@2.110.1':
+    resolution: {integrity: sha512-JmWCpMoe2iJPNrXIdHqIvf2Mie6NfSuWHS9Ve6YCmLkn1mNl3vrK3a67IukJ5lPjgmAzB+jFagyMz2oSIX+Xnw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/ssr@0.12.0':
+    resolution: {integrity: sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.108.0
+
+  '@supabase/storage-js@2.110.1':
+    resolution: {integrity: sha512-UqJGzhFMiIRBe8vT7a6ZtrN2U5YufH4Tk9nyc9KKfa2TUtV11BkSg/v3lyy/c4A8SbekVH3UywTF0s42zpF4zw==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/supabase-js@2.110.1':
+    resolution: {integrity: sha512-MiJh0THZgyAvTWm91FOLknjH5dYjXRKOdxpuUsyTVZVXIf7FxCShzevIm4KGCubHRU2n25Gyt8PhTXIFzcD9FA==}
+    engines: {node: '>=22.0.0'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -809,6 +847,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1170,6 +1212,10 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2124,6 +2170,43 @@ snapshots:
 
   '@rushstack/eslint-patch@1.16.1': {}
 
+  '@supabase/auth-js@2.110.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.110.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.4': {}
+
+  '@supabase/postgrest-js@2.110.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.110.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.4
+      tslib: 2.8.1
+
+  '@supabase/ssr@0.12.0(@supabase/supabase-js@2.110.1)':
+    dependencies:
+      '@supabase/supabase-js': 2.110.1
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.110.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.110.1':
+    dependencies:
+      '@supabase/auth-js': 2.110.1
+      '@supabase/functions-js': 2.110.1
+      '@supabase/postgrest-js': 2.110.1
+      '@supabase/realtime-js': 2.110.1
+      '@supabase/storage-js': 2.110.1
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2533,6 +2616,8 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3050,6 +3135,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
 

--- a/supabase/migrations/20260709100000_extensions_and_helpers.sql
+++ b/supabase/migrations/20260709100000_extensions_and_helpers.sql
@@ -1,0 +1,15 @@
+-- Coach Zone — extensions and helper functions
+-- Migration 1 of 4. Run this first.
+
+-- pgcrypto provides gen_random_bytes(), used below to generate share tokens.
+-- (gen_random_uuid() used elsewhere is already built into Postgres core.)
+create extension if not exists pgcrypto;
+
+-- Generates a short, URL-safe random token for public workout share links.
+create or replace function public.generate_share_id()
+returns text
+language sql
+volatile
+as $$
+  select rtrim(translate(encode(gen_random_bytes(9), 'base64'), '+/', '-_'), '=');
+$$;

--- a/supabase/migrations/20260709100100_schema.sql
+++ b/supabase/migrations/20260709100100_schema.sql
@@ -1,0 +1,71 @@
+-- Coach Zone — core schema
+-- Migration 2 of 4. Run after 20260709100000_extensions_and_helpers.sql.
+
+-- profiles: one row per auth user, created by the handle_new_user trigger
+-- (see migration 4). Never inserted directly by clients.
+create table public.profiles (
+  id uuid primary key references auth.users (id) on delete cascade,
+  display_name text not null,
+  club_name text,
+  avatar_url text,
+  created_at timestamptz not null default now()
+);
+
+-- categories: static reference data for exercises, managed via migrations/seed only.
+create table public.categories (
+  id serial primary key,
+  slug text not null unique,
+  name_pl text not null,
+  name_en text not null
+);
+
+-- exercises: author_id is nullable so official library exercises (seeded,
+-- author_id null) can coexist with user-authored ones.
+create table public.exercises (
+  id uuid primary key default gen_random_uuid(),
+  author_id uuid references public.profiles (id) on delete set null,
+  category_id integer not null references public.categories (id),
+  title text not null,
+  description text,
+  steps text[] not null default '{}',
+  duration_min integer,
+  difficulty smallint check (difficulty between 1 and 5),
+  equipment text[] not null default '{}',
+  media_url text,
+  is_public boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index exercises_author_id_idx on public.exercises (author_id);
+create index exercises_category_id_idx on public.exercises (category_id);
+
+-- workouts: a coach's training session plan. share_id is a random,
+-- unguessable token used for the public read-only share link (see the
+-- get_shared_workout function in migration 4).
+create table public.workouts (
+  id uuid primary key default gen_random_uuid(),
+  owner_id uuid not null references public.profiles (id) on delete cascade,
+  title text not null,
+  team_name text,
+  scheduled_for date,
+  notes text,
+  share_id text not null unique default public.generate_share_id(),
+  created_at timestamptz not null default now()
+);
+
+create index workouts_owner_id_idx on public.workouts (owner_id);
+
+-- workout_items: exercises placed into a workout, grouped into sections.
+create table public.workout_items (
+  id uuid primary key default gen_random_uuid(),
+  workout_id uuid not null references public.workouts (id) on delete cascade,
+  exercise_id uuid not null references public.exercises (id),
+  section text not null check (section in ('warmup', 'main', 'positional', 'cooldown')),
+  position integer not null,
+  duration_min integer,
+  assigned_to text
+);
+
+create index workout_items_workout_id_idx on public.workout_items (workout_id);
+create index workout_items_exercise_id_idx on public.workout_items (exercise_id);

--- a/supabase/migrations/20260709100200_rls_policies.sql
+++ b/supabase/migrations/20260709100200_rls_policies.sql
@@ -1,0 +1,130 @@
+-- Coach Zone — Row Level Security
+-- Migration 3 of 4. Run after 20260709100100_schema.sql.
+
+alter table public.profiles enable row level security;
+alter table public.categories enable row level security;
+alter table public.exercises enable row level security;
+alter table public.workouts enable row level security;
+alter table public.workout_items enable row level security;
+
+-- profiles: any authenticated user can read all profiles (needed to show
+-- e.g. a coach's name elsewhere in the app); only the owner can update
+-- their own row. No insert/delete policy - rows are only ever created by
+-- the handle_new_user trigger (security definer, bypasses RLS).
+create policy "profiles_select_authenticated"
+  on public.profiles for select
+  to authenticated
+  using (true);
+
+create policy "profiles_update_own"
+  on public.profiles for update
+  to authenticated
+  using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+-- categories: public reference data, readable by anyone.
+create policy "categories_select_public"
+  on public.categories for select
+  to anon, authenticated
+  using (true);
+
+-- exercises: readable when public or owned; writable only by the author.
+-- Seeded official rows have author_id null, so `author_id = auth.uid()`
+-- is never true for them - no user can insert with a null author_id,
+-- and none can update/delete the seeded rows.
+create policy "exercises_select_own_or_public"
+  on public.exercises for select
+  to authenticated
+  using (is_public or author_id = auth.uid());
+
+create policy "exercises_insert_own"
+  on public.exercises for insert
+  to authenticated
+  with check (author_id = auth.uid());
+
+create policy "exercises_update_own"
+  on public.exercises for update
+  to authenticated
+  using (author_id = auth.uid())
+  with check (author_id = auth.uid());
+
+create policy "exercises_delete_own"
+  on public.exercises for delete
+  to authenticated
+  using (author_id = auth.uid());
+
+-- workouts: full CRUD restricted to the owner. No public select policy -
+-- the public share link is served exclusively through the
+-- get_shared_workout() security definer function (migration 4).
+create policy "workouts_select_own"
+  on public.workouts for select
+  to authenticated
+  using (owner_id = auth.uid());
+
+create policy "workouts_insert_own"
+  on public.workouts for insert
+  to authenticated
+  with check (owner_id = auth.uid());
+
+create policy "workouts_update_own"
+  on public.workouts for update
+  to authenticated
+  using (owner_id = auth.uid())
+  with check (owner_id = auth.uid());
+
+create policy "workouts_delete_own"
+  on public.workouts for delete
+  to authenticated
+  using (owner_id = auth.uid());
+
+-- workout_items: same ownership rule, enforced via the parent workout.
+create policy "workout_items_select_own"
+  on public.workout_items for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.workouts w
+      where w.id = workout_items.workout_id
+        and w.owner_id = auth.uid()
+    )
+  );
+
+create policy "workout_items_insert_own"
+  on public.workout_items for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.workouts w
+      where w.id = workout_items.workout_id
+        and w.owner_id = auth.uid()
+    )
+  );
+
+create policy "workout_items_update_own"
+  on public.workout_items for update
+  to authenticated
+  using (
+    exists (
+      select 1 from public.workouts w
+      where w.id = workout_items.workout_id
+        and w.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.workouts w
+      where w.id = workout_items.workout_id
+        and w.owner_id = auth.uid()
+    )
+  );
+
+create policy "workout_items_delete_own"
+  on public.workout_items for delete
+  to authenticated
+  using (
+    exists (
+      select 1 from public.workouts w
+      where w.id = workout_items.workout_id
+        and w.owner_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/20260709100300_triggers_and_functions.sql
+++ b/supabase/migrations/20260709100300_triggers_and_functions.sql
@@ -1,0 +1,72 @@
+-- Coach Zone — triggers and RPC functions
+-- Migration 4 of 4. Run after 20260709100200_rls_policies.sql.
+
+-- Creates a profiles row right after signup. Runs as security definer so it
+-- can insert into profiles despite the caller not being "authenticated" yet
+-- at the moment auth.users is written.
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, display_name)
+  values (
+    new.id,
+    coalesce(
+      nullif(trim(new.raw_user_meta_data ->> 'full_name'), ''),
+      split_part(new.email, '@', 1)
+    )
+  );
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- Keeps exercises.updated_at current on every row update.
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger exercises_set_updated_at
+  before update on public.exercises
+  for each row execute function public.set_updated_at();
+
+-- Public, read-only access to a shared workout by its unguessable share_id.
+-- Security definer so it can bypass the owner-only RLS policy on workouts /
+-- workout_items, while only ever exposing the one row matched by share_id
+-- plus its items - never a full table scan. Used by the public share link
+-- (frontend for that comes in a later round).
+create or replace function public.get_shared_workout(p_share_id text)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select jsonb_build_object(
+    'workout', to_jsonb(w.*),
+    'items', coalesce(
+      (
+        select jsonb_agg(to_jsonb(wi.*) order by wi.section, wi.position)
+        from public.workout_items wi
+        where wi.workout_id = w.id
+      ),
+      '[]'::jsonb
+    )
+  )
+  from public.workouts w
+  where w.share_id = p_share_id;
+$$;
+
+grant execute on function public.get_shared_workout(text) to anon, authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,114 @@
+-- Coach Zone — official exercise library seed
+-- Run AFTER the schema migration. Official exercises have author_id = NULL.
+-- Descriptions in Polish (target users are Polish football coaches);
+-- category names are bilingual (name_pl / name_en).
+
+insert into public.categories (slug, name_pl, name_en) values
+  ('warmup',      'Rozgrzewka',        'Warm-up'),
+  ('technical',   'Technika',          'Technical'),
+  ('positional',  'Gra pozycyjna',     'Positional play'),
+  ('ssg',         'Gry zadaniowe',     'Small-sided games'),
+  ('strength',    'Motoryka',          'Strength & conditioning'),
+  ('cooldown',    'Schłodzenie',       'Cool-down')
+on conflict (slug) do nothing;
+
+-- Helper: category id by slug is looked up inline via subselect.
+
+insert into public.exercises
+  (author_id, category_id, title, description, steps, duration_min, difficulty, equipment, is_public)
+values
+-- ROZGRZEWKA -----------------------------------------------------------------
+(null, (select id from public.categories where slug='warmup'),
+ 'Rozgrzewka dynamiczna w truchcie',
+ 'Ogólna aktywacja przed treningiem: stopniowe podniesienie tętna i mobilizacja stawów w ruchu, bez statycznego rozciągania.',
+ array['Trucht wzdłuż linii boiska (2 okrążenia)','Wymachy nóg w przód i w bok co 10 m','Skip A, skip C, wielokroki','Krążenia bioder i obręczy barkowej','Kilka przyspieszeń na 70% na dystansie 20 m'],
+ 12, 1, array['pachołki'], true),
+
+(null, (select id from public.categories where slug='warmup'),
+ 'Rondo 4v1',
+ 'Klasyczne dziadki: utrzymanie piłki w kole, aktywacja techniczna i pierwszy kontakt pod presją. Świetne na rozgrzewkę z piłką.',
+ array['4 zawodników na obwodzie koła (śr. 8–10 m), 1 w środku','Podania pierwszym kontaktem, maksymalnie dwa kontakty','Zawodnik ze środka odbiera lub wymusza stratę','Kto stracił lub podał źle — wchodzi do środka','Zmiana broniącego co 2 min'],
+ 10, 2, array['piłki','znaczniki'], true),
+
+(null, (select id from public.categories where slug='warmup'),
+ 'Aktywacja z drabinką koordynacyjną',
+ 'Pobudzenie układu nerwowo-mięśniowego: szybka praca stóp i koordynacja przed częścią główną.',
+ array['5 wzorców kroków przez drabinkę (np. jedna stopa w polu, dwie stopy, bieg bokiem)','Po wyjściu z drabinki 5 m przyspieszenia','2–3 serie na wzorzec','Powrót truchtem do kolejki'],
+ 8, 1, array['drabinka koordynacyjna'], true),
+
+-- TECHNIKA -------------------------------------------------------------------
+(null, (select id from public.categories where slug='technical'),
+ 'Podania w parach na dwa kontakty',
+ 'Doskonalenie jakości pierwszego kontaktu i celności podania na krótkim dystansie.',
+ array['Pary naprzeciw siebie w odległości 8–12 m','Przyjęcie kierunkowe pierwszym kontaktem, podanie drugim','Po 10 podań zmiana nogi przyjmującej','Zwiększaj dystans i tempo z każdą serią'],
+ 12, 2, array['piłki','pachołki'], true),
+
+(null, (select id from public.categories where slug='technical'),
+ 'Prowadzenie piłki w slalomie',
+ 'Kontrola piłki przy zmianach kierunku i praca obu nóg podczas prowadzenia.',
+ array['Ustaw 6 pachołków co 1,5 m','Prowadź piłkę slalomem wewnętrzną i zewnętrzną częścią stopy','Na końcu tor wykończ podaniem do partnera','Mierz czas, ale nie kosztem kontroli'],
+ 10, 2, array['piłki','pachołki'], true),
+
+(null, (select id from public.categories where slug='technical'),
+ 'Uderzenia na bramkę po podaniu',
+ 'Wykończenie akcji: przyjęcie w ruchu i celne uderzenie z pierwszej lub po jednym kontakcie.',
+ array['Podający zagrywa z boku pola karnego','Strzelec nabiega, przyjmuje kierunkowo i uderza','Naprzemiennie prawa i lewa strona','Bramkarz w bramce — realna presja','Rotacja: strzelec → podający → koniec kolejki'],
+ 15, 3, array['piłki','bramka'], true),
+
+-- GRA POZYCYJNA --------------------------------------------------------------
+(null, (select id from public.categories where slug='positional'),
+ 'Gra pozycyjna 6v6+3',
+ 'Utrzymanie piłki z przewagą liczebną i nauka zajmowania właściwych pozycji w strefach.',
+ array['Kwadrat 25x25 m podzielony na strefy','6v6, 3 zawodników neutralnych zawsze z posiadającą drużyną','Cel: 8 podań pod rząd = punkt','Neutralni maksymalnie dwa kontakty','Akcent na szerokość i głębokość ustawienia'],
+ 18, 3, array['piłki','znaczniki','znaczniki treningowe'], true),
+
+(null, (select id from public.categories where slug='positional'),
+ 'Wyprowadzenie piłki spod pressingu 4v2',
+ 'Budowanie gry od tyłu: cierpliwe wyprowadzenie przez linie mimo presji dwóch napastników.',
+ array['4 obrońców/pomocników w prostokącie, 2 napastników presuje','Zadanie: przeprowadzić piłkę przez linię końcową podaniem','Napastnicy po odbiorze strzelają do małej bramki','Zmiana ról co 3 min'],
+ 15, 3, array['piłki','małe bramki','znaczniki'], true),
+
+(null, (select id from public.categories where slug='positional'),
+ 'Przejście z obrony do ataku (tranzycja)',
+ 'Szybkie przejście do ataku po odbiorze i natychmiastowy powrót do obrony po stracie.',
+ array['Dwie drużyny 7v7 na połowie boiska','Po odbiorze drużyna ma 8 s na dojście do bramki','Po stracie natychmiastowy pressing (5 s)','Trener wrzuca nową piłkę po każdej akcji, by utrzymać tempo'],
+ 20, 4, array['piłki','bramki','znaczniki'], true),
+
+-- GRY ZADANIOWE --------------------------------------------------------------
+(null, (select id from public.categories where slug='ssg'),
+ 'Gra 4v4 na cztery bramki',
+ 'Mała gra rozwijająca zmianę kierunku ataku i orientację w przestrzeni.',
+ array['Boisko 30x20 m, po dwie małe bramki na każdej połowie szerokości','Można zdobyć gola w dowolną z dwóch bramek przeciwnika','Zachęcaj do szybkiej zmiany strony ataku','4–6 minut na serię, przerwa na wodę'],
+ 16, 3, array['piłki','małe bramki','znaczniki'], true),
+
+(null, (select id from public.categories where slug='ssg'),
+ 'Gra 7v7 z warunkiem dwóch kontaktów',
+ 'Gra właściwa z ograniczeniem liczby kontaktów — wymusza szybkie myślenie i grę bez piłki.',
+ array['Boisko ok. 50x40 m, bramki z bramkarzami','Maksymalnie dwa kontakty na zawodnika','Trzeci kontakt = rzut wolny dla przeciwnika','Znieś warunek na ostatnie 5 min dla swobodnej gry'],
+ 20, 3, array['piłki','bramki','znaczniki'], true),
+
+-- MOTORYKA -------------------------------------------------------------------
+(null, (select id from public.categories where slug='strength'),
+ 'Interwały biegowe wysokiej intensywności',
+ 'Rozwój wytrzymałości szybkościowej: powtarzane wysiłki blisko maksymalnego tempa.',
+ array['Wyznacz odcinek 40 m','15 s bieg na 90–95%, 45 s trucht/marsz powrotny','6–8 powtórzeń w serii','2 serie z 3 min przerwy między nimi','Kontroluj technikę biegu przy zmęczeniu'],
+ 18, 4, array['pachołki','stoper'], true),
+
+(null, (select id from public.categories where slug='strength'),
+ 'Obwód siłowy z masą własnego ciała',
+ 'Wzmocnienie ogólne i profilaktyka urazów bez sprzętu — do wykonania na boisku.',
+ array['5 stacji: przysiady, wykroki, deska, pompki, mostek biodrowy','40 s pracy / 20 s przerwy na stację','Po pełnym obwodzie 2 min przerwy','2–3 rundy zależnie od okresu przygotowań','Akcent na poprawną technikę, nie liczbę powtórzeń'],
+ 15, 3, array['maty (opcjonalnie)'], true),
+
+-- SCHŁODZENIE ----------------------------------------------------------------
+(null, (select id from public.categories where slug='cooldown'),
+ 'Trucht wytłumiający i rozciąganie statyczne',
+ 'Stopniowe obniżenie tętna i rozciąganie głównych grup mięśniowych po wysiłku.',
+ array['5 min spokojnego truchtu, przechodzącego w marsz','Rozciąganie statyczne: łydki, uda przednie i tylne, biodra','Każda pozycja utrzymywana 20–30 s','Spokojny, głęboki oddech przez cały czas'],
+ 10, 1, array[]::text[], true),
+
+(null, (select id from public.categories where slug='cooldown'),
+ 'Rolowanie i mobilizacja',
+ 'Regeneracja powięziowa i redukcja napięcia mięśniowego po intensywnym treningu.',
+ array['Rolowanie: łydki, uda, pośladki, pasmo biodrowo-piszczelowe','30–45 s na każdą partię, unikaj rolowania stawów','Delikatna mobilizacja bioder i kręgosłupa piersiowego','Zakończ kilkoma spokojnymi, pełnymi oddechami'],
+ 10, 1, array['rollery'], true);


### PR DESCRIPTION
## Summary

Round 2: Supabase is wired into the Round 1 Next.js scaffold end to end - client setup, database schema + RLS, seed data, and email/password authentication with route protection. Everything runs on the anon/publishable key plus the logged-in user's session; no service-role key is used or referenced anywhere.

- **Client setup**: `@supabase/supabase-js` + `@supabase/ssr`, with browser/server client factories (`lib/supabase/client.ts`, `lib/supabase/server.ts`) using cookie-based sessions, plus a hand-written `Database` type (`lib/supabase/types.ts`) and an Auth-error-to-friendly-message mapper (`lib/supabase/errors.ts`).
- **Schema + RLS** (`supabase/migrations/*.sql`, 4 files, run in order): `profiles`, `categories`, `exercises` (nullable `author_id` for official seeded rows), `workouts`, `workout_items`. RLS everywhere: owner-only writes, public categories, public-or-own exercises, and a `get_shared_workout()` security-definer function for a future public share link instead of an open SELECT policy. A trigger auto-creates a `profiles` row on signup.
- **Seed data** (`supabase/seed.sql`): the official exercise library provided for this round, used verbatim.
- **Middleware** (`middleware.ts`, `lib/supabase/middleware.ts`): protects `/app/**`, bounces logged-in users away from `/login`/`/signup`, refreshes the session cookie on every request.
- **Auth pages**: `/signup`, `/login`, `/forgot-password`, `/reset-password`, styled to match the landing page, with inline validation and friendly error states (no raw error dumps). Email confirmation and password recovery both flow through `/auth/confirm` (token_hash exchange); `/auth/callback` is the matching OAuth code-exchange route.
- **Google OAuth**: code path is in place (`GoogleAuthButton`, `/auth/callback`) but stays behind `NEXT_PUBLIC_ENABLE_GOOGLE_AUTH` (unset/false) - renders as a disabled "Not yet configured" button until Google Cloud Console + the Supabase provider are set up in a later round.
- **Protected `/app` home**: greets the user by `profiles.display_name`, server-action logout, placeholder nav to `/app/exercises` and `/app/workouts` (Rounds 3-4).

Nothing secret is committed - `.env.local` stays gitignored, `.env.example` only lists variable names.

## Not applied yet

The SQL migrations and seed were **not** run against the live Supabase project from this session (no access token is configured, by design). They're posted in the session for the user to paste into the Supabase SQL Editor in order, along with the two email template edits `/auth/confirm` depends on and a manual test script for the live site.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build` all pass
- [x] `pnpm build` also verified with **no** env vars set (simulates CI) - every Supabase-touching route is `force-dynamic`, so nothing constructs a client at build time and no dummy secrets are needed in CI
- [x] Local dev server smoke-tested in a headless browser: landing page's "Log in" CTA, real `/login` / `/signup` / `/forgot-password` forms render, inline validation fires without hitting the network (mismatched passwords, invalid email format), Google button renders disabled with "Not yet configured", `/app` redirects to `/login` when logged out, no console errors
- [ ] Live end-to-end auth flow on Vercel (sign up → confirm → log in → `/app` → log out) - pending the user running the provided SQL and email template changes, since this session has no network access to the Supabase project itself


---
_Generated by [Claude Code](https://claude.ai/code/session_01EhY8xiN5AsLCJXCMgXdPko)_