### PR TITLE
Exercise library: browse/search/filter, detail, create/edit + Round 2 auth fixes

### DIFF
--- a/app/app/exercises/[id]/edit/page.tsx
+++ b/app/app/exercises/[id]/edit/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ExerciseForm } from "@/components/exercises/ExerciseForm";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Edytuj ćwiczenie — Coach Zone",
+};
+
+export default async function EditExercisePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const [{ data: exercise }, { data: userData }, { data: categories }] =
+    await Promise.all([
+      supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
+      supabase.auth.getUser(),
+      supabase.from("categories").select("*").order("id", { ascending: true }),
+    ]);
+
+  if (!userData.user) {
+    redirect("/login");
+  }
+
+  if (!exercise) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 pt-8 pb-20 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Nie znaleziono ćwiczenia
+        </h1>
+        <Link
+          href="/app/exercises"
+          className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Powrót do listy
+        </Link>
+      </main>
+    );
+  }
+
+  if (exercise.author_id !== userData.user.id) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 pt-8 pb-20 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">Brak dostępu</h1>
+        <p className="mt-3 text-neutral-600 dark:text-neutral-400">
+          Możesz edytować tylko własne ćwiczenia.
+        </p>
+        <Link
+          href={`/app/exercises/${exercise.id}`}
+          className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Powrót do ćwiczenia
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <h1 className="text-3xl font-bold tracking-tight">Edytuj ćwiczenie</h1>
+      <div className="mt-8">
+        <ExerciseForm
+          mode="edit"
+          categories={categories ?? []}
+          exercise={exercise}
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -1,0 +1,142 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CategoryBadge } from "@/components/exercises/CategoryBadge";
+import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
+import { DeleteExerciseButton } from "@/components/exercises/DeleteExerciseButton";
+import { formatDuration } from "@/lib/exercises";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Ćwiczenie — Coach Zone",
+};
+
+export default async function ExerciseDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const [{ data: exercise }, { data: userData }] = await Promise.all([
+    supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
+    supabase.auth.getUser(),
+  ]);
+
+  if (!exercise) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 pt-8 pb-20 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Nie znaleziono ćwiczenia
+        </h1>
+        <p className="mt-3 text-neutral-600 dark:text-neutral-400">
+          To ćwiczenie nie istnieje albo nie masz do niego dostępu.
+        </p>
+        <Link
+          href="/app/exercises"
+          className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Powrót do listy
+        </Link>
+      </main>
+    );
+  }
+
+  const { data: category } = await supabase
+    .from("categories")
+    .select("*")
+    .eq("id", exercise.category_id)
+    .maybeSingle();
+
+  const isOwner = userData.user?.id === exercise.author_id;
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 pt-8 pb-20">
+      <Link
+        href="/app/exercises"
+        className="text-sm font-medium text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+      >
+        ← Wszystkie ćwiczenia
+      </Link>
+
+      <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            {exercise.title}
+          </h1>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            {category && (
+              <CategoryBadge name={category.name_pl} slug={category.slug} />
+            )}
+            <DifficultyIndicator difficulty={exercise.difficulty} showLabel />
+            <span className="text-sm text-neutral-500 dark:text-neutral-500">
+              {formatDuration(exercise.duration_min)}
+            </span>
+            {!exercise.is_public && (
+              <span className="rounded-full bg-neutral-100 px-2.5 py-0.5 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
+                Prywatne
+              </span>
+            )}
+          </div>
+        </div>
+
+        {isOwner && (
+          <div className="flex shrink-0 gap-2">
+            <Link
+              href={`/app/exercises/${exercise.id}/edit`}
+              className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+            >
+              Edytuj
+            </Link>
+            <DeleteExerciseButton exerciseId={exercise.id} />
+          </div>
+        )}
+      </div>
+
+      {exercise.equipment.length > 0 && (
+        <div className="mt-6 flex flex-wrap gap-2">
+          {exercise.equipment.map((item) => (
+            <span
+              key={item}
+              className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {exercise.description && (
+        <p className="mt-6 whitespace-pre-line text-neutral-700 dark:text-neutral-300">
+          {exercise.description}
+        </p>
+      )}
+
+      {exercise.steps.length > 0 && (
+        <div className="mt-8">
+          <h2 className="text-lg font-semibold">Przebieg ćwiczenia</h2>
+          <ol className="mt-3 list-decimal space-y-2 pl-5 text-neutral-700 dark:text-neutral-300">
+            {exercise.steps.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {exercise.media_url && (
+        <div className="mt-8">
+          <a
+            href={exercise.media_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-emerald-600 hover:text-emerald-500"
+          >
+            Zobacz materiał →
+          </a>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/app/exercises/new/page.tsx
+++ b/app/app/exercises/new/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { ExerciseForm } from "@/components/exercises/ExerciseForm";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Nowe ćwiczenie — Coach Zone",
+};
+
+export default async function NewExercisePage() {
+  const supabase = await createClient();
+  const [{ data: userData }, { data: categories }] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.from("categories").select("*").order("id", { ascending: true }),
+  ]);
+
+  // Middleware already guarantees a user for any /app/* route; this is a
+  // defensive fallback since userId below is required for the insert.
+  if (!userData.user) {
+    redirect("/login");
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <h1 className="text-3xl font-bold tracking-tight">Nowe ćwiczenie</h1>
+      <p className="mt-2 text-neutral-600 dark:text-neutral-400">
+        Dodaj własne ćwiczenie do swojej biblioteki.
+      </p>
+      <div className="mt-8">
+        <ExerciseForm
+          mode="create"
+          categories={categories ?? []}
+          userId={userData.user.id}
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/app/exercises/page.tsx
+++ b/app/app/exercises/page.tsx
@@ -1,26 +1,19 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { ExercisesLibrary } from "@/components/exercises/ExercisesLibrary";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Exercises — Coach Zone",
+  title: "Ćwiczenia — Coach Zone",
 };
 
-export default function ExercisesPlaceholder() {
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-6 text-center text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-      <h1 className="text-2xl font-semibold tracking-tight">
-        Exercises are coming in Round 3
-      </h1>
-      <p className="mt-3 max-w-sm text-neutral-600 dark:text-neutral-400">
-        This is where you&rsquo;ll browse the official exercise library and
-        build your own drills.
-      </p>
-      <Link
-        href="/app"
-        className="mt-8 rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
-      >
-        Back to home
-      </Link>
-    </div>
-  );
+export default async function ExercisesPage() {
+  const supabase = await createClient();
+  const { data: categories } = await supabase
+    .from("categories")
+    .select("*")
+    .order("id", { ascending: true });
+
+  return <ExercisesLibrary categories={categories ?? []} />;
 }

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { logout } from "./actions";
+
+const navItems = [
+  { href: "/app/exercises", label: "Exercises" },
+  { href: "/app/workouts", label: "Workouts" },
+];
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <header className="border-b border-neutral-200 dark:border-neutral-800">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-6 sm:gap-8">
+            <Link href="/app" className="text-lg font-semibold tracking-tight">
+              Coach Zone
+            </Link>
+            <nav className="flex gap-4 sm:gap-6">
+              {navItems.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="text-sm font-medium text-neutral-600 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <form action={logout}>
+            <button
+              type="submit"
+              className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+            >
+              Log out
+            </button>
+          </form>
+        </div>
+      </header>
+
+      {children}
+    </div>
+  );
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import { logout } from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -42,42 +41,28 @@ export default async function AppHomePage() {
     profile?.display_name ?? user?.email?.split("@")[0] ?? "Coach";
 
   return (
-    <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-      <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
-        <span className="text-lg font-semibold tracking-tight">Coach Zone</span>
-        <form action={logout}>
-          <button
-            type="submit"
-            className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+      <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+        Welcome, {displayName}
+      </h1>
+      <p className="mt-3 text-neutral-600 dark:text-neutral-400">
+        Here&rsquo;s your Coach Zone home base.
+      </p>
+
+      <div className="mt-10 grid gap-6 sm:grid-cols-2">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="rounded-2xl border border-neutral-200 p-6 transition-colors hover:border-emerald-600/50 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-900"
           >
-            Log out
-          </button>
-        </form>
-      </header>
-
-      <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
-        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
-          Welcome, {displayName}
-        </h1>
-        <p className="mt-3 text-neutral-600 dark:text-neutral-400">
-          Here&rsquo;s your Coach Zone home base.
-        </p>
-
-        <div className="mt-10 grid gap-6 sm:grid-cols-2">
-          {navItems.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-2xl border border-neutral-200 p-6 transition-colors hover:border-emerald-600/50 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-900"
-            >
-              <h2 className="text-lg font-semibold">{item.title}</h2>
-              <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-                {item.description}
-              </p>
-            </Link>
-          ))}
-        </div>
-      </main>
-    </div>
+            <h2 className="text-lg font-semibold">{item.title}</h2>
+            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+              {item.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </main>
   );
 }

--- a/app/app/workouts/page.tsx
+++ b/app/app/workouts/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 
 export default function WorkoutsPlaceholder() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-white px-6 text-center text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+    <div className="flex min-h-[calc(100vh-65px)] flex-col items-center justify-center px-6 text-center">
       <h1 className="text-2xl font-semibold tracking-tight">
         Workouts are coming in Round 4
       </h1>

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -2,24 +2,39 @@ import type { EmailOtpType } from "@supabase/supabase-js";
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
-// Hit by the links in Supabase's "Confirm signup" and "Reset Password" email
-// templates, which must be set to point here with token_hash/type/next
-// query params (see the setup instructions) instead of the default
-// ConfirmationURL - that default doesn't play well with cookie-based SSR
-// sessions.
+// Meant to be hit by the links in Supabase's "Confirm signup" and "Reset
+// Password" email templates, customized per Supabase's docs to point here
+// with token_hash/type/next query params instead of the default
+// ConfirmationURL. We can't edit those templates yet (needs custom SMTP +
+// a domain), so today's un-edited default template actually verifies the
+// link against Supabase's own hosted endpoint first and redirects back with
+// the session encoded in the URL rather than as params here - that leg is
+// handled client-side instead (AuthLinkListener + the browser client's
+// automatic detectSessionInUrl). This route stays defensive about both the
+// token_hash/type shape (what we'll get once the template is customized)
+// and a PKCE `code` shape, so nothing else needs to change when that
+// happens.
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
-  const next = searchParams.get("next") ?? "/app";
+  const code = searchParams.get("code");
+  const next =
+    searchParams.get("next") ??
+    (type === "recovery" ? "/reset-password" : "/app");
+
+  const supabase = await createClient();
 
   if (tokenHash && type) {
-    const supabase = await createClient();
     const { error } = await supabase.auth.verifyOtp({
       type,
       token_hash: tokenHash,
     });
-
+    if (!error) {
+      return NextResponse.redirect(new URL(next, request.url));
+    }
+  } else if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
       return NextResponse.redirect(new URL(next, request.url));
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { AuthLinkListener } from "@/components/auth/AuthLinkListener";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,6 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <AuthLinkListener />
         {children}
       </body>
     </html>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,45 +1,15 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { AuthShell } from "@/components/auth/AuthShell";
-import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
-import { createClient } from "@/lib/supabase/server";
-
-export const dynamic = "force-dynamic";
+import { ResetPasswordGate } from "@/components/auth/ResetPasswordGate";
 
 export const metadata: Metadata = {
   title: "Set new password — Coach Zone",
 };
 
-export default async function ResetPasswordPage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // Reached without a valid recovery session: the link was already used,
-  // expired, or the user navigated here directly.
-  if (!user) {
-    return (
-      <AuthShell
-        title="Link expired"
-        subtitle="This password reset link is invalid or has expired."
-      >
-        <Link
-          href="/forgot-password"
-          className="block w-full rounded-full bg-emerald-600 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-emerald-500"
-        >
-          Request a new link
-        </Link>
-      </AuthShell>
-    );
-  }
-
+export default function ResetPasswordPage() {
   return (
-    <AuthShell
-      title="Set a new password"
-      subtitle="Choose a new password for your account."
-    >
-      <ResetPasswordForm />
+    <AuthShell title="Reset your password">
+      <ResetPasswordGate />
     </AuthShell>
   );
 }

--- a/components/auth/AuthLinkListener.tsx
+++ b/components/auth/AuthLinkListener.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+// Safety net for Supabase's un-edited default email templates (see
+// app/auth/confirm/route.ts for the full explanation): confirmation and
+// recovery links verify against Supabase's own hosted endpoint and redirect
+// back with the session encoded in the URL, which can land on whichever
+// page the project's Site URL / redirect_to happens to resolve to. The
+// browser client auto-detects and consumes that URL on construction
+// (detectSessionInUrl), emitting PASSWORD_RECOVERY or SIGNED_IN - this
+// listens for those events from anywhere in the app and routes the user to
+// the right screen instead of leaving them stranded wherever the link
+// landed.
+export function AuthLinkListener() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "PASSWORD_RECOVERY") {
+        router.replace("/reset-password");
+      } else if (event === "SIGNED_IN" && window.location.pathname === "/") {
+        // Only on the public homepage: a signed-in visitor landing there is
+        // almost always a just-confirmed signup, not someone mid-navigation
+        // elsewhere in the app (e.g. /login handles its own redirect).
+        router.replace("/app");
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [router]);
+
+  return null;
+}

--- a/components/auth/ForgotPasswordForm.tsx
+++ b/components/auth/ForgotPasswordForm.tsx
@@ -29,7 +29,9 @@ export function ForgotPasswordForm() {
 
     setLoading(true);
     const supabase = createClient();
-    const { error } = await supabase.auth.resetPasswordForEmail(email);
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/reset-password`,
+    });
     setLoading(false);
 
     if (error) {

--- a/components/auth/ResetPasswordGate.tsx
+++ b/components/auth/ResetPasswordGate.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { ResetPasswordForm } from "./ResetPasswordForm";
+
+type Status = "checking" | "ready" | "expired";
+
+// Whether a valid recovery session exists can only be known client-side:
+// the default (un-edited) recovery email link delivers the session encoded
+// in the URL rather than as a cookie a server component could read (see
+// app/auth/confirm/route.ts). getUser() waits for the browser client to
+// finish processing that URL before resolving, so this works whether the
+// session arrived that way or was already established as a cookie.
+export function ResetPasswordGate() {
+  const [status, setStatus] = useState<Status>("checking");
+
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!cancelled) setStatus(user ? "ready" : "expired");
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (status === "checking") {
+    return (
+      <p className="text-center text-sm text-neutral-500 dark:text-neutral-500">
+        Checking your link…
+      </p>
+    );
+  }
+
+  if (status === "expired") {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          This password reset link is invalid or has expired.
+        </p>
+        <Link
+          href="/forgot-password"
+          className="block w-full rounded-full bg-emerald-600 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Request a new link
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+        Choose a new password for your account.
+      </p>
+      <ResetPasswordForm />
+    </div>
+  );
+}

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -60,7 +60,10 @@ export function SignupForm() {
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
-      options: { data: { full_name: fullName.trim() } },
+      options: {
+        data: { full_name: fullName.trim() },
+        emailRedirectTo: `${window.location.origin}/`,
+      },
     });
     setLoading(false);
 

--- a/components/exercises/CategoryBadge.tsx
+++ b/components/exercises/CategoryBadge.tsx
@@ -1,0 +1,11 @@
+import { categoryBadgeClasses } from "@/lib/exercises";
+
+export function CategoryBadge({ name, slug }: { name: string; slug: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${categoryBadgeClasses(slug)}`}
+    >
+      {name}
+    </span>
+  );
+}

--- a/components/exercises/DeleteExerciseButton.tsx
+++ b/components/exercises/DeleteExerciseButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export function DeleteExerciseButton({ exerciseId }: { exerciseId: string }) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("exercises")
+      .delete()
+      .eq("id", exerciseId);
+
+    if (error) {
+      setDeleting(false);
+      setError("Nie udało się usunąć ćwiczenia. Spróbuj ponownie.");
+      return;
+    }
+
+    router.push("/app/exercises");
+    router.refresh();
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex flex-col items-end gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-neutral-600 dark:text-neutral-400">
+            Na pewno?
+          </span>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {deleting ? "Usuwanie…" : "Tak, usuń"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            disabled={deleting}
+            className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Anuluj
+          </button>
+        </div>
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setConfirming(true)}
+      className="rounded-full border border-red-300 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/40"
+    >
+      Usuń
+    </button>
+  );
+}

--- a/components/exercises/DifficultyIndicator.tsx
+++ b/components/exercises/DifficultyIndicator.tsx
@@ -1,0 +1,41 @@
+import type { Difficulty } from "@/lib/supabase/types";
+import { DIFFICULTY_LABELS } from "@/lib/exercises";
+
+export function DifficultyIndicator({
+  difficulty,
+  showLabel = false,
+}: {
+  difficulty: Difficulty | null;
+  showLabel?: boolean;
+}) {
+  if (!difficulty) {
+    return (
+      <span className="text-sm text-neutral-500 dark:text-neutral-500">—</span>
+    );
+  }
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5"
+      aria-label={`Poziom trudności: ${DIFFICULTY_LABELS[difficulty]} (${difficulty}/5)`}
+    >
+      <span className="flex gap-0.5" aria-hidden="true">
+        {Array.from({ length: 5 }, (_, i) => (
+          <span
+            key={i}
+            className={`h-1.5 w-1.5 rounded-full ${
+              i < difficulty
+                ? "bg-emerald-600"
+                : "bg-neutral-200 dark:bg-neutral-700"
+            }`}
+          />
+        ))}
+      </span>
+      {showLabel && (
+        <span className="text-sm text-neutral-600 dark:text-neutral-400">
+          {DIFFICULTY_LABELS[difficulty]}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/components/exercises/ExerciseCard.tsx
+++ b/components/exercises/ExerciseCard.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import type { Category, Exercise } from "@/lib/supabase/types";
+import { formatDuration } from "@/lib/exercises";
+import { CategoryBadge } from "./CategoryBadge";
+import { DifficultyIndicator } from "./DifficultyIndicator";
+
+export function ExerciseCard({
+  exercise,
+  category,
+}: {
+  exercise: Exercise;
+  category: Category | undefined;
+}) {
+  return (
+    <Link
+      href={`/app/exercises/${exercise.id}`}
+      className="flex flex-col rounded-2xl border border-neutral-200 p-5 transition-colors hover:border-emerald-600/50 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-900"
+    >
+      <h3 className="font-semibold tracking-tight">{exercise.title}</h3>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {category && (
+          <CategoryBadge name={category.name_pl} slug={category.slug} />
+        )}
+        <DifficultyIndicator difficulty={exercise.difficulty} />
+        <span className="text-xs text-neutral-500 dark:text-neutral-500">
+          {formatDuration(exercise.duration_min)}
+        </span>
+      </div>
+
+      {exercise.description && (
+        <p className="mt-3 line-clamp-2 text-sm text-neutral-600 dark:text-neutral-400">
+          {exercise.description}
+        </p>
+      )}
+    </Link>
+  );
+}

--- a/components/exercises/ExerciseCardSkeleton.tsx
+++ b/components/exercises/ExerciseCardSkeleton.tsx
@@ -1,0 +1,13 @@
+export function ExerciseCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-2xl border border-neutral-200 p-5 dark:border-neutral-800">
+      <div className="h-4 w-3/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-4 flex gap-2">
+        <div className="h-5 w-16 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+        <div className="h-5 w-10 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+      <div className="mt-4 h-3 w-full rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-2 h-3 w-5/6 rounded bg-neutral-200 dark:bg-neutral-800" />
+    </div>
+  );
+}

--- a/components/exercises/ExerciseForm.tsx
+++ b/components/exercises/ExerciseForm.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent, type KeyboardEvent } from "react";
+import { FormBanner } from "@/components/auth/FormBanner";
+import { FormField } from "@/components/auth/FormField";
+import { SubmitButton } from "@/components/auth/SubmitButton";
+import { DIFFICULTY_LABELS, DIFFICULTY_OPTIONS } from "@/lib/exercises";
+import { createClient } from "@/lib/supabase/client";
+import type { Category, Difficulty, Exercise } from "@/lib/supabase/types";
+
+type ExerciseFormProps =
+  | { mode: "create"; categories: Category[]; userId: string }
+  | { mode: "edit"; categories: Category[]; exercise: Exercise };
+
+interface FieldErrors {
+  title?: string;
+  category?: string;
+  steps?: string;
+  duration?: string;
+  mediaUrl?: string;
+}
+
+const labelClasses = "block text-sm font-medium";
+
+function fieldClasses(hasError?: boolean) {
+  return `w-full rounded-lg border bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:bg-neutral-900 ${
+    hasError
+      ? "border-red-400 dark:border-red-500"
+      : "border-neutral-300 dark:border-neutral-700"
+  }`;
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function ExerciseForm(props: ExerciseFormProps) {
+  const router = useRouter();
+  const initial = props.mode === "edit" ? props.exercise : null;
+
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [categoryId, setCategoryId] = useState<number | "">(
+    initial?.category_id ?? "",
+  );
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [steps, setSteps] = useState<string[]>(
+    initial?.steps && initial.steps.length > 0 ? initial.steps : [""],
+  );
+  const [durationMin, setDurationMin] = useState(
+    initial?.duration_min ? String(initial.duration_min) : "",
+  );
+  const [difficulty, setDifficulty] = useState<Difficulty>(
+    initial?.difficulty ?? 3,
+  );
+  const [equipment, setEquipment] = useState<string[]>(
+    initial?.equipment ?? [],
+  );
+  const [equipmentInput, setEquipmentInput] = useState("");
+  const [mediaUrl, setMediaUrl] = useState(initial?.media_url ?? "");
+  const [isPublic, setIsPublic] = useState(initial?.is_public ?? true);
+
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function validate(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (!title.trim()) errors.title = "Podaj nazwę ćwiczenia.";
+    if (!categoryId) errors.category = "Wybierz kategorię.";
+    if (steps.every((step) => !step.trim())) {
+      errors.steps = "Dodaj co najmniej jeden krok.";
+    }
+    if (durationMin.trim()) {
+      const value = Number(durationMin);
+      if (!Number.isInteger(value) || value <= 0) {
+        errors.duration =
+          "Podaj czas w minutach (liczba całkowita większa od zera).";
+      }
+    }
+    if (mediaUrl.trim() && !isValidUrl(mediaUrl.trim())) {
+      errors.mediaUrl =
+        "Podaj poprawny adres URL (zaczynający się od http:// lub https://).";
+    }
+    return errors;
+  }
+
+  function updateStep(index: number, value: string) {
+    setSteps((prev) => prev.map((step, i) => (i === index ? value : step)));
+  }
+
+  function removeStep(index: number) {
+    setSteps((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function handleStepKeyDown(
+    event: KeyboardEvent<HTMLInputElement>,
+    index: number,
+  ) {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    if (index === steps.length - 1) {
+      setSteps((prev) => [...prev, ""]);
+    }
+  }
+
+  function addEquipmentTag() {
+    const value = equipmentInput.trim();
+    if (value && !equipment.includes(value)) {
+      setEquipment((prev) => [...prev, value]);
+    }
+    setEquipmentInput("");
+  }
+
+  function handleEquipmentKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      addEquipmentTag();
+    }
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    setLoading(true);
+    const supabase = createClient();
+
+    const payload = {
+      title: title.trim(),
+      category_id: categoryId as number,
+      description: description.trim() || null,
+      steps: steps.map((step) => step.trim()).filter(Boolean),
+      duration_min: durationMin.trim() ? Number(durationMin) : null,
+      difficulty,
+      equipment,
+      media_url: mediaUrl.trim() || null,
+      is_public: isPublic,
+    };
+
+    if (props.mode === "create") {
+      const { data, error } = await supabase
+        .from("exercises")
+        .insert({ ...payload, author_id: props.userId })
+        .select("id")
+        .single();
+
+      setLoading(false);
+      if (error || !data) {
+        setFormError("Nie udało się zapisać ćwiczenia. Spróbuj ponownie.");
+        return;
+      }
+      router.push(`/app/exercises/${data.id}`);
+      router.refresh();
+      return;
+    }
+
+    const { error } = await supabase
+      .from("exercises")
+      .update(payload)
+      .eq("id", props.exercise.id);
+
+    setLoading(false);
+    if (error) {
+      setFormError("Nie udało się zapisać zmian. Spróbuj ponownie.");
+      return;
+    }
+    router.push(`/app/exercises/${props.exercise.id}`);
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-5">
+      <FormBanner variant="error" message={formError} />
+
+      <FormField
+        id="title"
+        label="Nazwa ćwiczenia"
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        error={fieldErrors.title}
+      />
+
+      <div>
+        <label htmlFor="category" className={labelClasses}>
+          Kategoria
+        </label>
+        <select
+          id="category"
+          value={categoryId}
+          onChange={(e) =>
+            setCategoryId(e.target.value ? Number(e.target.value) : "")
+          }
+          className={`mt-1.5 ${fieldClasses(Boolean(fieldErrors.category))}`}
+        >
+          <option value="">Wybierz kategorię…</option>
+          {props.categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.name_pl}
+            </option>
+          ))}
+        </select>
+        {fieldErrors.category && (
+          <p className="mt-1.5 text-sm text-red-600 dark:text-red-400">
+            {fieldErrors.category}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="description" className={labelClasses}>
+          Opis
+        </label>
+        <textarea
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          className={`mt-1.5 ${fieldClasses()}`}
+        />
+      </div>
+
+      <div>
+        <span className={labelClasses}>Kroki</span>
+        <div className="mt-1.5 space-y-2">
+          {steps.map((step, index) => (
+            <div key={index} className="flex gap-2">
+              <input
+                type="text"
+                value={step}
+                onChange={(e) => updateStep(index, e.target.value)}
+                onKeyDown={(e) => handleStepKeyDown(e, index)}
+                placeholder={`Krok ${index + 1}`}
+                aria-label={`Krok ${index + 1}`}
+                className={fieldClasses(Boolean(fieldErrors.steps))}
+              />
+              <button
+                type="button"
+                onClick={() => removeStep(index)}
+                aria-label="Usuń krok"
+                className="shrink-0 rounded-lg border border-neutral-300 px-3 text-sm text-neutral-500 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => setSteps((prev) => [...prev, ""])}
+          className="mt-2 text-sm font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          + Dodaj krok
+        </button>
+        {fieldErrors.steps && (
+          <p className="mt-1.5 text-sm text-red-600 dark:text-red-400">
+            {fieldErrors.steps}
+          </p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <FormField
+          id="duration"
+          label="Czas trwania (min)"
+          type="number"
+          min={1}
+          value={durationMin}
+          onChange={(e) => setDurationMin(e.target.value)}
+          error={fieldErrors.duration}
+        />
+
+        <div>
+          <label htmlFor="difficulty" className={labelClasses}>
+            Poziom trudności
+          </label>
+          <select
+            id="difficulty"
+            value={difficulty}
+            onChange={(e) =>
+              setDifficulty(Number(e.target.value) as Difficulty)
+            }
+            className={`mt-1.5 ${fieldClasses()}`}
+          >
+            {DIFFICULTY_OPTIONS.map((d) => (
+              <option key={d} value={d}>
+                {d} – {DIFFICULTY_LABELS[d]}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="equipment" className={labelClasses}>
+          Sprzęt
+        </label>
+        <div className="mt-1.5 flex gap-2">
+          <input
+            id="equipment"
+            type="text"
+            value={equipmentInput}
+            onChange={(e) => setEquipmentInput(e.target.value)}
+            onKeyDown={handleEquipmentKeyDown}
+            placeholder="np. piłki, pachołki…"
+            className={fieldClasses()}
+          />
+          <button
+            type="button"
+            onClick={addEquipmentTag}
+            className="shrink-0 rounded-lg border border-neutral-300 px-4 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Dodaj
+          </button>
+        </div>
+        {equipment.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {equipment.map((item) => (
+              <span
+                key={item}
+                className="inline-flex items-center gap-1.5 rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+              >
+                {item}
+                <button
+                  type="button"
+                  onClick={() =>
+                    setEquipment((prev) => prev.filter((i) => i !== item))
+                  }
+                  aria-label={`Usuń ${item}`}
+                  className="text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-100"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <FormField
+        id="mediaUrl"
+        label="Link do materiału (opcjonalnie)"
+        type="url"
+        placeholder="https://youtube.com/…"
+        value={mediaUrl}
+        onChange={(e) => setMediaUrl(e.target.value)}
+        error={fieldErrors.mediaUrl}
+      />
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={isPublic}
+          onChange={(e) => setIsPublic(e.target.checked)}
+          className="h-4 w-4 rounded border-neutral-300 text-emerald-600 focus:ring-emerald-600/50 dark:border-neutral-700"
+        />
+        Widoczne publicznie dla innych trenerów
+      </label>
+
+      <SubmitButton loading={loading} loadingText="Zapisywanie…">
+        {props.mode === "create" ? "Dodaj ćwiczenie" : "Zapisz zmiany"}
+      </SubmitButton>
+    </form>
+  );
+}

--- a/components/exercises/ExercisesLibrary.tsx
+++ b/components/exercises/ExercisesLibrary.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { Category, Difficulty, Exercise } from "@/lib/supabase/types";
+import { DIFFICULTY_LABELS, DIFFICULTY_OPTIONS } from "@/lib/exercises";
+import { ExerciseCard } from "./ExerciseCard";
+import { ExerciseCardSkeleton } from "./ExerciseCardSkeleton";
+
+const ALL = "all" as const;
+
+export function ExercisesLibrary({ categories }: { categories: Category[] }) {
+  const [exercises, setExercises] = useState<Exercise[] | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<number | typeof ALL>(
+    ALL,
+  );
+  const [difficultyFilter, setDifficultyFilter] = useState<
+    Difficulty | typeof ALL
+  >(ALL);
+  const [equipmentFilter, setEquipmentFilter] = useState<string>(ALL);
+
+  useEffect(() => {
+    let cancelled = false;
+    setExercises(null);
+    setLoadError(false);
+
+    const supabase = createClient();
+    supabase
+      .from("exercises")
+      .select("*")
+      .order("title", { ascending: true })
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        if (error || !data) {
+          setLoadError(true);
+          return;
+        }
+        setExercises(data);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  const categoriesById = useMemo(() => {
+    const map = new Map<number, Category>();
+    for (const category of categories) map.set(category.id, category);
+    return map;
+  }, [categories]);
+
+  const equipmentOptions = useMemo(() => {
+    const values = new Set<string>();
+    for (const exercise of exercises ?? []) {
+      for (const item of exercise.equipment) values.add(item);
+    }
+    return Array.from(values).sort((a, b) => a.localeCompare(b, "pl"));
+  }, [exercises]);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (exercises ?? []).filter((exercise) => {
+      if (query) {
+        const haystack =
+          `${exercise.title} ${exercise.description ?? ""}`.toLowerCase();
+        if (!haystack.includes(query)) return false;
+      }
+      if (categoryFilter !== ALL && exercise.category_id !== categoryFilter)
+        return false;
+      if (difficultyFilter !== ALL && exercise.difficulty !== difficultyFilter)
+        return false;
+      if (
+        equipmentFilter !== ALL &&
+        !exercise.equipment.includes(equipmentFilter)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [exercises, search, categoryFilter, difficultyFilter, equipmentFilter]);
+
+  function clearAll() {
+    setSearch("");
+    setCategoryFilter(ALL);
+    setDifficultyFilter(ALL);
+    setEquipmentFilter(ALL);
+  }
+
+  const activeFilters: Array<{ label: string; onClear: () => void }> = [];
+  const trimmedSearch = search.trim();
+  if (trimmedSearch) {
+    activeFilters.push({
+      label: `Szukaj: „${trimmedSearch}”`,
+      onClear: () => setSearch(""),
+    });
+  }
+  if (categoryFilter !== ALL) {
+    activeFilters.push({
+      label: `Kategoria: ${categoriesById.get(categoryFilter)?.name_pl ?? categoryFilter}`,
+      onClear: () => setCategoryFilter(ALL),
+    });
+  }
+  if (difficultyFilter !== ALL) {
+    activeFilters.push({
+      label: `Poziom: ${DIFFICULTY_LABELS[difficultyFilter]}`,
+      onClear: () => setDifficultyFilter(ALL),
+    });
+  }
+  if (equipmentFilter !== ALL) {
+    activeFilters.push({
+      label: `Sprzęt: ${equipmentFilter}`,
+      onClear: () => setEquipmentFilter(ALL),
+    });
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Biblioteka ćwiczeń
+          </h1>
+          <p className="mt-1 text-neutral-600 dark:text-neutral-400">
+            Przeglądaj oficjalną bibliotekę i twórz własne ćwiczenia.
+          </p>
+        </div>
+        <Link
+          href="/app/exercises/new"
+          className="rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Dodaj ćwiczenie
+        </Link>
+      </div>
+
+      <div className="mt-8 space-y-4">
+        <div>
+          <label
+            htmlFor="exercise-search"
+            className="block text-sm font-medium"
+          >
+            Szukaj
+          </label>
+          <input
+            id="exercise-search"
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Szukaj po nazwie lub opisie…"
+            className="mt-1.5 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <FilterSelect
+            id="category-filter"
+            label="Kategoria"
+            value={categoryFilter === ALL ? ALL : String(categoryFilter)}
+            onChange={(value) =>
+              setCategoryFilter(value === ALL ? ALL : Number(value))
+            }
+            options={[
+              { value: ALL, label: "Wszystkie kategorie" },
+              ...categories.map((c) => ({
+                value: String(c.id),
+                label: c.name_pl,
+              })),
+            ]}
+          />
+          <FilterSelect
+            id="difficulty-filter"
+            label="Poziom"
+            value={difficultyFilter === ALL ? ALL : String(difficultyFilter)}
+            onChange={(value) =>
+              setDifficultyFilter(
+                value === ALL ? ALL : (Number(value) as Difficulty),
+              )
+            }
+            options={[
+              { value: ALL, label: "Wszystkie poziomy" },
+              ...DIFFICULTY_OPTIONS.map((d) => ({
+                value: String(d),
+                label: `${d} – ${DIFFICULTY_LABELS[d]}`,
+              })),
+            ]}
+          />
+          <FilterSelect
+            id="equipment-filter"
+            label="Sprzęt"
+            value={equipmentFilter}
+            onChange={setEquipmentFilter}
+            options={[
+              { value: ALL, label: "Wszystkie" },
+              ...equipmentOptions.map((item) => ({ value: item, label: item })),
+            ]}
+          />
+        </div>
+
+        {activeFilters.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            {activeFilters.map((filter) => (
+              <button
+                key={filter.label}
+                type="button"
+                onClick={filter.onClear}
+                className="inline-flex items-center gap-1 rounded-full border border-neutral-300 px-2.5 py-1 text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-900"
+              >
+                {filter.label}
+                <span aria-hidden="true">×</span>
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-xs font-medium text-emerald-600 hover:text-emerald-500"
+            >
+              Wyczyść filtry
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-8">
+        {loadError ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/50 dark:bg-red-950/40">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Nie udało się wczytać ćwiczeń. Spróbuj ponownie.
+            </p>
+            <button
+              type="button"
+              onClick={() => setReloadToken((n) => n + 1)}
+              className="mt-3 rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
+            >
+              Spróbuj ponownie
+            </button>
+          </div>
+        ) : exercises === null ? (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }, (_, i) => (
+              <ExerciseCardSkeleton key={i} />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="rounded-2xl border border-neutral-200 p-8 text-center dark:border-neutral-800">
+            <p className="text-neutral-600 dark:text-neutral-400">
+              {exercises.length === 0
+                ? "Nie znaleziono żadnych ćwiczeń."
+                : "Brak ćwiczeń spełniających kryteria — spróbuj wyczyścić filtry."}
+            </p>
+            {activeFilters.length > 0 && (
+              <button
+                type="button"
+                onClick={clearAll}
+                className="mt-3 text-sm font-medium text-emerald-600 hover:text-emerald-500"
+              >
+                Wyczyść filtry
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((exercise) => (
+              <ExerciseCard
+                key={exercise.id}
+                exercise={exercise}
+                category={categoriesById.get(exercise.category_id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function FilterSelect({
+  id,
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: Array<{ value: string; label: string }>;
+}) {
+  const isActive = value !== ALL;
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium">
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`mt-1.5 w-full rounded-lg border bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:bg-neutral-900 ${
+          isActive
+            ? "border-emerald-600/50"
+            : "border-neutral-300 dark:border-neutral-700"
+        }`}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -1,0 +1,37 @@
+import type { Difficulty } from "@/lib/supabase/types";
+
+export const DIFFICULTY_LABELS: Record<Difficulty, string> = {
+  1: "Bardzo łatwy",
+  2: "Łatwy",
+  3: "Średni",
+  4: "Trudny",
+  5: "Bardzo trudny",
+};
+
+export const DIFFICULTY_OPTIONS: Difficulty[] = [1, 2, 3, 4, 5];
+
+// Keyed by category slug, with a neutral fallback for anything unrecognized.
+const CATEGORY_BADGE_CLASSES: Record<string, string> = {
+  warmup:
+    "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-900/50 dark:bg-orange-950/40 dark:text-orange-400",
+  technical:
+    "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900/50 dark:bg-blue-950/40 dark:text-blue-400",
+  positional:
+    "border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900/50 dark:bg-violet-950/40 dark:text-violet-400",
+  ssg: "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-400",
+  strength:
+    "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-400",
+  cooldown:
+    "border-cyan-200 bg-cyan-50 text-cyan-700 dark:border-cyan-900/50 dark:bg-cyan-950/40 dark:text-cyan-400",
+};
+
+const FALLBACK_BADGE_CLASSES =
+  "border-neutral-200 bg-neutral-50 text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300";
+
+export function categoryBadgeClasses(slug: string): string {
+  return CATEGORY_BADGE_CLASSES[slug] ?? FALLBACK_BADGE_CLASSES;
+}
+
+export function formatDuration(minutes: number | null): string {
+  return minutes ? `${minutes} min` : "—";
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,9 +1,19 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "./types";
 
+// Memoized so every caller shares one GoTrueClient instance. Several
+// components (see AuthLinkListener) independently check auth state on
+// mount, and Supabase's own URL-based session detection is one-shot -
+// running it twice from separate client instances races over the same
+// one-time recovery/confirmation link.
+let client: ReturnType<typeof createBrowserClient<Database>> | undefined;
+
 export function createClient() {
-  return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  );
+  if (!client) {
+    client = createBrowserClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    );
+  }
+  return client;
 }

--- a/lib/supabase/errors.ts
+++ b/lib/supabase/errors.ts
@@ -25,6 +25,11 @@ const MESSAGES_BY_CODE: Record<string, string> = {
   user_not_found: "Incorrect email or password.",
 };
 
+// Fallback for cases where Supabase doesn't populate error.code - notably
+// signInWithPassword's "Invalid login credentials", which auth-js currently
+// surfaces via the legacy invalid_grant response shape with code: undefined
+// (supabase/auth-js#937). email_not_confirmed is unaffected and matches via
+// error.code above, so the two cases still get distinct messages.
 const MESSAGES_BY_TEXT: Array<[RegExp, string]> = [
   [/already registered/i, MESSAGES_BY_CODE.user_already_exists],
   [/invalid login credentials/i, MESSAGES_BY_CODE.invalid_credentials],

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -218,3 +218,6 @@ export interface Database {
     Enums: Record<string, never>;
   };
 }
+
+export type Exercise = Database["public"]["Tables"]["exercises"]["Row"];
+export type Category = Database["public"]["Tables"]["categories"]["Row"];


### PR DESCRIPTION
## Summary

Round 3: the exercise library, plus three auth fixes from Round 2's manual testing (Step 0, done first as requested).

### Step 0 — Auth fixes

**1. Confirmation/recovery email links landing on the homepage instead of working (real bug, fixed).**
Root cause: Supabase's *un-edited* default email template doesn't hit our app at all first — it verifies the link against Supabase's own hosted endpoint, then redirects back with the session encoded in the URL (a hash fragment or PKCE `code`) rather than as params a server component/route handler can read. That's structurally invisible to `/auth/confirm` no matter how it's written, and it's why the link landed on `/` with nothing happening. We can't edit the template yet (needs custom SMTP + a domain), so the fix works around it:
- The browser Supabase client is now a singleton (`lib/supabase/client.ts`) so its automatic URL-based session detection (`detectSessionInUrl`) only ever runs once per page load instead of racing across multiple components.
- A new `AuthLinkListener` (mounted in the root layout) reacts to the `PASSWORD_RECOVERY` and homepage `SIGNED_IN` events the client emits once it consumes the session from the URL, and routes the user to `/reset-password` or `/app` accordingly.
- `ResetPasswordGate` resolves the recovery session client-side instead of gating on a server-side cookie check that structurally can't see it yet.
- Signup/forgot-password now pass explicit `emailRedirectTo`/`redirectTo` instead of relying on whatever the Supabase project's Site URL happens to be.
- `/auth/confirm` is now defensive about both the `token_hash`/`type` shape (what we'll get once the email template is customized per Supabase's docs) and a PKCE `code` shape, and defaults recovery links to `/reset-password` instead of `/app` when no explicit `next` is given.

**2. Misleading login error (`email_not_confirmed` vs `invalid_credentials`) — audited, already correct.**
`lib/supabase/errors.ts` already distinguishes these via `error.code`, with a text-based fallback for the known upstream auth-js quirk where `invalid_credentials` comes back with `code: undefined` (supabase/auth-js#937). Left a comment explaining why that fallback exists so it doesn't look like dead code later. No functional change.

**3. Signup with email confirmation disabled — audited, already correct.**
`SignupForm` already checks `data.session` and redirects straight to `/app` when one comes back, only showing "check your email" when confirmation is actually pending. No functional change beyond the `emailRedirectTo` addition above.

### Steps 1–3 — Exercise library

- **List** (`/app/exercises`): card grid (title, category badge, difficulty dots, duration, truncated description), search by title/description, category/difficulty/equipment filters that combine with search, active-filter chips with a clear-filters affordance, loading skeletons, error state with retry, empty state. UI copy is Polish per the seed content/target users; code and comments stay English.
- **Detail** (`/app/exercises/[id]`): full view with equipment, description, and steps as an ordered list. Edit/Delete only render for the exercise's own author — RLS enforces this server-side regardless, the UI just reflects it. Delete asks for inline confirmation and returns to the list on success.
- **Create/edit** (`/app/exercises/new`, `/app/exercises/[id]/edit`): shared form — title, category, description, repeatable steps, duration, difficulty, equipment tags, optional media URL, public/private toggle (default public). Sets `author_id` to the current user on insert per RLS, validates inline, redirects to the exercise's detail page on success. "Dodaj ćwiczenie" on the list wires into it.
- Extracted the duplicated `/app/*` header into a shared layout with nav (`app/app/layout.tsx`) now that there are enough real sub-pages to make navigating between them matter.

## Verification

No live Supabase project is reachable from this environment (Docker registry pulls are blocked by org egress policy, so a local Supabase stack wasn't an option either). What I did verify:
- `pnpm lint`, `pnpm typecheck`, `pnpm build` all pass.
- Drove the actual dev server with Playwright: homepage, login/signup/forgot-password validation, the `email_not_confirmed`-style error banner, middleware correctly redirecting every new `/app/exercises/*` route (including the dynamic `[id]` and `[id]/edit` segments) to `/login` when unauthenticated, and the reset-password page correctly resolving to its "expired" state without a session.
- For the exercises UI specifically, temporarily mounted the real components (`ExercisesLibrary`, the detail view, `ExerciseForm`) against mocked Supabase responses matching the real schema/seed shape, and drove them with Playwright: search, each filter, combined filters, active-filter chips, clear-filters, loading skeleton, error state, owner vs. non-owner detail view, delete confirm/cancel, and form validation (empty submit, partial fixes, step add/remove, equipment tag add/remove, bad media URL). Checked light and dark mode. That scaffolding was never committed — it was deleted before the commits in this PR.
- The actual CRUD-against-real-RLS path (does an insert/select/update/delete really behave the way the policies say) is **not** verified end-to-end here and needs the manual pass below on the live site.

## Manual test script (live site)

1. **Failed login message** — Go to `/login`, enter a real registered email with the *wrong* password. You should see "Incorrect email or password." (not a generic error).
2. **Signup with confirmation off** — Go to `/signup`, create a brand-new account. Since email confirmation is currently off, you should land straight in `/app` — you should *not* see a "check your email" screen.
3. **Password reset link** — From `/login`, click "Forgot password?", request a reset link for a real account, open the email, and click the link. It should land you on the **"Reset your password"** form (not the homepage) so you can set a new password. If it instead lands you on the homepage, please tell me — I have a documented, size-conscious fallback (a client-side hash-fragment catcher) I intentionally didn't build without being able to confirm which URL shape your project's link actually produces.
4. **Exercises list** — Log in, click "Exercises" in the header (or the card on `/app`). You should see the 15 seeded exercises as cards.
5. **Search & filters** — Type into "Szukaj" and confirm the grid narrows. Try the "Kategoria", "Poziom", and "Sprzęt" dropdowns individually and combined with search. Confirm the small filter chips appear and "Wyczyść filtry" clears everything back to all 15.
6. **Detail view** — Click any card. Confirm you see the category, difficulty, duration, equipment, description, and the steps as a numbered list. Confirm there's **no** Edit/Delete on these (they're all official, `author_id` is null).
7. **Create an exercise** — Click "Dodaj ćwiczenie", fill in a title, pick a category, add 2–3 steps, set duration/difficulty, add an equipment tag or two, leave "Widoczne publicznie" checked, save. Confirm you land on the new exercise's detail page and now see Edit/Delete buttons on it.
8. **Edit** — Click Edit, change the title, save. Confirm the change shows on the detail page.
9. **Delete** — Click Delete, confirm via the inline "Tak, usuń" prompt. Confirm you're returned to the list and the exercise is gone.
10. **Access control** — Confirm you still can't edit/delete any of the 15 official exercises, or (if you have a second test account) another user's exercises.

I'll keep watching this PR and follow up on CI/review comments.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eat99Lqd7U2iZY3DT16XMT)_