### PR TITLE
feat(workouts): workout builder — list, create, and drag-and-drop session assembly

### DIFF
--- a/app/app/workouts/[id]/page.tsx
+++ b/app/app/workouts/[id]/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { WorkoutBuilder } from "@/components/workouts/WorkoutBuilder";
+import type { Exercise } from "@/lib/supabase/types";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Trening — Coach Zone",
+};
+
+export default async function WorkoutBuilderPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const [{ data: workout }, { data: items }, { data: categories }] =
+    await Promise.all([
+      supabase.from("workouts").select("*").eq("id", id).maybeSingle(),
+      supabase
+        .from("workout_items")
+        .select("*")
+        .eq("workout_id", id)
+        .order("position", { ascending: true }),
+      supabase.from("categories").select("*").order("id", { ascending: true }),
+    ]);
+
+  if (!workout) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 pt-8 pb-20 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Nie znaleziono treningu
+        </h1>
+        <p className="mt-3 text-neutral-600 dark:text-neutral-400">
+          Ten trening nie istnieje albo nie masz do niego dostępu.
+        </p>
+        <Link
+          href="/app/workouts"
+          className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Powrót do listy
+        </Link>
+      </main>
+    );
+  }
+
+  const exerciseIds = Array.from(
+    new Set((items ?? []).map((item) => item.exercise_id)),
+  );
+  const { data: exercises } =
+    exerciseIds.length > 0
+      ? await supabase.from("exercises").select("*").in("id", exerciseIds)
+      : { data: [] as Exercise[] };
+
+  const exercisesById = Object.fromEntries(
+    (exercises ?? []).map((exercise) => [exercise.id, exercise]),
+  );
+
+  return (
+    <WorkoutBuilder
+      initialWorkout={workout}
+      initialItems={items ?? []}
+      initialExercisesById={exercisesById}
+      categories={categories ?? []}
+    />
+  );
+}

--- a/app/app/workouts/new/page.tsx
+++ b/app/app/workouts/new/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { WorkoutBasicsForm } from "@/components/workouts/WorkoutBasicsForm";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Nowy trening — Coach Zone",
+};
+
+export default async function NewWorkoutPage() {
+  const supabase = await createClient();
+  const { data: userData } = await supabase.auth.getUser();
+
+  // Middleware already guarantees a user for any /app/* route; this is a
+  // defensive fallback since userId below is required for the insert.
+  if (!userData.user) {
+    redirect("/login");
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <h1 className="text-3xl font-bold tracking-tight">Nowy trening</h1>
+      <p className="mt-2 text-neutral-600 dark:text-neutral-400">
+        Podaj podstawowe informacje — szczegóły ćwiczeń dodasz w kolejnym kroku.
+      </p>
+      <div className="mt-8">
+        <WorkoutBasicsForm mode="create" userId={userData.user.id} />
+      </div>
+    </main>
+  );
+}

--- a/app/app/workouts/page.tsx
+++ b/app/app/workouts/page.tsx
@@ -1,26 +1,10 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { WorkoutsList } from "@/components/workouts/WorkoutsList";
 
 export const metadata: Metadata = {
-  title: "Workouts — Coach Zone",
+  title: "Treningi — Coach Zone",
 };
 
-export default function WorkoutsPlaceholder() {
-  return (
-    <div className="flex min-h-[calc(100vh-65px)] flex-col items-center justify-center px-6 text-center">
-      <h1 className="text-2xl font-semibold tracking-tight">
-        Workouts are coming in Round 4
-      </h1>
-      <p className="mt-3 max-w-sm text-neutral-600 dark:text-neutral-400">
-        This is where you&rsquo;ll assemble training sessions and share them
-        with your team.
-      </p>
-      <Link
-        href="/app"
-        className="mt-8 rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
-      >
-        Back to home
-      </Link>
-    </div>
-  );
+export default function WorkoutsPage() {
+  return <WorkoutsList />;
 }

--- a/components/workouts/DeleteWorkoutButton.tsx
+++ b/components/workouts/DeleteWorkoutButton.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export function DeleteWorkoutButton({
+  workoutId,
+  onDeleted,
+}: {
+  workoutId: string;
+  onDeleted: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    setDeleting(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("workouts")
+      .delete()
+      .eq("id", workoutId);
+
+    if (error) {
+      setDeleting(false);
+      setError("Nie udało się usunąć treningu. Spróbuj ponownie.");
+      return;
+    }
+
+    onDeleted();
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex flex-col items-end gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-neutral-600 dark:text-neutral-400">
+            Na pewno?
+          </span>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {deleting ? "Usuwanie…" : "Tak, usuń"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            disabled={deleting}
+            className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Anuluj
+          </button>
+        </div>
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setConfirming(true)}
+      className="rounded-full border border-red-300 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/40"
+    >
+      Usuń
+    </button>
+  );
+}

--- a/components/workouts/ExercisePicker.tsx
+++ b/components/workouts/ExercisePicker.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { CategoryBadge } from "@/components/exercises/CategoryBadge";
+import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
+import {
+  DIFFICULTY_LABELS,
+  DIFFICULTY_OPTIONS,
+  formatDuration,
+} from "@/lib/exercises";
+import { SECTION_LABELS } from "@/lib/workouts";
+import type {
+  Category,
+  Difficulty,
+  Exercise,
+  WorkoutSection,
+} from "@/lib/supabase/types";
+
+const ALL = "all" as const;
+
+export function ExercisePicker({
+  section,
+  exercises,
+  loadError,
+  categories,
+  onAdd,
+  onClose,
+}: {
+  section: WorkoutSection;
+  exercises: Exercise[] | null;
+  loadError: boolean;
+  categories: Category[];
+  onAdd: (exercise: Exercise) => void;
+  onClose: () => void;
+}) {
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<number | typeof ALL>(
+    ALL,
+  );
+  const [difficultyFilter, setDifficultyFilter] = useState<
+    Difficulty | typeof ALL
+  >(ALL);
+  const [equipmentFilter, setEquipmentFilter] = useState<string>(ALL);
+  const [justAddedId, setJustAddedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const categoriesById = useMemo(() => {
+    const map = new Map<number, Category>();
+    for (const category of categories) map.set(category.id, category);
+    return map;
+  }, [categories]);
+
+  const equipmentOptions = useMemo(() => {
+    const values = new Set<string>();
+    for (const exercise of exercises ?? []) {
+      for (const item of exercise.equipment) values.add(item);
+    }
+    return Array.from(values).sort((a, b) => a.localeCompare(b, "pl"));
+  }, [exercises]);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return (exercises ?? []).filter((exercise) => {
+      if (query) {
+        const haystack =
+          `${exercise.title} ${exercise.description ?? ""}`.toLowerCase();
+        if (!haystack.includes(query)) return false;
+      }
+      if (categoryFilter !== ALL && exercise.category_id !== categoryFilter)
+        return false;
+      if (difficultyFilter !== ALL && exercise.difficulty !== difficultyFilter)
+        return false;
+      if (
+        equipmentFilter !== ALL &&
+        !exercise.equipment.includes(equipmentFilter)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [exercises, search, categoryFilter, difficultyFilter, equipmentFilter]);
+
+  function handleAdd(exercise: Exercise) {
+    onAdd(exercise);
+    setJustAddedId(exercise.id);
+    setTimeout(() => {
+      setJustAddedId((current) => (current === exercise.id ? null : current));
+    }, 1200);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="exercise-picker-title"
+        onClick={(e) => e.stopPropagation()}
+        className="flex max-h-[85vh] w-full max-w-2xl flex-col rounded-2xl bg-white p-6 dark:bg-neutral-900"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2
+              id="exercise-picker-title"
+              className="text-lg font-semibold tracking-tight"
+            >
+              Dodaj ćwiczenie
+            </h2>
+            <p className="text-sm text-neutral-600 dark:text-neutral-400">
+              Sekcja: {SECTION_LABELS[section]}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Zamknij"
+            className="shrink-0 rounded-full p-1.5 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Szukaj po nazwie lub opisie…"
+            aria-label="Szukaj ćwiczeń"
+            className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+          />
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+            <select
+              aria-label="Kategoria"
+              value={categoryFilter === ALL ? ALL : String(categoryFilter)}
+              onChange={(e) =>
+                setCategoryFilter(
+                  e.target.value === ALL ? ALL : Number(e.target.value),
+                )
+              }
+              className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              <option value={ALL}>Wszystkie kategorie</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name_pl}
+                </option>
+              ))}
+            </select>
+
+            <select
+              aria-label="Poziom trudności"
+              value={difficultyFilter === ALL ? ALL : String(difficultyFilter)}
+              onChange={(e) =>
+                setDifficultyFilter(
+                  e.target.value === ALL
+                    ? ALL
+                    : (Number(e.target.value) as Difficulty),
+                )
+              }
+              className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              <option value={ALL}>Wszystkie poziomy</option>
+              {DIFFICULTY_OPTIONS.map((d) => (
+                <option key={d} value={d}>
+                  {d} – {DIFFICULTY_LABELS[d]}
+                </option>
+              ))}
+            </select>
+
+            <select
+              aria-label="Sprzęt"
+              value={equipmentFilter}
+              onChange={(e) => setEquipmentFilter(e.target.value)}
+              className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              <option value={ALL}>Wszystkie</option>
+              {equipmentOptions.map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-4 min-h-0 flex-1 overflow-y-auto">
+          {loadError ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-center dark:border-red-900/50 dark:bg-red-950/40">
+              <p className="text-sm text-red-700 dark:text-red-400">
+                Nie udało się wczytać biblioteki ćwiczeń.
+              </p>
+            </div>
+          ) : exercises === null ? (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }, (_, i) => (
+                <div
+                  key={i}
+                  className="h-16 animate-pulse rounded-xl bg-neutral-100 dark:bg-neutral-800"
+                />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="rounded-xl border border-neutral-200 p-6 text-center text-sm text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
+              Brak ćwiczeń spełniających kryteria.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {filtered.map((exercise) => {
+                const category = categoriesById.get(exercise.category_id);
+                return (
+                  <li
+                    key={exercise.id}
+                    className="flex items-center justify-between gap-3 rounded-xl border border-neutral-200 p-3 dark:border-neutral-800"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold">
+                        {exercise.title}
+                      </p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        {category && (
+                          <CategoryBadge
+                            name={category.name_pl}
+                            slug={category.slug}
+                          />
+                        )}
+                        <DifficultyIndicator difficulty={exercise.difficulty} />
+                        <span className="text-xs text-neutral-500 dark:text-neutral-500">
+                          {formatDuration(exercise.duration_min)}
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleAdd(exercise)}
+                      className="shrink-0 rounded-full bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
+                    >
+                      {justAddedId === exercise.id ? "Dodano ✓" : "Dodaj"}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/workouts/SaveIndicator.tsx
+++ b/components/workouts/SaveIndicator.tsx
@@ -1,0 +1,34 @@
+import type { SaveState } from "@/lib/workouts";
+
+const CONFIG: Record<
+  Exclude<SaveState, "idle">,
+  { text: string; className: string }
+> = {
+  saving: {
+    text: "Zapisywanie…",
+    className: "text-neutral-500 dark:text-neutral-400",
+  },
+  saved: {
+    text: "Zapisano",
+    className: "text-emerald-600 dark:text-emerald-400",
+  },
+  error: {
+    text: "Błąd zapisu — sprawdź połączenie i spróbuj ponownie.",
+    className: "text-red-600 dark:text-red-400",
+  },
+};
+
+export function SaveIndicator({ state }: { state: SaveState }) {
+  if (state === "idle") return null;
+
+  const { text, className } = CONFIG[state];
+
+  return (
+    <span
+      role={state === "error" ? "alert" : "status"}
+      className={`text-right text-sm font-medium ${className}`}
+    >
+      {text}
+    </span>
+  );
+}

--- a/components/workouts/WorkoutBasicsForm.tsx
+++ b/components/workouts/WorkoutBasicsForm.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { FormBanner } from "@/components/auth/FormBanner";
+import { FormField } from "@/components/auth/FormField";
+import { SubmitButton } from "@/components/auth/SubmitButton";
+import { createClient } from "@/lib/supabase/client";
+import type { Workout } from "@/lib/supabase/types";
+
+type WorkoutBasicsFormProps =
+  | { mode: "create"; userId: string }
+  | {
+      mode: "edit";
+      workout: Workout;
+      onSaved: (workout: Workout) => void;
+      onCancel: () => void;
+    };
+
+interface FieldErrors {
+  title?: string;
+}
+
+const labelClasses = "block text-sm font-medium";
+
+function fieldClasses() {
+  return "w-full rounded-lg border bg-white px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:bg-neutral-900 border-neutral-300 dark:border-neutral-700";
+}
+
+export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
+  const router = useRouter();
+  const initial = props.mode === "edit" ? props.workout : null;
+
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [teamName, setTeamName] = useState(initial?.team_name ?? "");
+  const [scheduledFor, setScheduledFor] = useState(
+    initial?.scheduled_for ?? "",
+  );
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    if (!title.trim()) {
+      setFieldErrors({ title: "Podaj nazwę treningu." });
+      return;
+    }
+    setFieldErrors({});
+
+    setLoading(true);
+    const supabase = createClient();
+
+    const payload = {
+      title: title.trim(),
+      team_name: teamName.trim() || null,
+      scheduled_for: scheduledFor || null,
+      notes: notes.trim() || null,
+    };
+
+    if (props.mode === "create") {
+      const { data, error } = await supabase
+        .from("workouts")
+        .insert({ ...payload, owner_id: props.userId })
+        .select("id")
+        .single();
+
+      setLoading(false);
+      if (error || !data) {
+        setFormError("Nie udało się utworzyć treningu. Spróbuj ponownie.");
+        return;
+      }
+      router.push(`/app/workouts/${data.id}`);
+      router.refresh();
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from("workouts")
+      .update(payload)
+      .eq("id", props.workout.id)
+      .select("*")
+      .single();
+
+    setLoading(false);
+    if (error || !data) {
+      setFormError("Nie udało się zapisać zmian. Spróbuj ponownie.");
+      return;
+    }
+    props.onSaved(data);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-5">
+      <FormBanner variant="error" message={formError} />
+
+      <FormField
+        id="title"
+        label="Nazwa treningu"
+        type="text"
+        placeholder="np. Trening przedmeczowy"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        error={fieldErrors.title}
+      />
+
+      <FormField
+        id="teamName"
+        label="Drużyna (opcjonalnie)"
+        type="text"
+        placeholder="np. Orlik U15"
+        value={teamName}
+        onChange={(e) => setTeamName(e.target.value)}
+      />
+
+      <FormField
+        id="scheduledFor"
+        label="Data treningu (opcjonalnie)"
+        type="date"
+        value={scheduledFor}
+        onChange={(e) => setScheduledFor(e.target.value)}
+      />
+
+      <div>
+        <label htmlFor="notes" className={labelClasses}>
+          Notatki (opcjonalnie)
+        </label>
+        <textarea
+          id="notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={3}
+          className={`mt-1.5 ${fieldClasses()}`}
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <div className="flex-1">
+          <SubmitButton loading={loading} loadingText="Zapisywanie…">
+            {props.mode === "create" ? "Utwórz trening" : "Zapisz zmiany"}
+          </SubmitButton>
+        </div>
+        {props.mode === "edit" && (
+          <button
+            type="button"
+            onClick={props.onCancel}
+            disabled={loading}
+            className="shrink-0 rounded-full border border-neutral-300 px-4 py-2.5 text-sm font-medium transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Anuluj
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type {
+  Category,
+  Exercise,
+  Workout,
+  WorkoutItem,
+  WorkoutSection,
+} from "@/lib/supabase/types";
+import {
+  DEFAULT_ITEM_DURATION_MIN,
+  SECTION_LABELS,
+  SECTION_ORDER,
+  formatScheduledDate,
+  formatTotalDuration,
+  nextPosition,
+  type SaveState,
+} from "@/lib/workouts";
+import { DeleteWorkoutButton } from "./DeleteWorkoutButton";
+import { ExercisePicker } from "./ExercisePicker";
+import { SaveIndicator } from "./SaveIndicator";
+import { WorkoutBasicsForm } from "./WorkoutBasicsForm";
+import { WorkoutSectionColumn } from "./WorkoutSectionColumn";
+
+export function WorkoutBuilder({
+  initialWorkout,
+  initialItems,
+  initialExercisesById,
+  categories,
+}: {
+  initialWorkout: Workout;
+  initialItems: WorkoutItem[];
+  initialExercisesById: Record<string, Exercise>;
+  categories: Category[];
+}) {
+  const router = useRouter();
+
+  const [workout, setWorkout] = useState(initialWorkout);
+  const [items, setItems] = useState<WorkoutItem[]>(initialItems);
+  const [exercisesById, setExercisesById] = useState(initialExercisesById);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [editingBasics, setEditingBasics] = useState(false);
+  const [pickerSection, setPickerSection] = useState<WorkoutSection | null>(
+    null,
+  );
+
+  const [libraryExercises, setLibraryExercises] = useState<Exercise[] | null>(
+    null,
+  );
+  const [libraryError, setLibraryError] = useState(false);
+
+  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+
+  useEffect(() => {
+    const timers = debounceTimers.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+    };
+  }, []);
+
+  // Preloaded once so reopening the picker for another section is instant.
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    supabase
+      .from("exercises")
+      .select("*")
+      .order("title", { ascending: true })
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        if (error || !data) {
+          setLibraryError(true);
+          return;
+        }
+        setLibraryExercises(data);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const itemsBySection = useMemo(() => {
+    const map = new Map<WorkoutSection, WorkoutItem[]>();
+    for (const section of SECTION_ORDER) map.set(section, []);
+    for (const item of items) map.get(item.section)?.push(item);
+    for (const section of SECTION_ORDER) {
+      map.get(section)?.sort((a, b) => a.position - b.position);
+    }
+    return map;
+  }, [items]);
+
+  const categoriesById = useMemo(() => {
+    const map = new Map<number, Category>();
+    for (const category of categories) map.set(category.id, category);
+    return map;
+  }, [categories]);
+
+  const totalDuration = useMemo(
+    () => items.reduce((sum, item) => sum + (item.duration_min ?? 0), 0),
+    [items],
+  );
+
+  // Optimistic-update helper shared by every mutation: apply the new items
+  // array immediately, persist in the background, and roll back to the
+  // pre-mutation snapshot if the write fails so the UI never shows state
+  // that isn't actually saved.
+  async function applyMutation(
+    nextItems: WorkoutItem[],
+    persist: () => Promise<{ error: unknown }>,
+  ) {
+    const previousItems = items;
+    setItems(nextItems);
+    setSaveState("saving");
+    const { error } = await persist();
+    if (error) {
+      setItems(previousItems);
+      setSaveState("error");
+      return;
+    }
+    setSaveState("saved");
+  }
+
+  async function handleAddExercise(
+    section: WorkoutSection,
+    exercise: Exercise,
+  ) {
+    const sectionItems = itemsBySection.get(section) ?? [];
+    const newItem: WorkoutItem = {
+      id: crypto.randomUUID(),
+      workout_id: workout.id,
+      exercise_id: exercise.id,
+      section,
+      position: nextPosition(sectionItems),
+      duration_min: exercise.duration_min ?? DEFAULT_ITEM_DURATION_MIN,
+      assigned_to: null,
+    };
+
+    setExercisesById((prev) => ({ ...prev, [exercise.id]: exercise }));
+
+    await applyMutation([...items, newItem], async () => {
+      const supabase = createClient();
+      const { error } = await supabase.from("workout_items").insert(newItem);
+      return { error };
+    });
+  }
+
+  async function handleRemoveItem(itemId: string) {
+    await applyMutation(
+      items.filter((item) => item.id !== itemId),
+      async () => {
+        const supabase = createClient();
+        const { error } = await supabase
+          .from("workout_items")
+          .delete()
+          .eq("id", itemId);
+        return { error };
+      },
+    );
+  }
+
+  async function handleReorderSection(
+    section: WorkoutSection,
+    activeId: string,
+    overId: string,
+  ) {
+    const sectionItems = itemsBySection.get(section) ?? [];
+    const oldIndex = sectionItems.findIndex((item) => item.id === activeId);
+    const newIndex = sectionItems.findIndex((item) => item.id === overId);
+    if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return;
+
+    const reordered = [...sectionItems];
+    const [moved] = reordered.splice(oldIndex, 1);
+    reordered.splice(newIndex, 0, moved);
+    const renumbered = reordered.map((item, index) => ({
+      ...item,
+      position: index,
+    }));
+
+    const otherItems = items.filter((item) => item.section !== section);
+
+    await applyMutation([...otherItems, ...renumbered], async () => {
+      const supabase = createClient();
+      const results = await Promise.all(
+        renumbered.map((item) =>
+          supabase
+            .from("workout_items")
+            .update({ position: item.position })
+            .eq("id", item.id),
+        ),
+      );
+      const failed = results.find((result) => result.error);
+      return { error: failed?.error ?? null };
+    });
+  }
+
+  async function handleMoveToSection(
+    itemId: string,
+    newSection: WorkoutSection,
+  ) {
+    const item = items.find((i) => i.id === itemId);
+    if (!item || item.section === newSection) return;
+
+    const destItems = itemsBySection.get(newSection) ?? [];
+    const position = nextPosition(destItems);
+    const nextItems = items.map((i) =>
+      i.id === itemId ? { ...i, section: newSection, position } : i,
+    );
+
+    await applyMutation(nextItems, async () => {
+      const supabase = createClient();
+      const { error } = await supabase
+        .from("workout_items")
+        .update({ section: newSection, position })
+        .eq("id", itemId);
+      return { error };
+    });
+  }
+
+  function scheduleFieldSave(
+    itemId: string,
+    field: "duration_min" | "assigned_to",
+    patch: Partial<Pick<WorkoutItem, "duration_min" | "assigned_to">>,
+  ) {
+    const key = `${itemId}-${field}`;
+    const existing = debounceTimers.current.get(key);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(async () => {
+      setSaveState("saving");
+      const supabase = createClient();
+      const { error } = await supabase
+        .from("workout_items")
+        .update(patch)
+        .eq("id", itemId);
+      setSaveState(error ? "error" : "saved");
+    }, 500);
+    debounceTimers.current.set(key, timer);
+  }
+
+  function handleDurationChange(itemId: string, rawValue: string) {
+    if (rawValue === "") {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === itemId ? { ...item, duration_min: null } : item,
+        ),
+      );
+      scheduleFieldSave(itemId, "duration_min", { duration_min: null });
+      return;
+    }
+    const parsed = Number(rawValue);
+    // duration_min is a Postgres integer column - a fractional value here
+    // would round-trip fine through JS but fail the write with a cast error.
+    if (!Number.isInteger(parsed) || parsed < 0) return;
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === itemId ? { ...item, duration_min: parsed } : item,
+      ),
+    );
+    scheduleFieldSave(itemId, "duration_min", { duration_min: parsed });
+  }
+
+  function handleAssignedToChange(itemId: string, value: string) {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === itemId ? { ...item, assigned_to: value } : item,
+      ),
+    );
+    scheduleFieldSave(itemId, "assigned_to", {
+      assigned_to: value.trim() || null,
+    });
+  }
+
+  function handleBasicsSaved(updated: Workout) {
+    setWorkout(updated);
+    setEditingBasics(false);
+  }
+
+  function handleWorkoutDeleted() {
+    router.push("/app/workouts");
+    router.refresh();
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-24">
+      <Link
+        href="/app/workouts"
+        className="text-sm font-medium text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+      >
+        ← Wszystkie treningi
+      </Link>
+
+      <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          {editingBasics ? (
+            <div className="max-w-md">
+              <WorkoutBasicsForm
+                mode="edit"
+                workout={workout}
+                onSaved={handleBasicsSaved}
+                onCancel={() => setEditingBasics(false)}
+              />
+            </div>
+          ) : (
+            <>
+              <h1 className="text-3xl font-bold tracking-tight">
+                {workout.title}
+              </h1>
+              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-neutral-600 dark:text-neutral-400">
+                {workout.team_name && <span>{workout.team_name}</span>}
+                <span>{formatScheduledDate(workout.scheduled_for)}</span>
+              </div>
+              {workout.notes && (
+                <p className="mt-3 max-w-2xl whitespace-pre-line text-sm text-neutral-600 dark:text-neutral-400">
+                  {workout.notes}
+                </p>
+              )}
+              <button
+                type="button"
+                onClick={() => setEditingBasics(true)}
+                className="mt-3 text-sm font-medium text-emerald-600 hover:text-emerald-500"
+              >
+                Edytuj szczegóły
+              </button>
+            </>
+          )}
+        </div>
+
+        <div className="flex shrink-0 flex-col items-end gap-3">
+          <SaveIndicator state={saveState} />
+          <DeleteWorkoutButton
+            workoutId={workout.id}
+            onDeleted={handleWorkoutDeleted}
+          />
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2 rounded-2xl border border-neutral-200 px-5 py-4 text-sm dark:border-neutral-800">
+        <span className="font-semibold">
+          Łączny czas: {formatTotalDuration(totalDuration)}
+        </span>
+        {SECTION_ORDER.map((section) => (
+          <span
+            key={section}
+            className="text-neutral-600 dark:text-neutral-400"
+          >
+            {SECTION_LABELS[section]}:{" "}
+            {itemsBySection.get(section)?.length ?? 0}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {SECTION_ORDER.map((section) => (
+          <WorkoutSectionColumn
+            key={section}
+            section={section}
+            items={itemsBySection.get(section) ?? []}
+            exercisesById={exercisesById}
+            categoriesById={categoriesById}
+            onReorder={(activeId, overId) =>
+              handleReorderSection(section, activeId, overId)
+            }
+            onDurationChange={handleDurationChange}
+            onAssignedToChange={handleAssignedToChange}
+            onMoveToSection={handleMoveToSection}
+            onRemove={handleRemoveItem}
+            onOpenPicker={() => setPickerSection(section)}
+          />
+        ))}
+      </div>
+
+      {pickerSection && (
+        <ExercisePicker
+          key={pickerSection}
+          section={pickerSection}
+          exercises={libraryExercises}
+          loadError={libraryError}
+          categories={categories}
+          onAdd={(exercise) => handleAddExercise(pickerSection, exercise)}
+          onClose={() => setPickerSection(null)}
+        />
+      )}
+    </main>
+  );
+}

--- a/components/workouts/WorkoutCard.tsx
+++ b/components/workouts/WorkoutCard.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import type { Workout } from "@/lib/supabase/types";
+import { formatCreatedDate, formatScheduledDate } from "@/lib/workouts";
+import { DeleteWorkoutButton } from "./DeleteWorkoutButton";
+
+export function WorkoutCard({
+  workout,
+  itemCount,
+  onDeleted,
+}: {
+  workout: Workout;
+  itemCount: number;
+  onDeleted: () => void;
+}) {
+  return (
+    <div className="flex flex-col rounded-2xl border border-neutral-200 p-5 transition-colors hover:border-emerald-600/50 dark:border-neutral-800">
+      <Link
+        href={`/app/workouts/${workout.id}`}
+        className="flex-1 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/50"
+      >
+        <h3 className="font-semibold tracking-tight">{workout.title}</h3>
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-neutral-600 dark:text-neutral-400">
+          {workout.team_name && <span>{workout.team_name}</span>}
+          <span>{formatScheduledDate(workout.scheduled_for)}</span>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500 dark:text-neutral-500">
+          <span>
+            {itemCount} {itemCount === 1 ? "ćwiczenie" : "ćwiczeń"}
+          </span>
+          <span>Utworzono {formatCreatedDate(workout.created_at)}</span>
+        </div>
+      </Link>
+
+      <div className="mt-4 flex justify-end">
+        <DeleteWorkoutButton workoutId={workout.id} onDeleted={onDeleted} />
+      </div>
+    </div>
+  );
+}

--- a/components/workouts/WorkoutCardSkeleton.tsx
+++ b/components/workouts/WorkoutCardSkeleton.tsx
@@ -1,0 +1,12 @@
+export function WorkoutCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-2xl border border-neutral-200 p-5 dark:border-neutral-800">
+      <div className="h-4 w-2/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-4 h-3 w-1/2 rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-2 h-3 w-1/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-5 flex justify-end">
+        <div className="h-8 w-20 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+    </div>
+  );
+}

--- a/components/workouts/WorkoutItemRow.tsx
+++ b/components/workouts/WorkoutItemRow.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useState } from "react";
+import { CategoryBadge } from "@/components/exercises/CategoryBadge";
+import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
+import { SECTION_LABELS, SECTION_ORDER } from "@/lib/workouts";
+import type {
+  Category,
+  Exercise,
+  WorkoutItem,
+  WorkoutSection,
+} from "@/lib/supabase/types";
+
+export function WorkoutItemRow({
+  item,
+  exercise,
+  category,
+  onDurationChange,
+  onAssignedToChange,
+  onMoveToSection,
+  onRemove,
+}: {
+  item: WorkoutItem;
+  exercise: Exercise | undefined;
+  category: Category | undefined;
+  onDurationChange: (itemId: string, value: string) => void;
+  onAssignedToChange: (itemId: string, value: string) => void;
+  onMoveToSection: (itemId: string, section: WorkoutSection) => void;
+  onRemove: (itemId: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`rounded-xl border border-neutral-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950 ${
+        isDragging ? "z-10 opacity-90 shadow-lg" : ""
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          aria-label="Przeciągnij, aby zmienić kolejność"
+          className="mt-0.5 shrink-0 touch-none rounded p-1 text-base leading-none text-neutral-400 hover:text-neutral-600 active:cursor-grabbing dark:hover:text-neutral-300 cursor-grab"
+        >
+          ⠿
+        </button>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {exercise ? (
+              <a
+                href={`/app/exercises/${exercise.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="truncate text-sm font-semibold hover:text-emerald-600 dark:hover:text-emerald-400"
+              >
+                {exercise.title}
+              </a>
+            ) : (
+              <span className="text-sm font-semibold text-neutral-400">
+                Ćwiczenie niedostępne
+              </span>
+            )}
+            {category && (
+              <CategoryBadge name={category.name_pl} slug={category.slug} />
+            )}
+            {exercise && (
+              <DifficultyIndicator difficulty={exercise.difficulty} />
+            )}
+          </div>
+
+          <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <label className="text-xs text-neutral-500 dark:text-neutral-500">
+              Czas (min)
+              <input
+                type="number"
+                min={0}
+                value={item.duration_min ?? ""}
+                onChange={(e) => onDurationChange(item.id, e.target.value)}
+                className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-2 py-1.5 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+              />
+            </label>
+
+            <label className="col-span-1 text-xs text-neutral-500 dark:text-neutral-500 sm:col-span-2">
+              Przypisanie
+              <input
+                type="text"
+                value={item.assigned_to ?? ""}
+                onChange={(e) => onAssignedToChange(item.id, e.target.value)}
+                placeholder="np. obrońcy / Kowalski"
+                className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-2 py-1.5 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+              />
+            </label>
+
+            <label className="text-xs text-neutral-500 dark:text-neutral-500">
+              Sekcja
+              <select
+                value={item.section}
+                onChange={(e) =>
+                  onMoveToSection(item.id, e.target.value as WorkoutSection)
+                }
+                className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-2 py-1.5 text-sm outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 dark:border-neutral-700 dark:bg-neutral-900"
+              >
+                {SECTION_ORDER.map((section) => (
+                  <option key={section} value={section}>
+                    {SECTION_LABELS[section]}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div className="shrink-0">
+          {confirmingRemove ? (
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={() => onRemove(item.id)}
+                className="rounded-full bg-red-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-red-500"
+              >
+                Usuń
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmingRemove(false)}
+                className="rounded-full border border-neutral-300 px-2.5 py-1 text-xs font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+              >
+                Anuluj
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmingRemove(true)}
+              aria-label="Usuń ćwiczenie z treningu"
+              className="rounded-full p-1.5 text-lg leading-none text-neutral-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/workouts/WorkoutSectionColumn.tsx
+++ b/components/workouts/WorkoutSectionColumn.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { SECTION_HINTS, SECTION_LABELS } from "@/lib/workouts";
+import type {
+  Category,
+  Exercise,
+  WorkoutItem,
+  WorkoutSection,
+} from "@/lib/supabase/types";
+import { WorkoutItemRow } from "./WorkoutItemRow";
+
+export function WorkoutSectionColumn({
+  section,
+  items,
+  exercisesById,
+  categoriesById,
+  onReorder,
+  onDurationChange,
+  onAssignedToChange,
+  onMoveToSection,
+  onRemove,
+  onOpenPicker,
+}: {
+  section: WorkoutSection;
+  items: WorkoutItem[];
+  exercisesById: Record<string, Exercise>;
+  categoriesById: Map<number, Category>;
+  onReorder: (activeId: string, overId: string) => void;
+  onDurationChange: (itemId: string, value: string) => void;
+  onAssignedToChange: (itemId: string, value: string) => void;
+  onMoveToSection: (itemId: string, section: WorkoutSection) => void;
+  onRemove: (itemId: string) => void;
+  onOpenPicker: () => void;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    onReorder(String(active.id), String(over.id));
+  }
+
+  const totalMinutes = items.reduce(
+    (sum, item) => sum + (item.duration_min ?? 0),
+    0,
+  );
+
+  return (
+    <section className="rounded-2xl border border-neutral-200 p-5 dark:border-neutral-800">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold tracking-tight">
+          {SECTION_LABELS[section]}
+        </h2>
+        <span className="text-xs text-neutral-500 dark:text-neutral-500">
+          {items.length} · {totalMinutes} min
+        </span>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {items.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-neutral-300 px-4 py-6 text-center text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-500">
+            {SECTION_HINTS[section]}
+          </p>
+        ) : (
+          <DndContext
+            id={`workout-section-${section}`}
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={items.map((item) => item.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {items.map((item) => (
+                <WorkoutItemRow
+                  key={item.id}
+                  item={item}
+                  exercise={exercisesById[item.exercise_id]}
+                  category={
+                    exercisesById[item.exercise_id]
+                      ? categoriesById.get(
+                          exercisesById[item.exercise_id].category_id,
+                        )
+                      : undefined
+                  }
+                  onDurationChange={onDurationChange}
+                  onAssignedToChange={onAssignedToChange}
+                  onMoveToSection={onMoveToSection}
+                  onRemove={onRemove}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onOpenPicker}
+        className="mt-4 w-full rounded-full border border-dashed border-neutral-300 px-4 py-2.5 text-sm font-medium text-neutral-600 transition-colors hover:border-emerald-600/50 hover:text-emerald-600 dark:border-neutral-700 dark:text-neutral-400 dark:hover:border-emerald-600/50 dark:hover:text-emerald-400"
+      >
+        + Dodaj ćwiczenie
+      </button>
+    </section>
+  );
+}

--- a/components/workouts/WorkoutsList.tsx
+++ b/components/workouts/WorkoutsList.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { Workout } from "@/lib/supabase/types";
+import { WorkoutCard } from "./WorkoutCard";
+import { WorkoutCardSkeleton } from "./WorkoutCardSkeleton";
+
+export function WorkoutsList() {
+  const [workouts, setWorkouts] = useState<Workout[] | null>(null);
+  const [itemCounts, setItemCounts] = useState<Record<string, number>>({});
+  const [loadError, setLoadError] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setWorkouts(null);
+    setLoadError(false);
+
+    const supabase = createClient();
+
+    async function load() {
+      const { data: workoutsData, error: workoutsError } = await supabase
+        .from("workouts")
+        .select("*")
+        .order("created_at", { ascending: false });
+
+      if (cancelled) return;
+      if (workoutsError || !workoutsData) {
+        setLoadError(true);
+        return;
+      }
+
+      const ids = workoutsData.map((workout) => workout.id);
+      const { data: itemsData, error: itemsError } =
+        ids.length > 0
+          ? await supabase
+              .from("workout_items")
+              .select("workout_id")
+              .in("workout_id", ids)
+          : { data: [], error: null };
+
+      if (cancelled) return;
+      if (itemsError) {
+        setLoadError(true);
+        return;
+      }
+
+      const counts: Record<string, number> = {};
+      for (const item of itemsData ?? []) {
+        counts[item.workout_id] = (counts[item.workout_id] ?? 0) + 1;
+      }
+
+      setItemCounts(counts);
+      setWorkouts(workoutsData);
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  function handleDeleted(id: string) {
+    setWorkouts((prev) => prev?.filter((workout) => workout.id !== id) ?? prev);
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Twoje treningi</h1>
+          <p className="mt-1 text-neutral-600 dark:text-neutral-400">
+            Planuj sesje treningowe i buduj je z biblioteki ćwiczeń.
+          </p>
+        </div>
+        <Link
+          href="/app/workouts/new"
+          className="rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          Nowy trening
+        </Link>
+      </div>
+
+      <div className="mt-8">
+        {loadError ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/50 dark:bg-red-950/40">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Nie udało się wczytać treningów. Spróbuj ponownie.
+            </p>
+            <button
+              type="button"
+              onClick={() => setReloadToken((n) => n + 1)}
+              className="mt-3 rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
+            >
+              Spróbuj ponownie
+            </button>
+          </div>
+        ) : workouts === null ? (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 3 }, (_, i) => (
+              <WorkoutCardSkeleton key={i} />
+            ))}
+          </div>
+        ) : workouts.length === 0 ? (
+          <div className="rounded-2xl border border-neutral-200 p-8 text-center dark:border-neutral-800">
+            <p className="text-neutral-600 dark:text-neutral-400">
+              Nie masz jeszcze żadnych treningów — utwórz pierwszy.
+            </p>
+            <Link
+              href="/app/workouts/new"
+              className="mt-3 inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
+            >
+              Utwórz pierwszy trening →
+            </Link>
+          </div>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {workouts.map((workout) => (
+              <WorkoutCard
+                key={workout.id}
+                workout={workout}
+                itemCount={itemCounts[workout.id] ?? 0}
+                onDeleted={() => handleDeleted(workout.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -221,3 +221,5 @@ export interface Database {
 
 export type Exercise = Database["public"]["Tables"]["exercises"]["Row"];
 export type Category = Database["public"]["Tables"]["categories"]["Row"];
+export type Workout = Database["public"]["Tables"]["workouts"]["Row"];
+export type WorkoutItem = Database["public"]["Tables"]["workout_items"]["Row"];

--- a/lib/workouts.ts
+++ b/lib/workouts.ts
@@ -1,0 +1,65 @@
+import type { WorkoutItem, WorkoutSection } from "@/lib/supabase/types";
+
+export type SaveState = "idle" | "saving" | "saved" | "error";
+
+export const SECTION_ORDER: WorkoutSection[] = [
+  "warmup",
+  "main",
+  "positional",
+  "cooldown",
+];
+
+export const SECTION_LABELS: Record<WorkoutSection, string> = {
+  warmup: "Rozgrzewka",
+  main: "Część główna",
+  positional: "Ćwiczenia pozycyjne",
+  cooldown: "Schłodzenie",
+};
+
+export const SECTION_HINTS: Record<WorkoutSection, string> = {
+  warmup: "Brak ćwiczeń — dodaj rozgrzewkę, od której zacznie się trening.",
+  main: "Brak ćwiczeń — dodaj ćwiczenia stanowiące trzon treningu.",
+  positional:
+    "Brak ćwiczeń — tu przyda się przypisanie do pozycji lub zawodnika.",
+  cooldown: "Brak ćwiczeń — dodaj ćwiczenia kończące i schładzające.",
+};
+
+// Used when adding an exercise with no duration_min of its own set.
+export const DEFAULT_ITEM_DURATION_MIN = 10;
+
+// Positions are scoped per section and kept as small non-negative integers,
+// but not assumed contiguous (deleting an item leaves a gap on purpose, to
+// avoid renumbering the rest of the section on every removal). Basing the
+// next slot on the current max avoids colliding with a stale gap.
+export function nextPosition(sectionItems: WorkoutItem[]): number {
+  if (sectionItems.length === 0) return 0;
+  return Math.max(...sectionItems.map((item) => item.position)) + 1;
+}
+
+// scheduled_for is a plain `date` column (no time/timezone). Parsing it with
+// `new Date(string)` reads it as UTC midnight, which can render as the
+// previous day in timezones behind UTC - build the Date from components
+// instead so formatting stays in local time throughout.
+export function formatScheduledDate(value: string | null): string {
+  if (!value) return "Brak daty";
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString("pl-PL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+// created_at is a timestamptz, a real instant - safe to parse directly.
+export function formatCreatedDate(value: string): string {
+  return new Date(value).toLocaleDateString("pl-PL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function formatTotalDuration(totalMinutes: number): string {
+  return `${totalMinutes} min`;
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.110.1",
     "next": "15.5.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.0)
       '@supabase/ssr':
         specifier: ^0.12.0
         version: 0.12.0(@supabase/supabase-js@2.110.1)
@@ -63,6 +72,28 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1915,6 +1946,31 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
## Summary

Round 4: the workout builder. Replaces the `/app/workouts` placeholder with a full flow — list → create → builder.

- **`/app/workouts`** — the coach's own workouts (RLS-scoped), as cards with title, team, scheduled date, item count, created date. "Nowy trening" button, empty state, delete with inline confirmation.
- **`/app/workouts/new`** — basics form (title required; team/date/notes optional) → inserts the workout → redirects into the builder.
- **`/app/workouts/[id]`** — the builder itself:
  - Four fixed sections: Rozgrzewka · Część główna · Ćwiczenia pozycyjne · Schłodzenie.
  - Exercise picker modal reusing the Round 3 search + category/difficulty/equipment filters; adding an exercise creates a `workout_item` in the right section at the next position.
  - Drag-and-drop reorder **within** a section via `@dnd-kit` (pointer + keyboard sensors, dedicated touch-friendly drag handle so it doesn't fight the inline inputs or mobile scrolling).
  - Per-item `duration_min` (defaulted from the exercise's own duration) and `assigned_to` (free text), editable inline.
  - Live summary: total session duration + item count per section.
  - Remove item, edit workout basics inline, delete workout — all with confirmation on the destructive ones.
  - Responsive: sections stack to one column below `lg`; empty-section hints when a section has no items yet.

### Design decisions called out per the brief

- **Cross-section move**: implemented as the suggested fallback — a "Sekcja" select on each item — rather than cross-container dnd-kit. Each section is its own independent `DndContext`, which keeps the drag logic simple and avoids the collision-detection complexity of merging four containers into one.
- **Autosave, not an explicit save button**: every action (add/remove/reorder/move/edit field/edit basics) writes to Supabase immediately. A status indicator next to the workout title shows "Zapisywanie…" / "Zapisano" / "Błąd zapisu — sprawdź połączenie i spróbuj ponownie." Mutations apply optimistically and roll back to the last known-good state if the write fails, so the screen never shows unsaved state as saved.

## What I could and couldn't verify from the sandbox

This sandbox has no Supabase credentials (no `.env.local`, no reachable project), so I could not exercise the real RLS-backed flows end-to-end. What I did verify locally:

- `pnpm lint`, `pnpm typecheck`, `pnpm build` all pass.
- Booted the dev server and confirmed the new routes compile and the existing auth middleware still gates `/app/workouts*` correctly (redirects to `/login` when unauthenticated).
- Rendered the builder with mocked data (a temporary, gitignored-and-deleted preview route, never committed) and drove it with Playwright: drag-and-drop reorder, cross-section move, live-updating duration/summary math, remove/delete confirmations, the edit-basics toggle, and the picker's loading/error states. Also caught and fixed a real SSR hydration mismatch this way (dnd-kit's internal id counter drifted between server and client across the four independent `DndContext`s — fixed by passing a stable `id` per section).
- Confirmed the optimistic-update-then-rollback path by forcing a write failure: the UI applies the change immediately, then reverts and shows the error banner once the write fails.

I could **not** verify against the real Supabase project: actual persistence across reloads, RLS behavior with a real authenticated user, or the exact production visuals. Please run the test script below on the live site.

## Manual test script (live site)

1. Log in, go to **Treningi** in the nav (or `/app/workouts`). Confirm it shows your existing workouts (or the empty state with "Nie masz jeszcze żadnych treningów — utwórz pierwszy" if you have none).
2. Click **Nowy trening**. Fill in a title (required), optionally a team name, a date, and notes. Submit — you should land on the builder for the new workout.
3. In each of the four sections, click **+ Dodaj ćwiczenie**, use search/category/difficulty/equipment filters to find a drill, and click **Dodaj**. The modal stays open so you can add a few before closing it.
4. On an added item, edit **Czas (min)** and **Przypisanie** (e.g. "obrońcy") — confirm the summary bar's total duration updates immediately.
5. Drag an item by its handle (⠿) to reorder it within its section. Reload the page and confirm the new order persisted.
6. Use the **Sekcja** dropdown on an item to move it to a different section; confirm it appears there after the page reloads.
7. Remove an item (× → confirm). Confirm it's gone after a reload.
8. Click **Edytuj szczegóły** on the workout header, change the title/team/date/notes, save, and confirm it reflects immediately and survives a reload.
9. Go back to **Treningi**, confirm the item count and details on the card match what you built, then delete the workout (with confirmation) and confirm it's gone from the list.
10. Try steps 3–7 on a phone-width browser window (or an actual phone) to confirm sections stack and drag works with touch.

## Not in this round

PDF export, the public share link, sport-specific exercise splitting, and the tactics-board creator — all out of scope per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XCmji1bSeN7RCHeZmyeWM7)_