### PR TITLE
Round 6: fix share link domain, verify auth errors, visual polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,14 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
+# Public base URL used to build shareable/public links (the "Udostępnij"
+# workout link, OG tags) so they always resolve to the stable production
+# host instead of whatever Vercel deployment/preview URL is currently open.
+# Defaults to https://coach-zone.vercel.app when unset - only override this
+# locally (e.g. http://localhost:3000) if you need to test a share link
+# against your dev server.
+NEXT_PUBLIC_SITE_URL=https://coach-zone.vercel.app
+
 # Set to "true" once Google OAuth is configured in the Supabase dashboard
 # (Authentication > Providers > Google). Leave unset/false until then.
 NEXT_PUBLIC_ENABLE_GOOGLE_AUTH=

--- a/app/app/exercises/[id]/edit/loading.tsx
+++ b/app/app/exercises/[id]/edit/loading.tsx
@@ -1,0 +1,16 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <div className="h-8 w-56 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-8 space-y-5">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="h-3.5 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-10 w-full animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/app/exercises/[id]/edit/page.tsx
+++ b/app/app/exercises/[id]/edit/page.tsx
@@ -18,12 +18,15 @@ export default async function EditExercisePage({
   const { id } = await params;
   const supabase = await createClient();
 
-  const [{ data: exercise }, { data: userData }, { data: categories }] =
-    await Promise.all([
-      supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
-      supabase.auth.getUser(),
-      supabase.from("categories").select("*").order("id", { ascending: true }),
-    ]);
+  const [
+    { data: exercise, error: exerciseError },
+    { data: userData },
+    { data: categories },
+  ] = await Promise.all([
+    supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
+    supabase.auth.getUser(),
+    supabase.from("categories").select("*").order("id", { ascending: true }),
+  ]);
 
   if (!userData.user) {
     redirect("/login");
@@ -33,13 +36,18 @@ export default async function EditExercisePage({
     return (
       <main className="mx-auto max-w-2xl px-6 pt-8 pb-20 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">
-          Nie znaleziono ćwiczenia
+          {exerciseError ? "Wystąpił błąd" : "Nie znaleziono ćwiczenia"}
         </h1>
+        <p className="mt-3 text-neutral-600 dark:text-neutral-400">
+          {exerciseError
+            ? "Nie udało się wczytać ćwiczenia. Spróbuj ponownie."
+            : "To ćwiczenie nie istnieje albo nie masz do niego dostępu."}
+        </p>
         <Link
-          href="/app/exercises"
+          href={exerciseError ? `/app/exercises/${id}/edit` : "/app/exercises"}
           className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
         >
-          Powrót do listy
+          {exerciseError ? "Spróbuj ponownie" : "Powrót do listy"}
         </Link>
       </main>
     );

--- a/app/app/exercises/[id]/loading.tsx
+++ b/app/app/exercises/[id]/loading.tsx
@@ -1,0 +1,20 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <div className="h-4 w-32 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-4 h-8 w-2/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <div className="h-5 w-20 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+        <div className="h-5 w-16 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+        <div className="h-5 w-12 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+
+      <div className="mt-6 space-y-2">
+        <div className="h-4 w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        <div className="h-4 w-5/6 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        <div className="h-4 w-2/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+    </main>
+  );
+}

--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -20,25 +20,28 @@ export default async function ExerciseDetailPage({
   const { id } = await params;
   const supabase = await createClient();
 
-  const [{ data: exercise }, { data: userData }] = await Promise.all([
-    supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
-    supabase.auth.getUser(),
-  ]);
+  const [{ data: exercise, error: exerciseError }, { data: userData }] =
+    await Promise.all([
+      supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
+      supabase.auth.getUser(),
+    ]);
 
   if (!exercise) {
     return (
-      <main className="mx-auto max-w-3xl px-6 pt-8 pb-20 text-center">
+      <main className="mx-auto max-w-2xl px-6 pt-8 pb-20 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">
-          Nie znaleziono ćwiczenia
+          {exerciseError ? "Wystąpił błąd" : "Nie znaleziono ćwiczenia"}
         </h1>
         <p className="mt-3 text-neutral-600 dark:text-neutral-400">
-          To ćwiczenie nie istnieje albo nie masz do niego dostępu.
+          {exerciseError
+            ? "Nie udało się wczytać ćwiczenia. Spróbuj ponownie."
+            : "To ćwiczenie nie istnieje albo nie masz do niego dostępu."}
         </p>
         <Link
-          href="/app/exercises"
+          href={exerciseError ? `/app/exercises/${id}` : "/app/exercises"}
           className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
         >
-          Powrót do listy
+          {exerciseError ? "Spróbuj ponownie" : "Powrót do listy"}
         </Link>
       </main>
     );
@@ -53,7 +56,7 @@ export default async function ExerciseDetailPage({
   const isOwner = userData.user?.id === exercise.author_id;
 
   return (
-    <main className="mx-auto max-w-3xl px-6 pt-8 pb-20">
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
       <Link
         href="/app/exercises"
         className="text-sm font-medium text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"

--- a/app/app/exercises/loading.tsx
+++ b/app/app/exercises/loading.tsx
@@ -1,0 +1,21 @@
+import { ExerciseCardSkeleton } from "@/components/exercises/ExerciseCardSkeleton";
+
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-2">
+          <div className="h-8 w-56 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-4 w-72 max-w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+        <div className="h-10 w-40 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }, (_, i) => (
+          <ExerciseCardSkeleton key={i} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/app/exercises/new/loading.tsx
+++ b/app/app/exercises/new/loading.tsx
@@ -1,0 +1,17 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <div className="h-8 w-56 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-2 h-4 w-72 max-w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-8 space-y-5">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="h-3.5 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-10 w-full animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -3,20 +3,20 @@ import type { ReactNode } from "react";
 import { logout } from "./actions";
 
 const navItems = [
-  { href: "/app/exercises", label: "Exercises" },
-  { href: "/app/workouts", label: "Workouts" },
+  { href: "/app/exercises", label: "Ćwiczenia" },
+  { href: "/app/workouts", label: "Treningi" },
 ];
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
       <header className="border-b border-neutral-200 dark:border-neutral-800">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <div className="flex items-center gap-6 sm:gap-8">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-4 sm:px-6">
+          <div className="flex items-center gap-4 sm:gap-8">
             <Link href="/app" className="text-lg font-semibold tracking-tight">
               Coach Zone
             </Link>
-            <nav className="flex gap-4 sm:gap-6">
+            <nav className="flex gap-3 sm:gap-6">
               {navItems.map((item) => (
                 <Link
                   key={item.href}
@@ -31,9 +31,9 @@ export default function AppLayout({ children }: { children: ReactNode }) {
           <form action={logout}>
             <button
               type="submit"
-              className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+              className="rounded-full border border-neutral-300 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900 sm:px-4 sm:py-2"
             >
-              Log out
+              Wyloguj się
             </button>
           </form>
         </div>

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -11,13 +11,13 @@ export const metadata: Metadata = {
 const navItems = [
   {
     href: "/app/exercises",
-    title: "Exercises",
-    description: "Browse the official library and build your own drills.",
+    title: "Ćwiczenia",
+    description: "Przeglądaj oficjalną bibliotekę i twórz własne ćwiczenia.",
   },
   {
     href: "/app/workouts",
-    title: "Workouts",
-    description: "Plan training sessions and share them with your team.",
+    title: "Treningi",
+    description: "Planuj sesje treningowe i buduj je z biblioteki ćwiczeń.",
   },
 ];
 
@@ -41,12 +41,12 @@ export default async function AppHomePage() {
     profile?.display_name ?? user?.email?.split("@")[0] ?? "Coach";
 
   return (
-    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+    <main className="mx-auto max-w-3xl px-6 pt-8 pb-20">
       <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
-        Welcome, {displayName}
+        Witaj, {displayName}
       </h1>
       <p className="mt-3 text-neutral-600 dark:text-neutral-400">
-        Here&rsquo;s your Coach Zone home base.
+        To Twoja strona startowa w Coach Zone.
       </p>
 
       <div className="mt-10 grid gap-6 sm:grid-cols-2">

--- a/app/app/workouts/[id]/loading.tsx
+++ b/app/app/workouts/[id]/loading.tsx
@@ -1,0 +1,29 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-5xl px-6 pt-8 pb-24">
+      <div className="h-4 w-32 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <div className="h-8 w-56 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-4 w-40 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+        <div className="flex gap-2">
+          <div className="h-9 w-28 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-9 w-28 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+      </div>
+
+      <div className="mt-6 h-14 animate-pulse rounded-2xl bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={i}
+            className="h-48 animate-pulse rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-900"
+          />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/app/workouts/[id]/page.tsx
+++ b/app/app/workouts/[id]/page.tsx
@@ -18,31 +18,36 @@ export default async function WorkoutBuilderPage({
   const { id } = await params;
   const supabase = await createClient();
 
-  const [{ data: workout }, { data: items }, { data: categories }] =
-    await Promise.all([
-      supabase.from("workouts").select("*").eq("id", id).maybeSingle(),
-      supabase
-        .from("workout_items")
-        .select("*")
-        .eq("workout_id", id)
-        .order("position", { ascending: true }),
-      supabase.from("categories").select("*").order("id", { ascending: true }),
-    ]);
+  const [
+    { data: workout, error: workoutError },
+    { data: items },
+    { data: categories },
+  ] = await Promise.all([
+    supabase.from("workouts").select("*").eq("id", id).maybeSingle(),
+    supabase
+      .from("workout_items")
+      .select("*")
+      .eq("workout_id", id)
+      .order("position", { ascending: true }),
+    supabase.from("categories").select("*").order("id", { ascending: true }),
+  ]);
 
   if (!workout) {
     return (
-      <main className="mx-auto max-w-3xl px-6 pt-8 pb-20 text-center">
+      <main className="mx-auto max-w-2xl px-6 pt-8 pb-20 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">
-          Nie znaleziono treningu
+          {workoutError ? "Wystąpił błąd" : "Nie znaleziono treningu"}
         </h1>
         <p className="mt-3 text-neutral-600 dark:text-neutral-400">
-          Ten trening nie istnieje albo nie masz do niego dostępu.
+          {workoutError
+            ? "Nie udało się wczytać treningu. Spróbuj ponownie."
+            : "Ten trening nie istnieje albo nie masz do niego dostępu."}
         </p>
         <Link
-          href="/app/workouts"
+          href={workoutError ? `/app/workouts/${id}` : "/app/workouts"}
           className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
         >
-          Powrót do listy
+          {workoutError ? "Spróbuj ponownie" : "Powrót do listy"}
         </Link>
       </main>
     );

--- a/app/app/workouts/loading.tsx
+++ b/app/app/workouts/loading.tsx
@@ -1,0 +1,21 @@
+import { WorkoutCardSkeleton } from "@/components/workouts/WorkoutCardSkeleton";
+
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-2">
+          <div className="h-8 w-48 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-4 w-64 max-w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+        <div className="h-10 w-36 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }, (_, i) => (
+          <WorkoutCardSkeleton key={i} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/app/workouts/new/loading.tsx
+++ b/app/app/workouts/new/loading.tsx
@@ -1,0 +1,17 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <div className="h-8 w-48 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-2 h-4 w-80 max-w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-8 space-y-5">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="h-3.5 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-10 w-full animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -5,14 +5,14 @@ import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Reset password — Coach Zone",
+  title: "Reset hasła — Coach Zone",
 };
 
 export default function ForgotPasswordPage() {
   return (
     <AuthShell
-      title="Reset your password"
-      subtitle="Enter your email and we'll send you a reset link."
+      title="Zresetuj hasło"
+      subtitle="Podaj swój email, a wyślemy Ci link do zresetowania hasła."
     >
       <ForgotPasswordForm />
     </AuthShell>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { AuthLinkListener } from "@/components/auth/AuthLinkListener";
+import { SITE_URL } from "@/lib/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -13,10 +14,14 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// metadataBase anchors every relative OG/canonical URL declared by a page
+// (see app/w/[share_id]/page.tsx) to the stable production origin, so they
+// never resolve against a Vercel deployment/preview host - see lib/site.ts.
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Coach Zone",
   description:
-    "Build training sessions from a reusable exercise library, export them to PDF, and share them with your team.",
+    "Twórz treningi z biblioteki ćwiczeń, eksportuj je do PDF i udostępniaj swojej drużynie w kilka minut.",
 };
 
 export default function RootLayout({
@@ -25,7 +30,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="pl">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,13 +5,13 @@ import { LoginForm } from "@/components/auth/LoginForm";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Log in — Coach Zone",
+  title: "Zaloguj się — Coach Zone",
 };
 
 const QUERY_ERROR_MESSAGES: Record<string, string> = {
   confirmation_failed:
-    "That confirmation link is invalid or has expired. Try logging in, or sign up again to get a new one.",
-  oauth_failed: "Google sign-in didn't complete. Please try again.",
+    "Ten link potwierdzający jest nieprawidłowy albo wygasł. Spróbuj się zalogować albo zarejestruj się ponownie, aby otrzymać nowy.",
+  oauth_failed: "Logowanie przez Google nie powiodło się. Spróbuj ponownie.",
 };
 
 export default async function LoginPage({
@@ -24,8 +24,8 @@ export default async function LoginPage({
 
   return (
     <AuthShell
-      title="Welcome back"
-      subtitle="Log in to plan your next training session."
+      title="Witaj ponownie"
+      subtitle="Zaloguj się, aby zaplanować kolejny trening."
     >
       <LoginForm initialError={initialError} />
     </AuthShell>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Nie znaleziono strony — Coach Zone",
+};
+
+export default async function NotFound() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const homeHref = user ? "/app" : "/";
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-white px-6 text-center text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <p className="text-sm font-semibold text-emerald-600">404</p>
+      <h1 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+        Nie znaleziono strony
+      </h1>
+      <p className="mt-3 max-w-sm text-neutral-600 dark:text-neutral-400">
+        Strona, której szukasz, nie istnieje albo została przeniesiona.
+      </p>
+      <Link
+        href={homeHref}
+        className="mt-8 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+      >
+        Strona główna
+      </Link>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,34 +3,34 @@ import Link from "next/link";
 const steps = [
   {
     number: "1",
-    title: "Build your exercise library",
+    title: "Zbuduj bibliotekę ćwiczeń",
     description:
-      "Add drills once, organized by sport, position, and category, and reuse them in every training session you plan.",
+      "Dodaj ćwiczenia do swojej biblioteki raz — pogrupowane według kategorii i poziomu trudności — i korzystaj z nich w każdym kolejnym treningu.",
   },
   {
     number: "2",
-    title: "Assemble a session",
+    title: "Zbuduj trening",
     description:
-      "Pull exercises from your library into a session plan tailored to today's practice, in whatever order works for your team.",
+      "Wybieraj ćwiczenia z biblioteki i układaj je w plan dopasowany do dzisiejszych zajęć, w dowolnej kolejności.",
   },
   {
     number: "3",
-    title: "Export and share",
+    title: "Eksportuj i udostępniaj",
     description:
-      "Turn any session into a clean PDF and share it with players or coaching staff in one click.",
+      "Zamień dowolny trening w czytelny PDF i udostępnij go zawodnikom albo sztabowi jednym kliknięciem.",
   },
 ];
 
 export default function Home() {
   return (
     <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-      <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
+      <header className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-6">
         <span className="text-lg font-semibold tracking-tight">Coach Zone</span>
         <Link
           href="/login"
           className="rounded-full bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
         >
-          Log in
+          Zaloguj się
         </Link>
       </header>
 
@@ -40,15 +40,15 @@ export default function Home() {
             Coach Zone
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg text-neutral-600 sm:text-xl dark:text-neutral-400">
-            Build training sessions from a reusable exercise library, export
-            them to PDF, and share them with your team in minutes.
+            Twórz treningi z biblioteki ćwiczeń, eksportuj je do PDF i
+            udostępniaj swojej drużynie w kilka minut.
           </p>
           <div className="mt-10 flex justify-center">
             <Link
               href="/login"
               className="rounded-full bg-emerald-600 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-emerald-500"
             >
-              Log in
+              Zaloguj się
             </Link>
           </div>
         </section>
@@ -56,7 +56,7 @@ export default function Home() {
         <section className="border-t border-neutral-200 dark:border-neutral-800">
           <div className="mx-auto max-w-6xl px-6 py-16 sm:py-24">
             <h2 className="text-center text-2xl font-semibold tracking-tight sm:text-3xl">
-              How it works
+              Jak to działa
             </h2>
             <div className="mt-12 grid gap-10 sm:grid-cols-3 sm:gap-8">
               {steps.map((step) => (

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -3,12 +3,12 @@ import { AuthShell } from "@/components/auth/AuthShell";
 import { ResetPasswordGate } from "@/components/auth/ResetPasswordGate";
 
 export const metadata: Metadata = {
-  title: "Set new password — Coach Zone",
+  title: "Nowe hasło — Coach Zone",
 };
 
 export default function ResetPasswordPage() {
   return (
-    <AuthShell title="Reset your password">
+    <AuthShell title="Ustaw nowe hasło">
       <ResetPasswordGate />
     </AuthShell>
   );

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -5,14 +5,14 @@ import { SignupForm } from "@/components/auth/SignupForm";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "Sign up — Coach Zone",
+  title: "Zarejestruj się — Coach Zone",
 };
 
 export default function SignupPage() {
   return (
     <AuthShell
-      title="Create your account"
-      subtitle="Build your exercise library and start planning sessions."
+      title="Utwórz konto"
+      subtitle="Zbuduj bibliotekę ćwiczeń i zacznij planować treningi."
     >
       <SignupForm />
     </AuthShell>

--- a/app/w/[share_id]/loading.tsx
+++ b/app/w/[share_id]/loading.tsx
@@ -1,0 +1,25 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-white dark:bg-neutral-950">
+      <header className="border-b border-neutral-200 dark:border-neutral-800">
+        <div className="mx-auto max-w-3xl px-6 py-4">
+          <div className="h-6 w-32 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 pt-8 pb-20">
+        <div className="h-8 w-2/3 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        <div className="mt-3 h-4 w-1/2 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+
+        <div className="mt-8 space-y-3">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-xl border border-neutral-200 dark:border-neutral-800"
+            />
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/w/[share_id]/page.tsx
+++ b/app/w/[share_id]/page.tsx
@@ -12,10 +12,10 @@ export const dynamic = "force-dynamic";
 // Deduped so generateMetadata and the page body share one RPC call per request.
 const getSharedWorkout = cache(async (shareId: string) => {
   const supabase = await createClient();
-  const { data } = await supabase.rpc("get_shared_workout", {
+  const { data, error } = await supabase.rpc("get_shared_workout", {
     p_share_id: shareId,
   });
-  return data;
+  return { payload: data, error };
 });
 
 export async function generateMetadata({
@@ -24,16 +24,18 @@ export async function generateMetadata({
   params: Promise<{ share_id: string }>;
 }): Promise<Metadata> {
   const { share_id } = await params;
-  const payload = await getSharedWorkout(share_id);
+  const { payload } = await getSharedWorkout(share_id);
 
   if (!payload) {
     return { title: "Nie znaleziono treningu — Coach Zone" };
   }
 
   const title = `${payload.workout.title} — Coach Zone`;
+  const url = `/w/${share_id}`;
   return {
     title,
-    openGraph: { title, type: "website" },
+    alternates: { canonical: url },
+    openGraph: { title, type: "website", url },
   };
 }
 
@@ -43,22 +45,24 @@ export default async function SharedWorkoutPage({
   params: Promise<{ share_id: string }>;
 }) {
   const { share_id } = await params;
-  const payload = await getSharedWorkout(share_id);
+  const { payload, error } = await getSharedWorkout(share_id);
 
   if (!payload) {
     return (
       <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center px-6 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">
-          Nie znaleziono treningu
+          {error ? "Wystąpił błąd" : "Nie znaleziono treningu"}
         </h1>
         <p className="mt-3 text-neutral-600 dark:text-neutral-400">
-          Ten link jest nieprawidłowy albo trening został usunięty.
+          {error
+            ? "Nie udało się wczytać treningu. Spróbuj ponownie."
+            : "Ten link jest nieprawidłowy albo trening został usunięty."}
         </p>
         <Link
-          href="/"
+          href={error ? `/w/${share_id}` : "/"}
           className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
         >
-          Strona główna
+          {error ? "Spróbuj ponownie" : "Strona główna"}
         </Link>
       </main>
     );

--- a/components/auth/ForgotPasswordForm.tsx
+++ b/components/auth/ForgotPasswordForm.tsx
@@ -22,7 +22,7 @@ export function ForgotPasswordForm() {
     setFormError(null);
 
     if (!EMAIL_PATTERN.test(email)) {
-      setFieldError("Please enter a valid email address.");
+      setFieldError("Podaj poprawny adres email.");
       return;
     }
     setFieldError(undefined);
@@ -49,13 +49,13 @@ export function ForgotPasswordForm() {
       <div className="space-y-4 text-center">
         <FormBanner
           variant="success"
-          message="If an account exists for that email, we've sent a password reset link."
+          message="Jeśli konto z tym adresem email istnieje, wysłaliśmy na nie link do zresetowania hasła."
         />
         <Link
           href="/login"
           className="inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
         >
-          Back to log in
+          Powrót do logowania
         </Link>
       </div>
     );
@@ -67,7 +67,7 @@ export function ForgotPasswordForm() {
 
       <FormField
         id="email"
-        label="Email"
+        label="Adres e-mail"
         type="email"
         autoComplete="email"
         value={email}
@@ -75,17 +75,17 @@ export function ForgotPasswordForm() {
         error={fieldError}
       />
 
-      <SubmitButton loading={loading} loadingText="Sending link…">
-        Send reset link
+      <SubmitButton loading={loading} loadingText="Wysyłanie linku…">
+        Wyślij link
       </SubmitButton>
 
       <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
-        Remembered your password?{" "}
+        Pamiętasz hasło?{" "}
         <Link
           href="/login"
           className="font-medium text-emerald-600 hover:text-emerald-500"
         >
-          Log in
+          Zaloguj się
         </Link>
       </p>
     </form>

--- a/components/auth/GoogleAuthButton.tsx
+++ b/components/auth/GoogleAuthButton.tsx
@@ -48,14 +48,14 @@ export function GoogleAuthButton() {
           type="button"
           disabled
           aria-disabled="true"
-          title="Google sign-in isn't configured yet"
+          title="Logowanie przez Google nie jest jeszcze skonfigurowane"
           className="flex w-full cursor-not-allowed items-center justify-center gap-2 rounded-full border border-neutral-200 px-4 py-2.5 text-sm font-medium text-neutral-400 dark:border-neutral-800 dark:text-neutral-600"
         >
           <GoogleIcon />
-          Continue with Google
+          Kontynuuj z Google
         </button>
         <p className="mt-1.5 text-center text-xs text-neutral-500 dark:text-neutral-500">
-          Not yet configured
+          Jeszcze nieskonfigurowane
         </p>
       </div>
     );
@@ -68,7 +68,7 @@ export function GoogleAuthButton() {
       className="flex w-full items-center justify-center gap-2 rounded-full border border-neutral-300 px-4 py-2.5 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
     >
       <GoogleIcon />
-      Continue with Google
+      Kontynuuj z Google
     </button>
   );
 }

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -30,10 +30,10 @@ export function LoginForm({ initialError }: { initialError?: string | null }) {
   function validate(): FieldErrors {
     const errors: FieldErrors = {};
     if (!EMAIL_PATTERN.test(email)) {
-      errors.email = "Please enter a valid email address.";
+      errors.email = "Podaj poprawny adres email.";
     }
     if (!password) {
-      errors.password = "Please enter your password.";
+      errors.password = "Podaj hasło.";
     }
     return errors;
   }
@@ -71,13 +71,13 @@ export function LoginForm({ initialError }: { initialError?: string | null }) {
 
       <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-500">
         <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
-        or log in with email
+        lub zaloguj się emailem
         <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
       </div>
 
       <FormField
         id="email"
-        label="Email"
+        label="Adres e-mail"
         type="email"
         autoComplete="email"
         value={email}
@@ -87,7 +87,7 @@ export function LoginForm({ initialError }: { initialError?: string | null }) {
       <div>
         <FormField
           id="password"
-          label="Password"
+          label="Hasło"
           type="password"
           autoComplete="current-password"
           value={password}
@@ -99,22 +99,22 @@ export function LoginForm({ initialError }: { initialError?: string | null }) {
             href="/forgot-password"
             className="text-sm font-medium text-emerald-600 hover:text-emerald-500"
           >
-            Forgot password?
+            Nie pamiętasz hasła?
           </Link>
         </div>
       </div>
 
-      <SubmitButton loading={loading} loadingText="Logging in…">
-        Log in
+      <SubmitButton loading={loading} loadingText="Logowanie…">
+        Zaloguj się
       </SubmitButton>
 
       <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
-        Don&rsquo;t have an account?{" "}
+        Nie masz konta?{" "}
         <Link
           href="/signup"
           className="font-medium text-emerald-600 hover:text-emerald-500"
         >
-          Sign up
+          Zarejestruj się
         </Link>
       </p>
     </form>

--- a/components/auth/ResetPasswordForm.tsx
+++ b/components/auth/ResetPasswordForm.tsx
@@ -24,10 +24,10 @@ export function ResetPasswordForm() {
   function validate(): FieldErrors {
     const errors: FieldErrors = {};
     if (password.length < 6) {
-      errors.password = "Password must be at least 6 characters.";
+      errors.password = "Hasło musi mieć co najmniej 6 znaków.";
     }
     if (confirmPassword !== password) {
-      errors.confirmPassword = "Passwords don't match.";
+      errors.confirmPassword = "Hasła nie są takie same.";
     }
     return errors;
   }
@@ -60,7 +60,7 @@ export function ResetPasswordForm() {
 
       <FormField
         id="password"
-        label="New password"
+        label="Nowe hasło"
         type="password"
         autoComplete="new-password"
         value={password}
@@ -69,7 +69,7 @@ export function ResetPasswordForm() {
       />
       <FormField
         id="confirmPassword"
-        label="Confirm new password"
+        label="Powtórz nowe hasło"
         type="password"
         autoComplete="new-password"
         value={confirmPassword}
@@ -77,8 +77,8 @@ export function ResetPasswordForm() {
         error={fieldErrors.confirmPassword}
       />
 
-      <SubmitButton loading={loading} loadingText="Saving…">
-        Save new password
+      <SubmitButton loading={loading} loadingText="Zapisywanie…">
+        Zapisz nowe hasło
       </SubmitButton>
     </form>
   );

--- a/components/auth/ResetPasswordGate.tsx
+++ b/components/auth/ResetPasswordGate.tsx
@@ -32,7 +32,7 @@ export function ResetPasswordGate() {
   if (status === "checking") {
     return (
       <p className="text-center text-sm text-neutral-500 dark:text-neutral-500">
-        Checking your link…
+        Sprawdzanie linku…
       </p>
     );
   }
@@ -41,13 +41,13 @@ export function ResetPasswordGate() {
     return (
       <div className="space-y-4 text-center">
         <p className="text-sm text-neutral-600 dark:text-neutral-400">
-          This password reset link is invalid or has expired.
+          Ten link do resetowania hasła jest nieprawidłowy albo wygasł.
         </p>
         <Link
           href="/forgot-password"
           className="block w-full rounded-full bg-emerald-600 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-emerald-500"
         >
-          Request a new link
+          Poproś o nowy link
         </Link>
       </div>
     );
@@ -56,7 +56,7 @@ export function ResetPasswordGate() {
   return (
     <div className="space-y-4">
       <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
-        Choose a new password for your account.
+        Wybierz nowe hasło dla swojego konta.
       </p>
       <ResetPasswordForm />
     </div>

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -34,15 +34,15 @@ export function SignupForm() {
 
   function validate(): FieldErrors {
     const errors: FieldErrors = {};
-    if (!fullName.trim()) errors.fullName = "Please enter your name.";
+    if (!fullName.trim()) errors.fullName = "Podaj swoje imię i nazwisko.";
     if (!EMAIL_PATTERN.test(email)) {
-      errors.email = "Please enter a valid email address.";
+      errors.email = "Podaj poprawny adres email.";
     }
     if (password.length < 6) {
-      errors.password = "Password must be at least 6 characters.";
+      errors.password = "Hasło musi mieć co najmniej 6 znaków.";
     }
     if (confirmPassword !== password) {
-      errors.confirmPassword = "Passwords don't match.";
+      errors.confirmPassword = "Hasła nie są takie same.";
     }
     return errors;
   }
@@ -77,7 +77,7 @@ export function SignupForm() {
     // anti-enumeration behavior, not a real new signup.
     if (data.user && data.user.identities?.length === 0) {
       setFormError(
-        "An account with this email may already exist. Try logging in or resetting your password.",
+        "Konto z tym adresem email może już istnieć. Spróbuj się zalogować albo zresetować hasło.",
       );
       return;
     }
@@ -96,13 +96,13 @@ export function SignupForm() {
       <div className="space-y-4 text-center">
         <FormBanner
           variant="success"
-          message={`We've sent a confirmation link to ${confirmationSentTo}. Open it to activate your account.`}
+          message={`Wysłaliśmy link potwierdzający na adres ${confirmationSentTo}. Otwórz go, aby aktywować konto.`}
         />
         <Link
           href="/login"
           className="inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
         >
-          Back to log in
+          Powrót do logowania
         </Link>
       </div>
     );
@@ -116,13 +116,13 @@ export function SignupForm() {
 
       <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-500">
         <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
-        or sign up with email
+        lub zarejestruj się emailem
         <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />
       </div>
 
       <FormField
         id="fullName"
-        label="Full name"
+        label="Imię i nazwisko"
         type="text"
         autoComplete="name"
         value={fullName}
@@ -131,7 +131,7 @@ export function SignupForm() {
       />
       <FormField
         id="email"
-        label="Email"
+        label="Adres e-mail"
         type="email"
         autoComplete="email"
         value={email}
@@ -140,7 +140,7 @@ export function SignupForm() {
       />
       <FormField
         id="password"
-        label="Password"
+        label="Hasło"
         type="password"
         autoComplete="new-password"
         value={password}
@@ -149,7 +149,7 @@ export function SignupForm() {
       />
       <FormField
         id="confirmPassword"
-        label="Confirm password"
+        label="Powtórz hasło"
         type="password"
         autoComplete="new-password"
         value={confirmPassword}
@@ -157,17 +157,17 @@ export function SignupForm() {
         error={fieldErrors.confirmPassword}
       />
 
-      <SubmitButton loading={loading} loadingText="Creating account…">
-        Create account
+      <SubmitButton loading={loading} loadingText="Tworzenie konta…">
+        Utwórz konto
       </SubmitButton>
 
       <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
-        Already have an account?{" "}
+        Masz już konto?{" "}
         <Link
           href="/login"
           className="font-medium text-emerald-600 hover:text-emerald-500"
         >
-          Log in
+          Zaloguj się
         </Link>
       </p>
     </form>

--- a/components/auth/SubmitButton.tsx
+++ b/components/auth/SubmitButton.tsx
@@ -15,7 +15,7 @@ export function SubmitButton({
       disabled={loading}
       className="w-full rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
     >
-      {loading ? (loadingText ?? "Please wait…") : children}
+      {loading ? (loadingText ?? "Chwileczkę…") : children}
     </button>
   );
 }

--- a/components/workouts/ShareWorkoutButton.tsx
+++ b/components/workouts/ShareWorkoutButton.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { SITE_URL } from "@/lib/site";
 
 export function ShareWorkoutButton({ shareId }: { shareId: string }) {
   const [open, setOpen] = useState(false);
-  const [shareUrl, setShareUrl] = useState("");
   const [copied, setCopied] = useState(false);
 
-  // Computed after mount, not during render, so server and client markup
-  // match on first paint - window.location isn't available on the server.
-  useEffect(() => {
-    setShareUrl(`${window.location.origin}/w/${shareId}`);
-  }, [shareId]);
+  // Always the stable production origin, never window.location.origin -
+  // see lib/site.ts. Same value on server and client, so no mount-effect
+  // is needed to avoid a hydration mismatch.
+  const shareUrl = `${SITE_URL}/w/${shareId}`;
 
   async function handleCopy() {
     try {
@@ -37,15 +36,15 @@ export function ShareWorkoutButton({ shareId }: { shareId: string }) {
   }
 
   return (
-    <div className="flex flex-col items-end gap-2">
-      <div className="flex items-center gap-2">
+    <div className="flex w-full flex-col items-end gap-2 sm:w-auto">
+      <div className="flex w-full flex-wrap items-center justify-end gap-2">
         <input
           type="text"
           readOnly
           value={shareUrl}
           onFocus={(e) => e.target.select()}
           aria-label="Publiczny link do treningu"
-          className="w-48 truncate rounded-lg border border-neutral-300 bg-white px-2.5 py-1.5 text-xs outline-none dark:border-neutral-700 dark:bg-neutral-900 sm:w-72"
+          className="w-full min-w-0 flex-1 truncate rounded-lg border border-neutral-300 bg-white px-2.5 py-1.5 text-xs outline-none dark:border-neutral-700 dark:bg-neutral-900 sm:w-72 sm:flex-none"
         />
         <button
           type="button"

--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -305,7 +305,7 @@ export function WorkoutBuilder({
   }
 
   return (
-    <main className="mx-auto max-w-6xl px-6 pt-8 pb-24">
+    <main className="mx-auto max-w-5xl px-6 pt-8 pb-24">
       <Link
         href="/app/workouts"
         className="text-sm font-medium text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"

--- a/components/workouts/WorkoutItemRow.tsx
+++ b/components/workouts/WorkoutItemRow.tsx
@@ -111,7 +111,7 @@ export function WorkoutItemRow({
               />
             </label>
 
-            <label className="text-xs text-neutral-500 dark:text-neutral-500">
+            <label className="col-span-2 text-xs text-neutral-500 dark:text-neutral-500 sm:col-span-1">
               Sekcja
               <select
                 value={item.section}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,9 @@
+// Single source of truth for the app's public base URL. Always used for
+// shareable/public links (the "Udostępnij" copy value, OG tags) instead of
+// window.location.origin or the request host, which can point at a
+// Vercel deployment-scoped or branch-preview URL that's behind deployment
+// protection and unreachable for a logged-out player opening the link.
+const RAW_SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://coach-zone.vercel.app";
+
+export const SITE_URL = RAW_SITE_URL.replace(/\/+$/, "");

--- a/lib/supabase/errors.ts
+++ b/lib/supabase/errors.ts
@@ -2,34 +2,36 @@ import { isAuthError } from "@supabase/supabase-js";
 
 const MESSAGES_BY_CODE: Record<string, string> = {
   user_already_exists:
-    "An account with this email already exists. Try logging in instead.",
+    "Konto z tym adresem email już istnieje. Spróbuj się zalogować.",
   email_exists:
-    "An account with this email already exists. Try logging in instead.",
-  invalid_credentials: "Incorrect email or password.",
+    "Konto z tym adresem email już istnieje. Spróbuj się zalogować.",
+  invalid_credentials: "Nieprawidłowy email lub hasło.",
   email_not_confirmed:
-    "Please confirm your email address before logging in. Check your inbox for the confirmation link.",
-  email_address_invalid: "Please enter a valid email address.",
-  email_address_not_authorized: "This email address isn't allowed to sign up.",
-  signup_disabled: "Sign-ups are currently disabled.",
-  user_banned:
-    "This account has been disabled. Contact support if you think this is a mistake.",
-  weak_password: "Password must be at least 6 characters.",
-  same_password:
-    "Your new password must be different from your current password.",
+    "Potwierdź adres email, zanim się zalogujesz. Sprawdź skrzynkę — wysłaliśmy link potwierdzający.",
+  email_address_invalid: "Podaj poprawny adres email.",
+  email_address_not_authorized: "Ten adres email nie może się zarejestrować.",
+  signup_disabled: "Rejestracja jest obecnie wyłączona.",
+  user_banned: "To konto zostało zablokowane.",
+  weak_password: "Hasło musi mieć co najmniej 6 znaków.",
+  same_password: "Nowe hasło musi różnić się od obecnego.",
   over_email_send_rate_limit:
-    "Too many attempts. Please wait a moment and try again.",
+    "Zbyt wiele prób. Odczekaj chwilę i spróbuj ponownie.",
   over_request_rate_limit:
-    "Too many attempts. Please wait a moment and try again.",
-  validation_failed: "Please check the form for errors and try again.",
-  session_not_found: "Your session has expired. Please log in again.",
-  user_not_found: "Incorrect email or password.",
+    "Zbyt wiele prób. Odczekaj chwilę i spróbuj ponownie.",
+  validation_failed: "Sprawdź formularz i spróbuj ponownie.",
+  session_not_found: "Twoja sesja wygasła. Zaloguj się ponownie.",
+  user_not_found: "Nieprawidłowy email lub hasło.",
 };
 
-// Fallback for cases where Supabase doesn't populate error.code - notably
-// signInWithPassword's "Invalid login credentials", which auth-js currently
-// surfaces via the legacy invalid_grant response shape with code: undefined
-// (supabase/auth-js#937). email_not_confirmed is unaffected and matches via
-// error.code above, so the two cases still get distinct messages.
+// Fallback for responses that predate structured error codes, or that never
+// carry one client-side (e.g. AuthRetryableFetchError from a network blip).
+// Verified directly against the installed auth-js (2.110.1): every request
+// sends the `X-Supabase-Api-Version: 2024-01-01` header, and handleError()
+// in lib/fetch.js reads `code` straight from the JSON error body whenever
+// the server echoes back that version or later - which a current hosted
+// Supabase project always does. So invalid_credentials and
+// email_not_confirmed both already arrive as populated error.code values
+// via MESSAGES_BY_CODE above; this regex list is defense-in-depth only.
 const MESSAGES_BY_TEXT: Array<[RegExp, string]> = [
   [/already registered/i, MESSAGES_BY_CODE.user_already_exists],
   [/invalid login credentials/i, MESSAGES_BY_CODE.invalid_credentials],
@@ -39,7 +41,7 @@ const MESSAGES_BY_TEXT: Array<[RegExp, string]> = [
   [/rate limit/i, MESSAGES_BY_CODE.over_email_send_rate_limit],
 ];
 
-const FALLBACK_MESSAGE = "Something went wrong. Please try again.";
+const FALLBACK_MESSAGE = "Coś poszło nie tak. Spróbuj ponownie.";
 
 /**
  * Maps a Supabase Auth error to a short, user-facing message. Never returns


### PR DESCRIPTION
## Summary

- **Fix 1 — Share link domain.** The "Udostępnij" link is now always built from `NEXT_PUBLIC_SITE_URL` (defaults to `https://coach-zone.vercel.app`), never `window.location.origin`. Same source of truth drives the shared-workout page's OG/canonical tags via `metadataBase`.
- **Fix 2 — Auth error audit.** Traced the installed `@supabase/auth-js` (2.110.1) source directly: `invalid_credentials` and `email_not_confirmed` already arrive as distinct, populated `error.code` values from a real hosted Supabase project, and `SignupForm` already checks `data.session` dynamically before deciding between "go to /app" and "check your email." **Both were already logically correct** — left the control flow alone. The actual bug was that all of this (plus the rest of the landing page, `/app` shell, and auth flow) was still in English while the rest of the app is Polish, which is likely what read as "misbehaving." Translated everything and corrected a stale code comment that no longer matched this auth-js version's behavior.
- **Fix 3 — Visual polish.** Tightened the exercise detail / workout builder / `/app` home pages so they don't feel hollow on desktop; added `loading.tsx` skeletons for every exercises/workouts/share route that previously showed a blank screen while fetching; distinguished "not found" from "failed to load" instead of collapsing both into "not found"; fixed two mobile overflow spots (the expanded share-link row, the workout item's section dropdown); added a branded 404 page.

## ⚠️ Action needed from you

Set in Vercel (Project Settings → Environment Variables):

```
NEXT_PUBLIC_SITE_URL=https://coach-zone.vercel.app
```

**Env var changes require a redeploy to take effect** — Next.js inlines `NEXT_PUBLIC_*` vars at build time, so just saving it in the dashboard won't update an already-built deployment. Trigger a redeploy after setting it (or it'll pick up on the next deploy from this PR merging).

Until it's set, the code falls back to the same `https://coach-zone.vercel.app` default, so nothing breaks either way — this just makes the production value explicit and lets you override it later if the domain ever changes.

## What I could / couldn't verify

My sandbox has no real Supabase project or credentials, and `middleware.ts` unconditionally constructs a Supabase client (crashes without them), so I couldn't run the app end-to-end against live data. What I did instead:

- **Auth error codes**: verified directly from the installed `auth-js` source (not guessed) — see the commit message on `feat(i18n)` for the exact trace (API version header, `handleError()`, the `ErrorCode` union type).
- **UI rendering**: stood up the dev server with a stub (unreachable) `NEXT_PUBLIC_SUPABASE_URL` — enough to get past the client constructor and exercise every page's shell, loading skeleton, and error state (a real `ECONNREFUSED` naturally triggers the new "failed to load" paths). Screenshotted every page at 1280×900 and 390×844. Landing, login, signup, forgot-password, 404, and the `/app` shell (nav/logout) render correctly in Polish with no console errors.
- **Not verified**: an actual successful login/signup round-trip, a real share link opened logged-out from a deployment-scoped host, and the populated (non-empty, non-error) states of the exercise/workout list and detail pages. Please run the manual script below against your real Supabase project.

## Manual test script

1. **Share link domain** — Open the app from a Vercel *preview* deployment URL (not `coach-zone.vercel.app`), open a workout, click "Udostępnij", copy the link. It should start with `https://coach-zone.vercel.app/w/...` regardless of the host you're browsing from. Open it in an incognito window (logged out) — it should load the workout, not a Vercel login wall.
2. **Login errors** — Try logging in with a wrong password on a real account → expect "Nieprawidłowy email lub hasło." Try logging in on an account with a pending confirmation (if you have confirmation-required test data) → expect the distinct "Potwierdź adres email..." message.
3. **Signup** — Sign up with a new email. Since confirmation is OFF, you should land straight on `/app` with no "check your email" screen.
4. **404** — Visit a nonsense URL like `/does-not-exist` → friendly Polish 404 page, links home (or to `/app` if logged in).
5. **Hollow pages** — Open an exercise with a short description and a workout with 0–1 exercises on a large monitor; neither should feel like it trails off into empty space the way it used to.
6. **Loading states** — Throttle your network (DevTools → Slow 3G) and navigate to an exercise/workout detail page or the share page; you should see a skeleton instead of a blank screen.
7. **Mobile** — On a phone (or DevTools device mode, ~375px wide): check the `/app` nav header doesn't clip, the exercise library grid is single-column, the workout builder's "Udostępnij" row wraps instead of overflowing, and the public share page reads cleanly.

## CI

`pnpm lint`, `pnpm typecheck`, `pnpm build`, and `prettier --check .` all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_011k8YoMuN9uGw2SHd1n1MPM)_