### PR TITLE
Round 7: duplicate a workout, segment exercises by sport

### DIFF
--- a/app/app/exercises/[id]/edit/page.tsx
+++ b/app/app/exercises/[id]/edit/page.tsx
@@ -22,10 +22,12 @@ export default async function EditExercisePage({
     { data: exercise, error: exerciseError },
     { data: userData },
     { data: categories },
+    { data: sports },
   ] = await Promise.all([
     supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
     supabase.auth.getUser(),
     supabase.from("categories").select("*").order("id", { ascending: true }),
+    supabase.from("sports").select("*").order("id", { ascending: true }),
   ]);
 
   if (!userData.user) {
@@ -77,6 +79,7 @@ export default async function EditExercisePage({
         <ExerciseForm
           mode="edit"
           categories={categories ?? []}
+          sports={sports ?? []}
           exercise={exercise}
         />
       </div>

--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { CategoryBadge } from "@/components/exercises/CategoryBadge";
+import { SportBadge } from "@/components/exercises/SportBadge";
 import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
 import { DeleteExerciseButton } from "@/components/exercises/DeleteExerciseButton";
 import { formatDuration } from "@/lib/exercises";
@@ -47,11 +48,18 @@ export default async function ExerciseDetailPage({
     );
   }
 
-  const { data: category } = await supabase
-    .from("categories")
-    .select("*")
-    .eq("id", exercise.category_id)
-    .maybeSingle();
+  const [{ data: category }, { data: sport }] = await Promise.all([
+    supabase
+      .from("categories")
+      .select("*")
+      .eq("id", exercise.category_id)
+      .maybeSingle(),
+    supabase
+      .from("sports")
+      .select("*")
+      .eq("id", exercise.sport_id)
+      .maybeSingle(),
+  ]);
 
   const isOwner = userData.user?.id === exercise.author_id;
 
@@ -70,6 +78,7 @@ export default async function ExerciseDetailPage({
             {exercise.title}
           </h1>
           <div className="mt-3 flex flex-wrap items-center gap-3">
+            {sport && <SportBadge name={sport.name_pl} />}
             {category && (
               <CategoryBadge name={category.name_pl} slug={category.slug} />
             )}

--- a/app/app/exercises/new/page.tsx
+++ b/app/app/exercises/new/page.tsx
@@ -11,10 +11,12 @@ export const metadata: Metadata = {
 
 export default async function NewExercisePage() {
   const supabase = await createClient();
-  const [{ data: userData }, { data: categories }] = await Promise.all([
-    supabase.auth.getUser(),
-    supabase.from("categories").select("*").order("id", { ascending: true }),
-  ]);
+  const [{ data: userData }, { data: categories }, { data: sports }] =
+    await Promise.all([
+      supabase.auth.getUser(),
+      supabase.from("categories").select("*").order("id", { ascending: true }),
+      supabase.from("sports").select("*").order("id", { ascending: true }),
+    ]);
 
   // Middleware already guarantees a user for any /app/* route; this is a
   // defensive fallback since userId below is required for the insert.
@@ -32,6 +34,7 @@ export default async function NewExercisePage() {
         <ExerciseForm
           mode="create"
           categories={categories ?? []}
+          sports={sports ?? []}
           userId={userData.user.id}
         />
       </div>

--- a/app/app/exercises/page.tsx
+++ b/app/app/exercises/page.tsx
@@ -10,10 +10,12 @@ export const metadata: Metadata = {
 
 export default async function ExercisesPage() {
   const supabase = await createClient();
-  const { data: categories } = await supabase
-    .from("categories")
-    .select("*")
-    .order("id", { ascending: true });
+  const [{ data: categories }, { data: sports }] = await Promise.all([
+    supabase.from("categories").select("*").order("id", { ascending: true }),
+    supabase.from("sports").select("*").order("id", { ascending: true }),
+  ]);
 
-  return <ExercisesLibrary categories={categories ?? []} />;
+  return (
+    <ExercisesLibrary categories={categories ?? []} sports={sports ?? []} />
+  );
 }

--- a/components/exercises/ExerciseForm.tsx
+++ b/components/exercises/ExerciseForm.tsx
@@ -7,15 +7,26 @@ import { FormField } from "@/components/auth/FormField";
 import { SubmitButton } from "@/components/auth/SubmitButton";
 import { DIFFICULTY_LABELS, DIFFICULTY_OPTIONS } from "@/lib/exercises";
 import { createClient } from "@/lib/supabase/client";
-import type { Category, Difficulty, Exercise } from "@/lib/supabase/types";
+import type {
+  Category,
+  Difficulty,
+  Exercise,
+  Sport,
+} from "@/lib/supabase/types";
 
 type ExerciseFormProps =
-  | { mode: "create"; categories: Category[]; userId: string }
-  | { mode: "edit"; categories: Category[]; exercise: Exercise };
+  | { mode: "create"; categories: Category[]; sports: Sport[]; userId: string }
+  | {
+      mode: "edit";
+      categories: Category[];
+      sports: Sport[];
+      exercise: Exercise;
+    };
 
 interface FieldErrors {
   title?: string;
   category?: string;
+  sport?: string;
   steps?: string;
   duration?: string;
   mediaUrl?: string;
@@ -48,6 +59,11 @@ export function ExerciseForm(props: ExerciseFormProps) {
   const [categoryId, setCategoryId] = useState<number | "">(
     initial?.category_id ?? "",
   );
+  const [sportId, setSportId] = useState<number | "">(
+    initial?.sport_id ??
+      props.sports.find((sport) => sport.slug === "football")?.id ??
+      "",
+  );
   const [description, setDescription] = useState(initial?.description ?? "");
   const [steps, setSteps] = useState<string[]>(
     initial?.steps && initial.steps.length > 0 ? initial.steps : [""],
@@ -73,6 +89,7 @@ export function ExerciseForm(props: ExerciseFormProps) {
     const errors: FieldErrors = {};
     if (!title.trim()) errors.title = "Podaj nazwę ćwiczenia.";
     if (!categoryId) errors.category = "Wybierz kategorię.";
+    if (!sportId) errors.sport = "Wybierz dyscyplinę.";
     if (steps.every((step) => !step.trim())) {
       errors.steps = "Dodaj co najmniej jeden krok.";
     }
@@ -138,6 +155,7 @@ export function ExerciseForm(props: ExerciseFormProps) {
     const payload = {
       title: title.trim(),
       category_id: categoryId as number,
+      sport_id: sportId as number,
       description: description.trim() || null,
       steps: steps.map((step) => step.trim()).filter(Boolean),
       duration_min: durationMin.trim() ? Number(durationMin) : null,
@@ -190,6 +208,32 @@ export function ExerciseForm(props: ExerciseFormProps) {
         onChange={(e) => setTitle(e.target.value)}
         error={fieldErrors.title}
       />
+
+      <div>
+        <label htmlFor="sport" className={labelClasses}>
+          Dyscyplina
+        </label>
+        <select
+          id="sport"
+          value={sportId}
+          onChange={(e) =>
+            setSportId(e.target.value ? Number(e.target.value) : "")
+          }
+          className={`mt-1.5 ${fieldClasses(Boolean(fieldErrors.sport))}`}
+        >
+          <option value="">Wybierz dyscyplinę…</option>
+          {props.sports.map((sport) => (
+            <option key={sport.id} value={sport.id}>
+              {sport.name_pl}
+            </option>
+          ))}
+        </select>
+        {fieldErrors.sport && (
+          <p className="mt-1.5 text-sm text-red-600 dark:text-red-400">
+            {fieldErrors.sport}
+          </p>
+        )}
+      </div>
 
       <div>
         <label htmlFor="category" className={labelClasses}>

--- a/components/exercises/ExercisesLibrary.tsx
+++ b/components/exercises/ExercisesLibrary.tsx
@@ -3,19 +3,31 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
-import type { Category, Difficulty, Exercise } from "@/lib/supabase/types";
+import type {
+  Category,
+  Difficulty,
+  Exercise,
+  Sport,
+} from "@/lib/supabase/types";
 import { DIFFICULTY_LABELS, DIFFICULTY_OPTIONS } from "@/lib/exercises";
 import { ExerciseCard } from "./ExerciseCard";
 import { ExerciseCardSkeleton } from "./ExerciseCardSkeleton";
 
 const ALL = "all" as const;
 
-export function ExercisesLibrary({ categories }: { categories: Category[] }) {
+export function ExercisesLibrary({
+  categories,
+  sports,
+}: {
+  categories: Category[];
+  sports: Sport[];
+}) {
   const [exercises, setExercises] = useState<Exercise[] | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
 
   const [search, setSearch] = useState("");
+  const [sportFilter, setSportFilter] = useState<number | typeof ALL>(ALL);
   const [categoryFilter, setCategoryFilter] = useState<number | typeof ALL>(
     ALL,
   );
@@ -54,6 +66,12 @@ export function ExercisesLibrary({ categories }: { categories: Category[] }) {
     return map;
   }, [categories]);
 
+  const sportsById = useMemo(() => {
+    const map = new Map<number, Sport>();
+    for (const sport of sports) map.set(sport.id, sport);
+    return map;
+  }, [sports]);
+
   const equipmentOptions = useMemo(() => {
     const values = new Set<string>();
     for (const exercise of exercises ?? []) {
@@ -70,6 +88,8 @@ export function ExercisesLibrary({ categories }: { categories: Category[] }) {
           `${exercise.title} ${exercise.description ?? ""}`.toLowerCase();
         if (!haystack.includes(query)) return false;
       }
+      if (sportFilter !== ALL && exercise.sport_id !== sportFilter)
+        return false;
       if (categoryFilter !== ALL && exercise.category_id !== categoryFilter)
         return false;
       if (difficultyFilter !== ALL && exercise.difficulty !== difficultyFilter)
@@ -82,10 +102,18 @@ export function ExercisesLibrary({ categories }: { categories: Category[] }) {
       }
       return true;
     });
-  }, [exercises, search, categoryFilter, difficultyFilter, equipmentFilter]);
+  }, [
+    exercises,
+    search,
+    sportFilter,
+    categoryFilter,
+    difficultyFilter,
+    equipmentFilter,
+  ]);
 
   function clearAll() {
     setSearch("");
+    setSportFilter(ALL);
     setCategoryFilter(ALL);
     setDifficultyFilter(ALL);
     setEquipmentFilter(ALL);
@@ -97,6 +125,12 @@ export function ExercisesLibrary({ categories }: { categories: Category[] }) {
     activeFilters.push({
       label: `Szukaj: „${trimmedSearch}”`,
       onClear: () => setSearch(""),
+    });
+  }
+  if (sportFilter !== ALL) {
+    activeFilters.push({
+      label: `Dyscyplina: ${sportsById.get(sportFilter)?.name_pl ?? sportFilter}`,
+      onClear: () => setSportFilter(ALL),
     });
   }
   if (categoryFilter !== ALL) {
@@ -155,7 +189,19 @@ export function ExercisesLibrary({ categories }: { categories: Category[] }) {
           />
         </div>
 
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <FilterSelect
+            id="sport-filter"
+            label="Dyscyplina"
+            value={sportFilter === ALL ? ALL : String(sportFilter)}
+            onChange={(value) =>
+              setSportFilter(value === ALL ? ALL : Number(value))
+            }
+            options={[
+              { value: ALL, label: "Wszystkie dyscypliny" },
+              ...sports.map((s) => ({ value: String(s.id), label: s.name_pl })),
+            ]}
+          />
           <FilterSelect
             id="category-filter"
             label="Kategoria"

--- a/components/exercises/SportBadge.tsx
+++ b/components/exercises/SportBadge.tsx
@@ -1,0 +1,7 @@
+export function SportBadge({ name }: { name: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full border border-neutral-200 bg-neutral-50 px-2.5 py-0.5 text-xs font-medium text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300">
+      {name}
+    </span>
+  );
+}

--- a/components/workouts/DuplicateWorkoutButton.tsx
+++ b/components/workouts/DuplicateWorkoutButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export function DuplicateWorkoutButton({ workoutId }: { workoutId: string }) {
+  const router = useRouter();
+  const [duplicating, setDuplicating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDuplicate() {
+    setDuplicating(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { data, error } = await supabase.rpc("duplicate_workout", {
+      p_workout_id: workoutId,
+    });
+
+    if (error || !data) {
+      setDuplicating(false);
+      setError("Nie udało się zduplikować treningu. Spróbuj ponownie.");
+      return;
+    }
+
+    router.push(`/app/workouts/${data.id}`);
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <button
+        type="button"
+        onClick={handleDuplicate}
+        disabled={duplicating}
+        className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-900"
+      >
+        {duplicating ? "Duplikowanie…" : "Duplikuj"}
+      </button>
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/components/workouts/WorkoutCard.tsx
+++ b/components/workouts/WorkoutCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { Workout } from "@/lib/supabase/types";
 import { formatCreatedDate, formatScheduledDate } from "@/lib/workouts";
 import { DeleteWorkoutButton } from "./DeleteWorkoutButton";
+import { DuplicateWorkoutButton } from "./DuplicateWorkoutButton";
 
 export function WorkoutCard({
   workout,
@@ -31,7 +32,8 @@ export function WorkoutCard({
         </div>
       </Link>
 
-      <div className="mt-4 flex justify-end">
+      <div className="mt-4 flex flex-wrap justify-end gap-2">
+        <DuplicateWorkoutButton workoutId={workout.id} />
         <DeleteWorkoutButton workoutId={workout.id} onDeleted={onDeleted} />
       </div>
     </div>

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -245,6 +245,10 @@ export interface Database {
         Args: { p_share_id: string };
         Returns: SharedWorkoutPayload | null;
       };
+      duplicate_workout: {
+        Args: { p_workout_id: string };
+        Returns: Database["public"]["Tables"]["workouts"]["Row"];
+      };
     };
     Enums: Record<string, never>;
   };

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -58,11 +58,33 @@ export interface Database {
         };
         Relationships: [];
       };
+      sports: {
+        Row: {
+          id: number;
+          slug: string;
+          name_pl: string;
+          name_en: string;
+        };
+        Insert: {
+          id?: number;
+          slug: string;
+          name_pl: string;
+          name_en: string;
+        };
+        Update: {
+          id?: number;
+          slug?: string;
+          name_pl?: string;
+          name_en?: string;
+        };
+        Relationships: [];
+      };
       exercises: {
         Row: {
           id: string;
           author_id: string | null;
           category_id: number;
+          sport_id: number;
           title: string;
           description: string | null;
           steps: string[];
@@ -78,6 +100,7 @@ export interface Database {
           id?: string;
           author_id?: string | null;
           category_id: number;
+          sport_id: number;
           title: string;
           description?: string | null;
           steps?: string[];
@@ -93,6 +116,7 @@ export interface Database {
           id?: string;
           author_id?: string | null;
           category_id?: number;
+          sport_id?: number;
           title?: string;
           description?: string | null;
           steps?: string[];
@@ -117,6 +141,13 @@ export interface Database {
             columns: ["category_id"];
             isOneToOne: false;
             referencedRelation: "categories";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "exercises_sport_id_fkey";
+            columns: ["sport_id"];
+            isOneToOne: false;
+            referencedRelation: "sports";
             referencedColumns: ["id"];
           },
         ];
@@ -221,6 +252,7 @@ export interface Database {
 
 export type Exercise = Database["public"]["Tables"]["exercises"]["Row"];
 export type Category = Database["public"]["Tables"]["categories"]["Row"];
+export type Sport = Database["public"]["Tables"]["sports"]["Row"];
 export type Workout = Database["public"]["Tables"]["workouts"]["Row"];
 export type WorkoutItem = Database["public"]["Tables"]["workout_items"]["Row"];
 

--- a/supabase/migrations/20260710100000_sports_and_exercise_sport_id.sql
+++ b/supabase/migrations/20260710100000_sports_and_exercise_sport_id.sql
@@ -1,0 +1,60 @@
+-- Coach Zone — sport segmentation
+-- Migration 6. Run after 20260709100400_shared_workout_exercise_details.sql.
+
+-- sports: static reference data for exercises, managed via migrations/seed
+-- only - same shape and intent as categories. Categories stay sport-agnostic
+-- (a warmup is a warmup regardless of sport), so this only tags exercises,
+-- not categories.
+create table public.sports (
+  id serial primary key,
+  slug text not null unique,
+  name_pl text not null,
+  name_en text not null
+);
+
+insert into public.sports (slug, name_pl, name_en) values
+  ('football',   'Piłka nożna',  'Football'),
+  ('basketball', 'Koszykówka',   'Basketball'),
+  ('volleyball', 'Siatkówka',    'Volleyball'),
+  ('handball',   'Piłka ręczna', 'Handball')
+on conflict (slug) do nothing;
+
+alter table public.sports enable row level security;
+
+-- sports: public reference data, readable by anyone - same policy shape as
+-- categories_select_public.
+create policy "sports_select_public"
+  on public.sports for select
+  to anon, authenticated
+  using (true);
+
+-- The whole existing library is implicitly football. Add the column
+-- nullable first so the backfill below has something to target, then lock
+-- it down once every row has a value.
+alter table public.exercises
+  add column sport_id integer references public.sports (id);
+
+update public.exercises
+  set sport_id = (select id from public.sports where slug = 'football')
+  where sport_id is null;
+
+alter table public.exercises
+  alter column sport_id set not null;
+
+create index exercises_sport_id_idx on public.exercises (sport_id);
+
+-- Column DEFAULTs can't contain a subquery, so the football id is looked up
+-- once here and baked in as a literal via dynamic SQL rather than
+-- hardcoding whatever id it happens to get from the insert above.
+do $$
+declare
+  v_football_id integer;
+begin
+  select id into v_football_id from public.sports where slug = 'football';
+
+  execute format(
+    'alter table public.exercises alter column sport_id set default %s',
+    v_football_id
+  );
+end;
+$$;

--- a/supabase/migrations/20260710100100_duplicate_workout.sql
+++ b/supabase/migrations/20260710100100_duplicate_workout.sql
@@ -1,0 +1,42 @@
+-- Coach Zone — duplicate workout
+-- Migration 7. Run after 20260710100000_sports_and_exercise_sport_id.sql.
+
+-- Duplicates a workout the caller owns into a new workout row (fresh id and
+-- a new share_id - the copy never reuses the original's public share
+-- token) plus copies of all its workout_items. Deliberately security
+-- invoker (the default, so not declared): the owner-only RLS policies
+-- already guarantee the caller can only select a workout they own (the
+-- first insert's source select) and can only insert rows owned by
+-- themselves (owner_id = auth.uid()), so this function needs no elevated
+-- privilege at all. The whole body runs as a single statement from
+-- Postgres's point of view, so a failure partway through (e.g. the items
+-- insert) rolls back the new workout row too - no half-copied workout can
+-- result.
+create or replace function public.duplicate_workout(p_workout_id uuid)
+returns public.workouts
+language plpgsql
+as $$
+declare
+  new_workout public.workouts;
+begin
+  insert into public.workouts (owner_id, title, team_name, scheduled_for, notes)
+  select auth.uid(), w.title || ' (kopia)', w.team_name, null, w.notes
+  from public.workouts w
+  where w.id = p_workout_id
+  returning * into new_workout;
+
+  if new_workout.id is null then
+    raise exception 'Workout % not found or not owned by the caller', p_workout_id;
+  end if;
+
+  insert into public.workout_items
+    (workout_id, exercise_id, section, position, duration_min, assigned_to)
+  select new_workout.id, wi.exercise_id, wi.section, wi.position, wi.duration_min, wi.assigned_to
+  from public.workout_items wi
+  where wi.workout_id = p_workout_id;
+
+  return new_workout;
+end;
+$$;
+
+grant execute on function public.duplicate_workout(uuid) to authenticated;


### PR DESCRIPTION
## Summary

Two quick wins for round 7:

- **Duplicate a workout** — one-click "Duplikuj" on `/app/workouts`, lands you in the builder for the independent copy.
- **Sport segmentation** — exercises now carry a `sport_id`, library gets a "Dyscyplina" filter, groundwork for multi-sport later.

## Decisions (as requested, flagging for confirmation)

- **`scheduled_for` on the copy → left `null`.** Copying forward the original's date felt actively misleading (a duplicate of last week's session showing "today" or last week's date isn't right either) — leaving it blank nudges the coach to set the real date, which the brief already expects them to do.
- **`sport_id` → `NOT NULL` with a default pointing at football**, as you leaned toward. The whole existing library (seeded + any user-created rows) is backfilled to football in the same migration. Column defaults can't contain a subquery, so the migration looks up football's id once and bakes it in as a literal via a `DO` block instead of hardcoding `1`.

## Feature 1 — Duplicate a workout

New `duplicate_workout(p_workout_id uuid)` Postgres function:
- Copies `title` (suffixed `" (kopia)"`), `team_name`, `notes`, and **all** `workout_items` (`exercise_id`, `section`, `position`, `duration_min`, `assigned_to`).
- Fresh `id` and a **new** `share_id` — both come from the columns' own `DEFAULT` expressions since the insert never specifies them, so the copy can never reuse the original's public link.
- `owner_id = auth.uid()`, i.e. always the caller — not copied from the source row.
- **Security invoker, not definer** (deliberately): the existing owner-only RLS policies already guarantee the caller can only read a workout they own (the source `select`) and can only insert rows owned by themselves. No elevated privilege needed, and RLS alone rejects an attempt to duplicate someone else's workout.
- The whole copy is one PL/pgSQL function body → one statement from Postgres's point of view, so a failure partway through (e.g. the items insert) rolls back the new workout row too. No half-copied workout possible.

`WorkoutCard` gets a "Duplikuj" button next to "Usuń" (no confirmation step, since it's non-destructive); on success it navigates straight into `/app/workouts/[new-id]`.

## Feature 2 — Sport segmentation

- New `sports` table (`id serial`, `slug` unique, `name_pl`, `name_en`), seeded with football (Piłka nożna), basketball (Koszykówka), volleyball (Siatkówka), handball (Piłka ręczna).
- `sports_select_public` RLS policy — public reference data, same shape as `categories_select_public`.
- `exercises.sport_id`: added nullable → backfilled to football → locked to `NOT NULL` with a football default, all in one migration.
- Categories are **not** coupled to sports this round, per the brief.
- UI: "Dyscyplina" filter on `/app/exercises` (combinable with category/difficulty/equipment), required "Dyscyplina" select on the create/edit form (defaults to football), small badge on the exercise detail page.

## Migration SQL — run in order in the Supabase SQL Editor

**1. `supabase/migrations/20260710100000_sports_and_exercise_sport_id.sql`**

```sql
-- Coach Zone — sport segmentation
-- Migration 6. Run after 20260709100400_shared_workout_exercise_details.sql.

-- sports: static reference data for exercises, managed via migrations/seed
-- only - same shape and intent as categories. Categories stay sport-agnostic
-- (a warmup is a warmup regardless of sport), so this only tags exercises,
-- not categories.
create table public.sports (
  id serial primary key,
  slug text not null unique,
  name_pl text not null,
  name_en text not null
);

insert into public.sports (slug, name_pl, name_en) values
  ('football',   'Piłka nożna',  'Football'),
  ('basketball', 'Koszykówka',   'Basketball'),
  ('volleyball', 'Siatkówka',    'Volleyball'),
  ('handball',   'Piłka ręczna', 'Handball')
on conflict (slug) do nothing;

alter table public.sports enable row level security;

-- sports: public reference data, readable by anyone - same policy shape as
-- categories_select_public.
create policy "sports_select_public"
  on public.sports for select
  to anon, authenticated
  using (true);

-- The whole existing library is implicitly football. Add the column
-- nullable first so the backfill below has something to target, then lock
-- it down once every row has a value.
alter table public.exercises
  add column sport_id integer references public.sports (id);

update public.exercises
  set sport_id = (select id from public.sports where slug = 'football')
  where sport_id is null;

alter table public.exercises
  alter column sport_id set not null;

create index exercises_sport_id_idx on public.exercises (sport_id);

-- Column DEFAULTs can't contain a subquery, so the football id is looked up
-- once here and baked in as a literal via dynamic SQL rather than
-- hardcoding whatever id it happens to get from the insert above.
do $$
declare
  v_football_id integer;
begin
  select id into v_football_id from public.sports where slug = 'football';

  execute format(
    'alter table public.exercises alter column sport_id set default %s',
    v_football_id
  );
end;
$$;
```

**2. `supabase/migrations/20260710100100_duplicate_workout.sql`**

```sql
-- Coach Zone — duplicate workout
-- Migration 7. Run after 20260710100000_sports_and_exercise_sport_id.sql.

-- Duplicates a workout the caller owns into a new workout row (fresh id and
-- a new share_id - the copy never reuses the original's public share
-- token) plus copies of all its workout_items. Deliberately security
-- invoker (the default, so not declared): the owner-only RLS policies
-- already guarantee the caller can only select a workout they own (the
-- first insert's source select) and can only insert rows owned by
-- themselves (owner_id = auth.uid()), so this function needs no elevated
-- privilege at all. The whole body runs as a single statement from
-- Postgres's point of view, so a failure partway through (e.g. the items
-- insert) rolls back the new workout row too - no half-copied workout can
-- result.
create or replace function public.duplicate_workout(p_workout_id uuid)
returns public.workouts
language plpgsql
as $$
declare
  new_workout public.workouts;
begin
  insert into public.workouts (owner_id, title, team_name, scheduled_for, notes)
  select auth.uid(), w.title || ' (kopia)', w.team_name, null, w.notes
  from public.workouts w
  where w.id = p_workout_id
  returning * into new_workout;

  if new_workout.id is null then
    raise exception 'Workout % not found or not owned by the caller', p_workout_id;
  end if;

  insert into public.workout_items
    (workout_id, exercise_id, section, position, duration_min, assigned_to)
  select new_workout.id, wi.exercise_id, wi.section, wi.position, wi.duration_min, wi.assigned_to
  from public.workout_items wi
  where wi.workout_id = p_workout_id;

  return new_workout;
end;
$$;

grant execute on function public.duplicate_workout(uuid) to authenticated;
```

`supabase/seed.sql` needed **no changes** — its exercise inserts don't specify `sport_id`, so on a fresh `supabase db reset` they pick up the football default automatically once migration 6 has created it.

## What I verified vs. what needs your live check

No Supabase token in this sandbox, so I couldn't hit the real project. To de-risk that as much as possible, I stood up a scratch **local Postgres 16** instance, applied all 7 migration files in order (the 5 existing ones + these 2 new ones) plus `seed.sql`, and built a minimal stand-in for the parts of a Supabase project our migrations don't own (an `auth.users`/`auth.uid()` stub and `anon`/`authenticated` roles with RLS enforced — not committed, test-only). Against that I mechanically confirmed:

- All 7 migrations + seed apply cleanly in order, zero errors.
- Every existing exercise (all 15 seeded rows) backfilled to `sport_id` = football; a new insert omitting `sport_id` also defaults to football.
- `sports` is readable by `anon` (4 rows); `exercises` is still correctly invisible to `anon` (unchanged, sanity check).
- Two-coach scenario end-to-end: Coach A creates a workout with 3 items across warmup/main/cooldown → `duplicate_workout()` returns a row with a fresh id, a fresh `share_id` (different from the original's), title suffixed `" (kopia)"`, `scheduled_for` null, `team_name`/`notes` copied, owner = Coach A → all 3 items copied with matching `section`/`position`/`duration_min`/`assigned_to`/`exercise_id` but fresh item ids.
- **Independence**: editing the copy's title/notes/an item's duration afterward left the original completely untouched.
- **Cross-owner rejection**: Coach B calling `duplicate_workout()` on Coach A's workout id correctly fails ("not found or not owned by the caller") — RLS blocks it with no security-definer escape hatch, and Coach B still can't `select` that workout directly either.

I also ran `pnpm typecheck`, `pnpm lint`, and `pnpm build` clean, and smoke-tested `next dev` (boots fine, `/login` renders, `/app/*` correctly redirects unauthenticated requests — expected, since I have no real session to exercise the actual library/builder UI in a browser).

**Flagging for your live check**, since none of the above is a substitute for the real hosted project:
- Running the two migrations above against production Supabase itself (I only validated the SQL logic against a local stand-in, not your actual instance/data).
- The `duplicate_workout` RPC through the real PostgREST/`supabase-js` path (my local test called the function directly in `psql`, not through `supabase.rpc()` over HTTP).
- The actual browser UI — Dyscyplina filter/select/badge, and the Duplikuj button end to end — since every affected route lives behind auth I can't reach without a real session.

## Manual test script

**Before:** run both migrations above, in order, in the Supabase SQL Editor.

**Sport segmentation**
1. Open `/app/exercises` — every existing exercise should still show (nothing broke).
2. Open any existing exercise's detail page — should show a "Piłka nożna" badge.
3. Use the new "Dyscyplina" filter — selecting "Piłka nożna" should show the full library; selecting e.g. "Koszykówka" should show zero results (nothing's tagged yet); combine it with the category/difficulty filters to confirm they still AND together correctly.
4. Click "Dodaj ćwiczenie" — the "Dyscyplina" select should default to "Piłka nożna" and be required; try clearing it (browser permitting) and submitting to see the validation message; save with a sport chosen and confirm the new exercise's detail page shows the right badge.
5. Edit an existing exercise — "Dyscyplina" should be pre-filled with its current sport; change it and save, then confirm the detail badge updated.

**Duplicate a workout**
1. On `/app/workouts`, pick a workout that has items in multiple sections and click "Duplikuj".
2. Should land you directly in the builder for a new workout titled `"<original> (kopia)"`, same team/notes, no scheduled date, and all the same items in the same sections/order.
3. Copy the new workout's share link ("Udostępnij") and confirm it's different from the original's.
4. Edit something in the copy (retitle, change an item's duration, remove an item) and confirm the original workout is untouched.
5. Delete the copy and confirm the original and its items are still intact.

## Not in this round (per the brief)

Calendar/week view, shared library / copying other coaches' exercises, tactics board.


---
_Generated by [Claude Code](https://claude.ai/code/session_016jsDmz8aruuRrDV89X8zUq)_