### PR TITLE
feat(calendar): add week view calendar for scheduled workouts

### DIFF
--- a/app/app/calendar/loading.tsx
+++ b/app/app/calendar/loading.tsx
@@ -1,0 +1,23 @@
+import { WorkoutCardSkeleton } from "@/components/workouts/WorkoutCardSkeleton";
+
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-2">
+          <div className="h-8 w-56 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-4 w-40 max-w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+        <div className="h-10 w-36 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+
+      <div className="mt-6 h-9 w-64 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-7">
+        {Array.from({ length: 7 }, (_, i) => (
+          <WorkoutCardSkeleton key={i} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/app/calendar/page.tsx
+++ b/app/app/calendar/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { CalendarView } from "@/components/workouts/CalendarView";
+
+export const metadata: Metadata = {
+  title: "Kalendarz — Coach Zone",
+};
+
+export default function CalendarPage() {
+  return <CalendarView />;
+}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -5,6 +5,7 @@ import { logout } from "./actions";
 const navItems = [
   { href: "/app/exercises", label: "Ćwiczenia" },
   { href: "/app/workouts", label: "Treningi" },
+  { href: "/app/calendar", label: "Kalendarz" },
 ];
 
 export default function AppLayout({ children }: { children: ReactNode }) {

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -19,6 +19,11 @@ const navItems = [
     title: "Treningi",
     description: "Planuj sesje treningowe i buduj je z biblioteki ćwiczeń.",
   },
+  {
+    href: "/app/calendar",
+    title: "Kalendarz",
+    description: "Zobacz treningi w widoku tygodnia i planuj mikrocykle.",
+  },
 ];
 
 export default async function AppHomePage() {
@@ -49,7 +54,7 @@ export default async function AppHomePage() {
         To Twoja strona startowa w Coach Zone.
       </p>
 
-      <div className="mt-10 grid gap-6 sm:grid-cols-2">
+      <div className="mt-10 grid gap-6 sm:grid-cols-3">
         {navItems.map((item) => (
           <Link
             key={item.href}

--- a/app/app/workouts/new/page.tsx
+++ b/app/app/workouts/new/page.tsx
@@ -9,7 +9,13 @@ export const metadata: Metadata = {
   title: "Nowy trening — Coach Zone",
 };
 
-export default async function NewWorkoutPage() {
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export default async function NewWorkoutPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
   const supabase = await createClient();
   const { data: userData } = await supabase.auth.getUser();
 
@@ -19,6 +25,9 @@ export default async function NewWorkoutPage() {
     redirect("/login");
   }
 
+  const { date } = await searchParams;
+  const initialScheduledFor = date && DATE_PATTERN.test(date) ? date : undefined;
+
   return (
     <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
       <h1 className="text-3xl font-bold tracking-tight">Nowy trening</h1>
@@ -26,7 +35,11 @@ export default async function NewWorkoutPage() {
         Podaj podstawowe informacje — szczegóły ćwiczeń dodasz w kolejnym kroku.
       </p>
       <div className="mt-8">
-        <WorkoutBasicsForm mode="create" userId={userData.user.id} />
+        <WorkoutBasicsForm
+          mode="create"
+          userId={userData.user.id}
+          initialScheduledFor={initialScheduledFor}
+        />
       </div>
     </main>
   );

--- a/components/workouts/CalendarDayCard.tsx
+++ b/components/workouts/CalendarDayCard.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import type { Workout } from "@/lib/supabase/types";
+import { formatTotalDuration, type WorkoutStats } from "@/lib/workouts";
+import { formatDayLabel, toDateKey } from "@/lib/calendar";
+
+export function CalendarDayCard({
+  date,
+  workouts,
+  stats,
+  isToday,
+}: {
+  date: Date;
+  workouts: Workout[];
+  stats: Record<string, WorkoutStats>;
+  isToday: boolean;
+}) {
+  const dateKey = toDateKey(date);
+
+  return (
+    <div
+      className={`flex flex-col rounded-2xl border p-4 ${
+        isToday
+          ? "border-emerald-600 bg-emerald-50/60 dark:border-emerald-500 dark:bg-emerald-950/20"
+          : "border-neutral-200 dark:border-neutral-800"
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={`text-sm font-semibold ${
+            isToday
+              ? "text-emerald-700 dark:text-emerald-400"
+              : "text-neutral-900 dark:text-neutral-100"
+          }`}
+        >
+          {formatDayLabel(date)}
+        </span>
+        {isToday && (
+          <span className="shrink-0 rounded-full bg-emerald-600 px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white uppercase">
+            Dziś
+          </span>
+        )}
+      </div>
+
+      <div className="mt-3 flex flex-1 flex-col gap-2">
+        {workouts.length === 0 ? (
+          <p className="text-xs text-neutral-500 dark:text-neutral-500">
+            Brak treningów
+          </p>
+        ) : (
+          workouts.map((workout) => {
+            const workoutStats = stats[workout.id] ?? {
+              itemCount: 0,
+              totalMinutes: 0,
+            };
+            return (
+              <Link
+                key={workout.id}
+                href={`/app/workouts/${workout.id}`}
+                className="rounded-lg border border-neutral-200 px-3 py-2 text-sm transition-colors hover:border-emerald-600/50 dark:border-neutral-800"
+              >
+                <div className="font-medium">{workout.title}</div>
+                <div className="mt-1 flex flex-wrap gap-x-2 text-xs text-neutral-500 dark:text-neutral-400">
+                  {workout.team_name && <span>{workout.team_name}</span>}
+                  <span>
+                    {workoutStats.itemCount}{" "}
+                    {workoutStats.itemCount === 1 ? "ćwiczenie" : "ćwiczeń"}
+                  </span>
+                  <span>{formatTotalDuration(workoutStats.totalMinutes)}</span>
+                </div>
+              </Link>
+            );
+          })
+        )}
+      </div>
+
+      <Link
+        href={`/app/workouts/new?date=${dateKey}`}
+        className="mt-3 rounded-full border border-dashed border-neutral-300 px-3 py-2 text-center text-xs font-medium text-neutral-500 transition-colors hover:border-emerald-600/50 hover:text-emerald-600 dark:border-neutral-700 dark:text-neutral-400 dark:hover:border-emerald-600/50 dark:hover:text-emerald-400"
+      >
+        + Dodaj trening
+      </Link>
+    </div>
+  );
+}

--- a/components/workouts/CalendarView.tsx
+++ b/components/workouts/CalendarView.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { Workout } from "@/lib/supabase/types";
+import { summarizeWorkoutItems, type WorkoutStats } from "@/lib/workouts";
+import {
+  addWeeks,
+  formatWeekRangeLabel,
+  getWeekDays,
+  getWeekStart,
+  isSameDay,
+  toDateKey,
+} from "@/lib/calendar";
+import { CalendarDayCard } from "./CalendarDayCard";
+import { UnscheduledWorkoutCard } from "./UnscheduledWorkoutCard";
+import { WorkoutCardSkeleton } from "./WorkoutCardSkeleton";
+
+export function CalendarView() {
+  const [workouts, setWorkouts] = useState<Workout[] | null>(null);
+  const [stats, setStats] = useState<Record<string, WorkoutStats>>({});
+  const [loadError, setLoadError] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [weekStart, setWeekStart] = useState(() => getWeekStart(new Date()));
+
+  useEffect(() => {
+    let cancelled = false;
+    setWorkouts(null);
+    setLoadError(false);
+
+    const supabase = createClient();
+
+    async function load() {
+      const { data: workoutsData, error: workoutsError } = await supabase
+        .from("workouts")
+        .select("*")
+        .order("created_at", { ascending: true });
+
+      if (cancelled) return;
+      if (workoutsError || !workoutsData) {
+        setLoadError(true);
+        return;
+      }
+
+      const ids = workoutsData.map((workout) => workout.id);
+      const { data: itemsData, error: itemsError } =
+        ids.length > 0
+          ? await supabase
+              .from("workout_items")
+              .select("workout_id, duration_min")
+              .in("workout_id", ids)
+          : { data: [], error: null };
+
+      if (cancelled) return;
+      if (itemsError) {
+        setLoadError(true);
+        return;
+      }
+
+      setStats(summarizeWorkoutItems(itemsData ?? []));
+      setWorkouts(workoutsData);
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  const today = useMemo(() => new Date(), []);
+  const weekDays = useMemo(() => getWeekDays(weekStart), [weekStart]);
+
+  const workoutsByDate = useMemo(() => {
+    const map = new Map<string, Workout[]>();
+    for (const workout of workouts ?? []) {
+      if (!workout.scheduled_for) continue;
+      const list = map.get(workout.scheduled_for) ?? [];
+      list.push(workout);
+      map.set(workout.scheduled_for, list);
+    }
+    return map;
+  }, [workouts]);
+
+  const unscheduled = useMemo(
+    () => (workouts ?? []).filter((workout) => !workout.scheduled_for),
+    [workouts],
+  );
+
+  function handleDateAssigned(workoutId: string, newDate: string) {
+    setWorkouts(
+      (prev) =>
+        prev?.map((workout) =>
+          workout.id === workoutId
+            ? { ...workout, scheduled_for: newDate }
+            : workout,
+        ) ?? prev,
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 pt-8 pb-20">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Kalendarz treningów
+          </h1>
+          <p className="mt-1 text-neutral-600 dark:text-neutral-400">
+            {formatWeekRangeLabel(weekStart)}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/app/workouts"
+            className="rounded-full border border-neutral-300 px-4 py-2.5 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Lista treningów
+          </Link>
+          <Link
+            href="/app/workouts/new"
+            className="rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Nowy trening
+          </Link>
+        </div>
+      </div>
+
+      <div className="mt-6 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setWeekStart((current) => addWeeks(current, -1))}
+          aria-label="Poprzedni tydzień"
+          className="rounded-full border border-neutral-300 px-3 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+        >
+          ← Poprzedni
+        </button>
+        <button
+          type="button"
+          onClick={() => setWeekStart(getWeekStart(new Date()))}
+          className="rounded-full border border-neutral-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+        >
+          Dziś
+        </button>
+        <button
+          type="button"
+          onClick={() => setWeekStart((current) => addWeeks(current, 1))}
+          aria-label="Następny tydzień"
+          className="rounded-full border border-neutral-300 px-3 py-2 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+        >
+          Następny →
+        </button>
+      </div>
+
+      <div className="mt-6">
+        {loadError ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/50 dark:bg-red-950/40">
+            <p className="text-sm text-red-700 dark:text-red-400">
+              Nie udało się wczytać treningów. Spróbuj ponownie.
+            </p>
+            <button
+              type="button"
+              onClick={() => setReloadToken((n) => n + 1)}
+              className="mt-3 rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
+            >
+              Spróbuj ponownie
+            </button>
+          </div>
+        ) : workouts === null ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-7">
+            {Array.from({ length: 7 }, (_, i) => (
+              <WorkoutCardSkeleton key={i} />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-7">
+            {weekDays.map((date) => (
+              <CalendarDayCard
+                key={toDateKey(date)}
+                date={date}
+                workouts={workoutsByDate.get(toDateKey(date)) ?? []}
+                stats={stats}
+                isToday={isSameDay(date, today)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {workouts !== null && !loadError && (
+        <div className="mt-10">
+          <h2 className="text-xl font-semibold tracking-tight">
+            Bez terminu
+          </h2>
+          <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+            Treningi bez przypisanej daty — nadaj datę, aby pojawiły się w
+            kalendarzu.
+          </p>
+          <div className="mt-4">
+            {unscheduled.length === 0 ? (
+              <p className="text-sm text-neutral-500 dark:text-neutral-500">
+                Wszystkie treningi mają przypisaną datę.
+              </p>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {unscheduled.map((workout) => (
+                  <UnscheduledWorkoutCard
+                    key={workout.id}
+                    workout={workout}
+                    stats={stats[workout.id]}
+                    onDateAssigned={handleDateAssigned}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/components/workouts/UnscheduledWorkoutCard.tsx
+++ b/components/workouts/UnscheduledWorkoutCard.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { Workout } from "@/lib/supabase/types";
+import { formatTotalDuration, type WorkoutStats } from "@/lib/workouts";
+
+export function UnscheduledWorkoutCard({
+  workout,
+  stats,
+  onDateAssigned,
+}: {
+  workout: Workout;
+  stats?: WorkoutStats;
+  onDateAssigned: (workoutId: string, date: string) => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(false);
+  const workoutStats = stats ?? { itemCount: 0, totalMinutes: 0 };
+
+  async function handleDateChange(value: string) {
+    if (!value) return;
+    setSaving(true);
+    setError(false);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("workouts")
+      .update({ scheduled_for: value })
+      .eq("id", workout.id);
+
+    setSaving(false);
+    if (error) {
+      setError(true);
+      return;
+    }
+    onDateAssigned(workout.id, value);
+  }
+
+  return (
+    <div className="flex flex-col rounded-2xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <Link
+        href={`/app/workouts/${workout.id}`}
+        className="flex-1 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/50"
+      >
+        <h3 className="font-semibold tracking-tight">{workout.title}</h3>
+        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-neutral-500 dark:text-neutral-500">
+          {workout.team_name && <span>{workout.team_name}</span>}
+          <span>
+            {workoutStats.itemCount}{" "}
+            {workoutStats.itemCount === 1 ? "ćwiczenie" : "ćwiczeń"}
+          </span>
+          <span>{formatTotalDuration(workoutStats.totalMinutes)}</span>
+        </div>
+      </Link>
+
+      <div className="mt-3 flex items-center gap-2">
+        <label
+          htmlFor={`schedule-${workout.id}`}
+          className="text-xs font-medium text-neutral-600 dark:text-neutral-400"
+        >
+          Ustaw datę
+        </label>
+        <input
+          id={`schedule-${workout.id}`}
+          type="date"
+          disabled={saving}
+          defaultValue=""
+          onChange={(e) => handleDateChange(e.target.value)}
+          className="rounded-lg border border-neutral-300 bg-white px-2 py-1 text-xs outline-none transition-colors focus:ring-2 focus:ring-emerald-600/50 disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900"
+        />
+      </div>
+      {error && (
+        <p className="mt-1.5 text-xs text-red-600 dark:text-red-400">
+          Nie udało się zapisać daty. Spróbuj ponownie.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/workouts/WorkoutBasicsForm.tsx
+++ b/components/workouts/WorkoutBasicsForm.tsx
@@ -9,7 +9,7 @@ import { createClient } from "@/lib/supabase/client";
 import type { Workout } from "@/lib/supabase/types";
 
 type WorkoutBasicsFormProps =
-  | { mode: "create"; userId: string }
+  | { mode: "create"; userId: string; initialScheduledFor?: string }
   | {
       mode: "edit";
       workout: Workout;
@@ -34,7 +34,8 @@ export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
   const [title, setTitle] = useState(initial?.title ?? "");
   const [teamName, setTeamName] = useState(initial?.team_name ?? "");
   const [scheduledFor, setScheduledFor] = useState(
-    initial?.scheduled_for ?? "",
+    initial?.scheduled_for ??
+      (props.mode === "create" ? (props.initialScheduledFor ?? "") : ""),
   );
   const [notes, setNotes] = useState(initial?.notes ?? "");
 

--- a/components/workouts/WorkoutsList.tsx
+++ b/components/workouts/WorkoutsList.tsx
@@ -76,12 +76,20 @@ export function WorkoutsList() {
             Planuj sesje treningowe i buduj je z biblioteki ćwiczeń.
           </p>
         </div>
-        <Link
-          href="/app/workouts/new"
-          className="rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
-        >
-          Nowy trening
-        </Link>
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/app/calendar"
+            className="rounded-full border border-neutral-300 px-4 py-2.5 text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Kalendarz
+          </Link>
+          <Link
+            href="/app/workouts/new"
+            className="rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Nowy trening
+          </Link>
+        </div>
       </div>
 
       <div className="mt-8">

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1,0 +1,74 @@
+// All helpers work on local-midnight Date objects and never round-trip
+// through toISOString()/Date parsing of ISO strings - both convert through
+// UTC and can shift the calendar day depending on the viewer's timezone,
+// the same pitfall documented next to formatScheduledDate in lib/workouts.ts.
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function addDays(date: Date, days: number): Date {
+  const next = startOfDay(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function addWeeks(date: Date, weeks: number): Date {
+  return addDays(date, weeks * 7);
+}
+
+// Monday-start week, matching Polish/European convention.
+export function getWeekStart(date: Date): Date {
+  const day = startOfDay(date);
+  const weekday = day.getDay(); // 0 = Sunday, 1 = Monday, ...
+  const diffFromMonday = weekday === 0 ? -6 : 1 - weekday;
+  return addDays(day, diffFromMonday);
+}
+
+export function getWeekDays(weekStart: Date): Date[] {
+  return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+}
+
+// Matches the Postgres `date` column format and the value <input type="date">
+// reads/writes, built from local components (not toISOString).
+export function toDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return toDateKey(a) === toDateKey(b);
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function formatDayLabel(date: Date): string {
+  const weekday = date.toLocaleDateString("pl-PL", { weekday: "long" });
+  const dayMonth = date.toLocaleDateString("pl-PL", {
+    day: "numeric",
+    month: "long",
+  });
+  return `${capitalize(weekday)}, ${dayMonth}`;
+}
+
+export function formatWeekRangeLabel(weekStart: Date): string {
+  const weekEnd = addDays(weekStart, 6);
+  const sameMonth =
+    weekStart.getMonth() === weekEnd.getMonth() &&
+    weekStart.getFullYear() === weekEnd.getFullYear();
+
+  const startLabel = weekStart.toLocaleDateString(
+    "pl-PL",
+    sameMonth ? { day: "numeric" } : { day: "numeric", month: "long" },
+  );
+  const endLabel = weekEnd.toLocaleDateString("pl-PL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+  return `${startLabel} – ${endLabel}`;
+}

--- a/lib/workouts.ts
+++ b/lib/workouts.ts
@@ -78,6 +78,30 @@ export interface PdfWorkoutItem {
   exerciseDescription: string | null;
 }
 
+export interface WorkoutStats {
+  itemCount: number;
+  totalMinutes: number;
+}
+
+// Shared by the workouts list (item counts) and the calendar view (item
+// counts + total duration) - both derive per-workout stats from the same
+// flat workout_items rows.
+export function summarizeWorkoutItems(
+  items: { workout_id: string; duration_min: number | null }[],
+): Record<string, WorkoutStats> {
+  const stats: Record<string, WorkoutStats> = {};
+  for (const item of items) {
+    const current = stats[item.workout_id] ?? {
+      itemCount: 0,
+      totalMinutes: 0,
+    };
+    current.itemCount += 1;
+    current.totalMinutes += item.duration_min ?? 0;
+    stats[item.workout_id] = current;
+  }
+  return stats;
+}
+
 export function groupItemsBySection<
   T extends { section: WorkoutSection; position: number },
 >(items: T[]): Map<WorkoutSection, T[]> {


### PR DESCRIPTION
## Summary

- New `/app/calendar` route: a Monday–Sunday week view of `workouts.scheduled_for` (no schema change — reads the existing column). Chosen approach: **dedicated route**, not a toggle on `/app/workouts` — the list page is untouched aside from a small "Kalendarz" cross-link, and a "Lista treningów" link goes back the other way. Both pages are also in the top nav and the `/app` dashboard cards.
- Week navigation: "← Poprzedni" / "Następny →" plus a "Dziś" button that jumps back to the current week. Today's day card is visually highlighted (emerald border/background + "Dziś" badge) and the current week is the default landing view.
- Each day card lists that day's workouts (title, team name, item count, total duration computed from `workout_items.duration_min`) and always shows a subtle "+ Dodaj trening" link that creates a workout with `scheduled_for` pre-filled to that day (`/app/workouts/new?date=YYYY-MM-DD`) and lands you in the builder, same as the existing create flow.
- **"Bez terminu" section** below the calendar lists any workout with `scheduled_for = null` (including freshly duplicated workouts from Round 7) so they're never unreachable. Each has an inline date picker that updates `scheduled_for` and moves it onto the calendar immediately (optimistic local state update, no page reload).
- **Responsive**: the day grid is `grid-cols-1` by default and `md:grid-cols-7`, so phones get a clean vertical day-by-day list and nothing needs a separate mobile component.
- Loading/error states mirror the existing `WorkoutsList` pattern (skeleton grid, red error banner with retry).

## Files

- `lib/calendar.ts` — Monday-start week date helpers (local-date arithmetic, same UTC-shift precaution already documented next to `formatScheduledDate`).
- `lib/workouts.ts` — added `summarizeWorkoutItems()`, a small shared helper for per-workout item count + total duration, used by the calendar.
- `components/workouts/CalendarView.tsx`, `CalendarDayCard.tsx`, `UnscheduledWorkoutCard.tsx` — new.
- `app/app/calendar/page.tsx`, `app/app/calendar/loading.tsx` — new route.
- `app/app/workouts/new/page.tsx`, `components/workouts/WorkoutBasicsForm.tsx` — accept an optional `?date=` to pre-fill `scheduled_for` on create.
- `app/app/layout.tsx`, `app/app/page.tsx`, `components/workouts/WorkoutsList.tsx` — nav entries and cross-links only; no behavior change to the existing workouts list.

## Test plan

Ran locally (no test suite in this repo — CI is lint + typecheck + build):
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — succeeds, `/app/calendar` registered as a route
- [x] Smoke-tested routing with `pnpm start` + dummy Supabase env vars: `/app/calendar` and `/app/workouts` both correctly 307-redirect to `/login` when unauthenticated (middleware protection intact)

**Could not verify against real Supabase from this sandbox** (no live project credentials here) — please check on the live site:
- [ ] `/app/calendar` shows the current week with dated workouts on the correct days
- [ ] Prev/Next/"Dziś" navigation works and today is highlighted
- [ ] Clicking a workout opens `/app/workouts/[id]`
- [ ] "+ Dodaj trening" on a day creates a workout with that date pre-filled and opens the builder
- [ ] Duplicated / undated workouts show up under "Bez terminu" and setting a date moves them onto the correct day without a reload
- [ ] Mobile viewport shows the vertical day-by-day list (no 7-column squeeze)
- [ ] `/app/workouts` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXgJKCZj1jJSwRHWWA4nZd)_