### PR TITLE
feat(board): add interactive tactics board editor

### DIFF
--- a/app/app/board/loading.tsx
+++ b/app/app/board/loading.tsx
@@ -1,0 +1,13 @@
+import { BoardSkeleton } from "@/components/board/BoardSkeleton";
+
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-4xl px-4 pt-8 pb-20 sm:px-6">
+      <div className="h-8 w-64 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-2 h-4 w-80 max-w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+      <div className="mt-6">
+        <BoardSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/app/app/board/page.tsx
+++ b/app/app/board/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { TacticsBoardLoader } from "@/components/board/TacticsBoardLoader";
+
+export const metadata: Metadata = {
+  title: "Tablica taktyczna — Coach Zone",
+};
+
+export default function BoardPage() {
+  return (
+    <main className="mx-auto max-w-4xl px-4 pt-8 pb-20 sm:px-6">
+      <h1 className="text-3xl font-bold tracking-tight">Tablica taktyczna</h1>
+      <p className="mt-2 text-neutral-600 dark:text-neutral-400">
+        Rysuj ustawienia i akcje na boisku. Wersja robocza — bez zapisywania i
+        eksportu (dołączymy je w kolejnym etapie).
+      </p>
+      <div className="mt-6">
+        <TacticsBoardLoader />
+      </div>
+    </main>
+  );
+}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -6,6 +6,7 @@ const navItems = [
   { href: "/app/exercises", label: "Ćwiczenia" },
   { href: "/app/workouts", label: "Treningi" },
   { href: "/app/calendar", label: "Kalendarz" },
+  { href: "/app/board", label: "Tablica taktyczna" },
 ];
 
 export default function AppLayout({ children }: { children: ReactNode }) {

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -24,6 +24,12 @@ const navItems = [
     title: "Kalendarz",
     description: "Zobacz treningi w widoku tygodnia i planuj mikrocykle.",
   },
+  {
+    href: "/app/board",
+    title: "Tablica taktyczna",
+    description:
+      "Rysuj ustawienia i akcje na boisku (wersja robocza, bez zapisywania).",
+  },
 ];
 
 export default async function AppHomePage() {

--- a/components/board/BoardElementNode.tsx
+++ b/components/board/BoardElementNode.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type Konva from "konva";
+import { Arrow, Circle, Group, RegularPolygon, Text } from "react-konva";
+import { isLineElement, type BoardElement, type PointElementType } from "@/lib/board/types";
+import { POINT_RADIUS } from "@/lib/board/elements";
+
+const SELECTION_COLOR = "#fbbf24";
+
+interface BoardElementNodeProps {
+  element: BoardElement;
+  selected: boolean;
+  interactive: boolean;
+  onSelect: (id: string) => void;
+  onDragEnd: (id: string, pos: { x: number; y: number }) => void;
+  onRegisterNode: (id: string, node: Konva.Node | null) => void;
+  onEditLabel: (id: string) => void;
+}
+
+export function BoardElementNode({
+  element,
+  selected,
+  interactive,
+  onSelect,
+  onDragEnd,
+  onRegisterNode,
+  onEditLabel,
+}: BoardElementNodeProps) {
+  const select = (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
+    e.cancelBubble = true;
+    onSelect(element.id);
+  };
+
+  const handleDragEnd = (e: Konva.KonvaEventObject<DragEvent>) => {
+    onDragEnd(element.id, { x: e.target.x(), y: e.target.y() });
+  };
+
+  if (isLineElement(element)) {
+    const isPassLine = element.type === "passLine";
+    const color = isPassLine ? "#7c3aed" : "#111827";
+    return (
+      <Arrow
+        ref={(node) => onRegisterNode(element.id, node)}
+        id={element.id}
+        x={element.x}
+        y={element.y}
+        rotation={element.rotation}
+        points={[0, 0, element.endX, element.endY]}
+        stroke={color}
+        fill={color}
+        strokeWidth={4}
+        dash={isPassLine ? [14, 10] : undefined}
+        pointerLength={14}
+        pointerWidth={14}
+        hitStrokeWidth={28}
+        draggable={interactive}
+        onClick={select}
+        onTap={select}
+        onDragEnd={handleDragEnd}
+        shadowColor="black"
+        shadowOpacity={selected ? 0.4 : 0}
+        shadowBlur={selected ? 6 : 0}
+      />
+    );
+  }
+
+  const canLabel = element.type === "player" || element.type === "opponent";
+  const editLabel = () => {
+    if (canLabel) onEditLabel(element.id);
+  };
+
+  return (
+    <Group
+      ref={(node) => onRegisterNode(element.id, node)}
+      id={element.id}
+      x={element.x}
+      y={element.y}
+      rotation={element.rotation}
+      draggable={interactive}
+      onClick={select}
+      onTap={select}
+      onDragEnd={handleDragEnd}
+      onDblClick={editLabel}
+      onDblTap={editLabel}
+    >
+      {/* Enlarges the touch/click target well beyond the visible glyph -
+          markers render small relative to the whole pitch, especially on
+          phones, so a bigger hidden hit area keeps them tap/drag-able. */}
+      <Circle radius={POINT_RADIUS * 2.2} fill="rgba(0,0,0,0.001)" />
+      <PointGlyph type={element.type} selected={selected} />
+      {element.label && (
+        <Text
+          text={element.label}
+          fontSize={13}
+          fontStyle="bold"
+          fill="#ffffff"
+          width={POINT_RADIUS * 2}
+          height={POINT_RADIUS * 2}
+          offsetX={POINT_RADIUS}
+          offsetY={POINT_RADIUS}
+          align="center"
+          verticalAlign="middle"
+          listening={false}
+        />
+      )}
+    </Group>
+  );
+}
+
+function PointGlyph({
+  type,
+  selected,
+}: {
+  type: PointElementType;
+  selected: boolean;
+}) {
+  const stroke = selected ? SELECTION_COLOR : "#ffffff";
+  const strokeWidth = selected ? 4 : 2;
+
+  switch (type) {
+    case "player":
+      return (
+        <Circle
+          radius={POINT_RADIUS}
+          fill="#2563eb"
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+    case "opponent":
+      return (
+        <RegularPolygon
+          sides={3}
+          radius={POINT_RADIUS + 5}
+          fill="#dc2626"
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+    case "ball":
+      return (
+        <Group>
+          <Circle
+            radius={POINT_RADIUS * 0.65}
+            fill="#ffffff"
+            stroke={selected ? SELECTION_COLOR : "#111827"}
+            strokeWidth={selected ? 4 : 1.5}
+          />
+          <RegularPolygon sides={5} radius={POINT_RADIUS * 0.3} fill="#111827" />
+        </Group>
+      );
+    case "cone":
+      return (
+        <RegularPolygon
+          sides={3}
+          radius={POINT_RADIUS * 0.9}
+          fill="#f97316"
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+  }
+}

--- a/components/board/BoardSkeleton.tsx
+++ b/components/board/BoardSkeleton.tsx
@@ -1,0 +1,11 @@
+export function BoardSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="h-[76px] animate-pulse rounded-2xl bg-neutral-200 dark:bg-neutral-800" />
+      <div
+        className="w-full animate-pulse rounded-2xl bg-neutral-200 dark:bg-neutral-800"
+        style={{ aspectRatio: "1040 / 680" }}
+      />
+    </div>
+  );
+}

--- a/components/board/BoardToolbar.tsx
+++ b/components/board/BoardToolbar.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { ActiveTool, PitchMode } from "@/lib/board/types";
+import {
+  BallIcon,
+  ConeIcon,
+  OpponentIcon,
+  PassLineIcon,
+  PlayerIcon,
+  RedoIcon,
+  RunArrowIcon,
+  SelectIcon,
+  TrashIcon,
+  UndoIcon,
+} from "./icons";
+
+const TOOLS: { id: ActiveTool; label: string; icon: ReactNode }[] = [
+  { id: "select", label: "Wskaźnik", icon: <SelectIcon /> },
+  { id: "player", label: "Zawodnik", icon: <PlayerIcon /> },
+  { id: "opponent", label: "Przeciwnik", icon: <OpponentIcon /> },
+  { id: "ball", label: "Piłka", icon: <BallIcon /> },
+  { id: "cone", label: "Pachołek", icon: <ConeIcon /> },
+  { id: "arrow", label: "Strzałka ruchu", icon: <RunArrowIcon /> },
+  { id: "passLine", label: "Linia podania", icon: <PassLineIcon /> },
+];
+
+interface BoardToolbarProps {
+  activeTool: ActiveTool;
+  onToolChange: (tool: ActiveTool) => void;
+  pitchMode: PitchMode;
+  onPitchModeChange: (mode: PitchMode) => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  onClear: () => void;
+  hasSelection: boolean;
+  onDeleteSelected: () => void;
+}
+
+export function BoardToolbar({
+  activeTool,
+  onToolChange,
+  pitchMode,
+  onPitchModeChange,
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+  onClear,
+  hasSelection,
+  onDeleteSelected,
+}: BoardToolbarProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-neutral-200 bg-white p-2.5 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex overflow-hidden rounded-full border border-neutral-300 text-sm dark:border-neutral-700">
+          <button
+            type="button"
+            onClick={() => onPitchModeChange("full")}
+            aria-pressed={pitchMode === "full"}
+            className={`px-3 py-1.5 font-medium transition-colors ${
+              pitchMode === "full"
+                ? "bg-emerald-600 text-white"
+                : "hover:bg-neutral-50 dark:hover:bg-neutral-800"
+            }`}
+          >
+            Pełne boisko
+          </button>
+          <button
+            type="button"
+            onClick={() => onPitchModeChange("half")}
+            aria-pressed={pitchMode === "half"}
+            className={`px-3 py-1.5 font-medium transition-colors ${
+              pitchMode === "half"
+                ? "bg-emerald-600 text-white"
+                : "hover:bg-neutral-50 dark:hover:bg-neutral-800"
+            }`}
+          >
+            Połowa boiska
+          </button>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onUndo}
+            disabled={!canUndo}
+            aria-label="Cofnij"
+            title="Cofnij"
+            className="rounded-full border border-neutral-300 p-2 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            <UndoIcon />
+          </button>
+          <button
+            type="button"
+            onClick={onRedo}
+            disabled={!canRedo}
+            aria-label="Ponów"
+            title="Ponów"
+            className="rounded-full border border-neutral-300 p-2 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            <RedoIcon />
+          </button>
+          <button
+            type="button"
+            onClick={onDeleteSelected}
+            disabled={!hasSelection}
+            aria-label="Usuń zaznaczony element"
+            title="Usuń zaznaczony element"
+            className="rounded-full border border-neutral-300 p-2 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            <TrashIcon />
+          </button>
+          <button
+            type="button"
+            onClick={onClear}
+            className="rounded-full border border-neutral-300 px-3 py-1.5 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 dark:border-neutral-700 dark:text-red-400 dark:hover:bg-red-950/40"
+          >
+            Wyczyść
+          </button>
+        </div>
+      </div>
+
+      <div className="flex snap-x gap-2 overflow-x-auto pb-1">
+        {TOOLS.map((tool) => (
+          <button
+            key={tool.id}
+            type="button"
+            onClick={() => onToolChange(tool.id)}
+            aria-pressed={activeTool === tool.id}
+            className={`flex shrink-0 snap-start flex-col items-center gap-1 rounded-xl border px-3 py-2 text-xs font-medium transition-colors ${
+              activeTool === tool.id
+                ? "border-emerald-600 bg-emerald-50 text-emerald-700 dark:border-emerald-500 dark:bg-emerald-950/40 dark:text-emerald-400"
+                : "border-transparent text-neutral-600 hover:bg-neutral-50 dark:text-neutral-400 dark:hover:bg-neutral-800"
+            }`}
+          >
+            {tool.icon}
+            {tool.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/board/PitchBackground.tsx
+++ b/components/board/PitchBackground.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { Arc, Circle, Group, Layer, Line, Rect } from "react-konva";
+import type { PitchMode } from "@/lib/board/types";
+
+const MARGIN = 24;
+const LINE_COLOR = "#f8fafc";
+const LINE_WIDTH = 3;
+const TURF_DARK = "#1f8a4c";
+const TURF_LIGHT = "#22994f";
+
+export function PitchBackground({
+  mode,
+  width,
+  height,
+}: {
+  mode: PitchMode;
+  width: number;
+  height: number;
+}) {
+  return (
+    <Layer listening={false}>
+      <Turf width={width} height={height} />
+      <Rect
+        x={MARGIN}
+        y={MARGIN}
+        width={width - MARGIN * 2}
+        height={height - MARGIN * 2}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      {mode === "full" ? (
+        <FullPitchMarkings width={width} height={height} />
+      ) : (
+        <HalfPitchMarkings width={width} height={height} />
+      )}
+    </Layer>
+  );
+}
+
+function Turf({ width, height }: { width: number; height: number }) {
+  const stripeCount = 8;
+  const stripeWidth = width / stripeCount;
+  return (
+    <Group>
+      <Rect x={0} y={0} width={width} height={height} fill={TURF_DARK} />
+      {Array.from({ length: stripeCount }, (_, i) =>
+        i % 2 === 0 ? (
+          <Rect
+            key={i}
+            x={i * stripeWidth}
+            y={0}
+            width={stripeWidth}
+            height={height}
+            fill={TURF_LIGHT}
+          />
+        ) : null,
+      )}
+    </Group>
+  );
+}
+
+// x = pitch length axis, y = pitch width axis (touchline to touchline).
+function FullPitchMarkings({
+  width,
+  height,
+}: {
+  width: number;
+  height: number;
+}) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const scaleX = playW / 105;
+  const scaleY = playH / 68;
+  const avgScale = (scaleX + scaleY) / 2;
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  const boxDepth = 16.5 * scaleX;
+  const boxHalfWidth = 20.16 * scaleY;
+  const sixDepth = 5.5 * scaleX;
+  const sixHalfWidth = 9.16 * scaleY;
+  const spotOffset = 11 * scaleX;
+  const arcRadius = 9.15 * avgScale;
+  const goalHalfWidth = 3.66 * scaleY;
+  const goalDepth = 2 * scaleX;
+
+  return (
+    <Group>
+      <Line
+        points={[centerX, MARGIN, centerX, height - MARGIN]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle
+        x={centerX}
+        y={centerY}
+        radius={arcRadius}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle x={centerX} y={centerY} radius={3} fill={LINE_COLOR} />
+
+      {[
+        { goalX: MARGIN, dir: 1 },
+        { goalX: width - MARGIN, dir: -1 },
+      ].map(({ goalX, dir }) => (
+        <Group key={goalX}>
+          <Rect
+            x={dir === 1 ? goalX : goalX - boxDepth}
+            y={centerY - boxHalfWidth}
+            width={boxDepth}
+            height={boxHalfWidth * 2}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH}
+          />
+          <Rect
+            x={dir === 1 ? goalX : goalX - sixDepth}
+            y={centerY - sixHalfWidth}
+            width={sixDepth}
+            height={sixHalfWidth * 2}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH}
+          />
+          <Circle
+            x={goalX + dir * spotOffset}
+            y={centerY}
+            radius={3}
+            fill={LINE_COLOR}
+          />
+          <Arc
+            x={goalX + dir * spotOffset}
+            y={centerY}
+            innerRadius={arcRadius}
+            outerRadius={arcRadius}
+            rotation={dir === 1 ? -53 : 127}
+            angle={106}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH}
+          />
+          <Rect
+            x={dir === 1 ? goalX - goalDepth : goalX}
+            y={centerY - goalHalfWidth}
+            width={goalDepth}
+            height={goalHalfWidth * 2}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH}
+          />
+          <Arc
+            x={goalX}
+            y={dir === 1 ? MARGIN : height - MARGIN}
+            innerRadius={2 * avgScale}
+            outerRadius={2 * avgScale}
+            rotation={dir === 1 ? 0 : 180}
+            angle={90}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH}
+          />
+          <Arc
+            x={goalX}
+            y={dir === 1 ? height - MARGIN : MARGIN}
+            innerRadius={2 * avgScale}
+            outerRadius={2 * avgScale}
+            rotation={dir === 1 ? -90 : 90}
+            angle={90}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH}
+          />
+        </Group>
+      ))}
+    </Group>
+  );
+}
+
+// x = pitch width axis (touchline to touchline), y = half-length axis.
+// Halfway line sits at the top, goal line at the bottom.
+function HalfPitchMarkings({
+  width,
+  height,
+}: {
+  width: number;
+  height: number;
+}) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const scaleX = playW / 68;
+  const scaleY = playH / 55;
+  const avgScale = (scaleX + scaleY) / 2;
+  const centerX = width / 2;
+  const goalY = height - MARGIN;
+
+  const boxDepth = 16.5 * scaleY;
+  const boxHalfWidth = 20.16 * scaleX;
+  const sixDepth = 5.5 * scaleY;
+  const sixHalfWidth = 9.16 * scaleX;
+  const spotOffset = 11 * scaleY;
+  const arcRadius = 9.15 * avgScale;
+  const goalHalfWidth = 3.66 * scaleX;
+  const goalDepth = 2 * scaleY;
+  const spotY = goalY - spotOffset;
+
+  return (
+    <Group>
+      <Arc
+        x={centerX}
+        y={MARGIN}
+        innerRadius={arcRadius}
+        outerRadius={arcRadius}
+        rotation={0}
+        angle={180}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Rect
+        x={centerX - boxHalfWidth}
+        y={goalY - boxDepth}
+        width={boxHalfWidth * 2}
+        height={boxDepth}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Rect
+        x={centerX - sixHalfWidth}
+        y={goalY - sixDepth}
+        width={sixHalfWidth * 2}
+        height={sixDepth}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle x={centerX} y={spotY} radius={3} fill={LINE_COLOR} />
+      <Arc
+        x={centerX}
+        y={spotY}
+        innerRadius={arcRadius}
+        outerRadius={arcRadius}
+        rotation={217}
+        angle={106}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Rect
+        x={centerX - goalHalfWidth}
+        y={goalY}
+        width={goalHalfWidth * 2}
+        height={goalDepth}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Arc
+        x={MARGIN}
+        y={goalY}
+        innerRadius={2 * avgScale}
+        outerRadius={2 * avgScale}
+        rotation={180}
+        angle={90}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Arc
+        x={width - MARGIN}
+        y={goalY}
+        innerRadius={2 * avgScale}
+        outerRadius={2 * avgScale}
+        rotation={90}
+        angle={90}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+    </Group>
+  );
+}

--- a/components/board/TacticsBoard.tsx
+++ b/components/board/TacticsBoard.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import type Konva from "konva";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { Arrow, Layer, Stage, Transformer } from "react-konva";
+import {
+  createLineElementFromDrag,
+  createPointElement,
+  isLineElementType,
+  MIN_LINE_LENGTH,
+} from "@/lib/board/elements";
+import {
+  boardHistoryReducer,
+  initialBoardHistoryState,
+} from "@/lib/board/historyReducer";
+import { PITCH_DIMENSIONS } from "@/lib/board/pitch";
+import {
+  isLineElement,
+  type ActiveTool,
+  type LineElementType,
+  type PitchMode,
+} from "@/lib/board/types";
+import { BoardElementNode } from "./BoardElementNode";
+import { BoardToolbar } from "./BoardToolbar";
+import { PitchBackground } from "./PitchBackground";
+
+type PendingAction = { type: "clear" } | { type: "pitch"; mode: PitchMode };
+
+interface DrawingLine {
+  type: LineElementType;
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+}
+
+export function TacticsBoard() {
+  const [history, dispatch] = useReducer(
+    boardHistoryReducer,
+    initialBoardHistoryState,
+  );
+  const [pitchMode, setPitchMode] = useState<PitchMode>("full");
+  const [activeTool, setActiveTool] = useState<ActiveTool>("select");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(
+    null,
+  );
+  const [drawingLine, setDrawingLine] = useState<DrawingLine | null>(null);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const stageRef = useRef<Konva.Stage>(null);
+  const transformerRef = useRef<Konva.Transformer>(null);
+  const nodesRef = useRef(new Map<string, Konva.Node>());
+
+  const dims = PITCH_DIMENSIONS[pitchMode];
+  const scale = containerSize.width > 0 ? containerSize.width / dims.width : 1;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setContainerSize({ width, height });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const registerNode = useCallback((id: string, node: Konva.Node | null) => {
+    if (node) nodesRef.current.set(id, node);
+    else nodesRef.current.delete(id);
+  }, []);
+
+  useEffect(() => {
+    const tr = transformerRef.current;
+    if (!tr) return;
+    const el = history.present.find((item) => item.id === selectedId);
+    if (el && isLineElement(el)) {
+      const node = nodesRef.current.get(el.id);
+      tr.nodes(node ? [node] : []);
+    } else {
+      tr.nodes([]);
+    }
+    tr.getLayer()?.batchDraw();
+  }, [selectedId, history.present]);
+
+  const handleDeleteSelected = useCallback(() => {
+    setSelectedId((current) => {
+      if (current) dispatch({ type: "delete", id: current });
+      return null;
+    });
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      ) {
+        return;
+      }
+      if (pendingAction) {
+        if (e.key === "Escape") setPendingAction(null);
+        return;
+      }
+      if (e.key === "Delete" || e.key === "Backspace") {
+        e.preventDefault();
+        handleDeleteSelected();
+      } else if (e.key === "Escape") {
+        setSelectedId(null);
+        setActiveTool("select");
+        setDrawingLine(null);
+      } else if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z") {
+        e.preventDefault();
+        dispatch({ type: e.shiftKey ? "redo" : "undo" });
+      } else if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "y") {
+        e.preventDefault();
+        dispatch({ type: "redo" });
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handleDeleteSelected, pendingAction]);
+
+  function getPointer() {
+    return stageRef.current?.getRelativePointerPosition() ?? null;
+  }
+
+  function handleToolChange(tool: ActiveTool) {
+    setActiveTool(tool);
+    setDrawingLine(null);
+  }
+
+  function handleStageClick(
+    e: Konva.KonvaEventObject<MouseEvent | TouchEvent>,
+  ) {
+    if (e.target !== stageRef.current) return;
+    if (activeTool === "select") {
+      setSelectedId(null);
+      return;
+    }
+    if (isLineElementType(activeTool)) return;
+    const pos = getPointer();
+    if (!pos) return;
+    const el = createPointElement(activeTool, pos.x, pos.y);
+    dispatch({ type: "add", element: el });
+    setSelectedId(el.id);
+  }
+
+  function handleStagePointerDown(
+    e: Konva.KonvaEventObject<MouseEvent | TouchEvent>,
+  ) {
+    if (activeTool === "select" || !isLineElementType(activeTool)) return;
+    if (e.target !== stageRef.current) return;
+    const pos = getPointer();
+    if (!pos) return;
+    setDrawingLine({ type: activeTool, start: pos, end: pos });
+  }
+
+  function handleStagePointerMove(
+    e: Konva.KonvaEventObject<MouseEvent | TouchEvent>,
+  ) {
+    if (!drawingLine) return;
+    e.evt.preventDefault();
+    const pos = getPointer();
+    if (!pos) return;
+    setDrawingLine((current) => (current ? { ...current, end: pos } : current));
+  }
+
+  function handleStagePointerUp() {
+    if (!drawingLine) return;
+    const el = createLineElementFromDrag(
+      drawingLine.type,
+      drawingLine.start,
+      drawingLine.end,
+    );
+    dispatch({ type: "add", element: el });
+    setSelectedId(el.id);
+    setDrawingLine(null);
+    setActiveTool("select");
+  }
+
+  function handleElementDragEnd(id: string, pos: { x: number; y: number }) {
+    dispatch({ type: "update", id, patch: { x: pos.x, y: pos.y } });
+  }
+
+  function handleTransformEnd() {
+    const node = transformerRef.current?.nodes()[0];
+    if (!node || !selectedId) return;
+    const scaleX = node.scaleX();
+    node.scaleX(1);
+    node.scaleY(1);
+    const el = history.present.find((item) => item.id === selectedId);
+    if (!el || !isLineElement(el)) return;
+    const newLength = Math.max(el.endX * scaleX, MIN_LINE_LENGTH);
+    dispatch({
+      type: "update",
+      id: selectedId,
+      patch: {
+        x: node.x(),
+        y: node.y(),
+        rotation: node.rotation(),
+        endX: newLength,
+        endY: 0,
+      },
+    });
+  }
+
+  function handleEditLabel(id: string) {
+    const el = history.present.find((item) => item.id === id);
+    if (!el || isLineElement(el)) return;
+    const next = window.prompt("Numer / etykieta zawodnika", el.label);
+    if (next === null) return;
+    dispatch({ type: "update", id, patch: { label: next.trim().slice(0, 3) } });
+  }
+
+  function handlePitchModeChange(mode: PitchMode) {
+    if (mode === pitchMode) return;
+    if (history.present.length === 0) {
+      setPitchMode(mode);
+      return;
+    }
+    setPendingAction({ type: "pitch", mode });
+  }
+
+  function handleClearRequest() {
+    if (history.present.length === 0) return;
+    setPendingAction({ type: "clear" });
+  }
+
+  function confirmPendingAction() {
+    if (!pendingAction) return;
+    if (pendingAction.type === "pitch") setPitchMode(pendingAction.mode);
+    dispatch({ type: "clear" });
+    setSelectedId(null);
+    setPendingAction(null);
+  }
+
+  // Frozen while a destructive action (clear / pitch switch) awaits
+  // confirmation, so nothing drawn in the meantime can be silently wiped
+  // out by a stale "Tak".
+  const frozenClassName = pendingAction
+    ? "pointer-events-none opacity-60"
+    : undefined;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className={frozenClassName}>
+        <BoardToolbar
+          activeTool={activeTool}
+          onToolChange={handleToolChange}
+          pitchMode={pitchMode}
+          onPitchModeChange={handlePitchModeChange}
+          canUndo={history.past.length > 0}
+          canRedo={history.future.length > 0}
+          onUndo={() => dispatch({ type: "undo" })}
+          onRedo={() => dispatch({ type: "redo" })}
+          onClear={handleClearRequest}
+          hasSelection={selectedId !== null}
+          onDeleteSelected={handleDeleteSelected}
+        />
+      </div>
+
+      {pendingAction && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-2.5 text-sm dark:border-amber-900/50 dark:bg-amber-950/30">
+          <span className="text-amber-800 dark:text-amber-300">
+            {pendingAction.type === "clear"
+              ? "Na pewno wyczyścić całą tablicę?"
+              : "Zmiana boiska wyczyści obecny rysunek. Kontynuować?"}
+          </span>
+          <div className="flex shrink-0 gap-2">
+            <button
+              type="button"
+              onClick={confirmPendingAction}
+              className="rounded-full bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-500"
+            >
+              Tak
+            </button>
+            <button
+              type="button"
+              onClick={() => setPendingAction(null)}
+              className="rounded-full border border-neutral-300 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+            >
+              Anuluj
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div
+        ref={containerRef}
+        className={`w-full touch-none overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950 ${frozenClassName ?? ""}`}
+        style={{ aspectRatio: `${dims.width} / ${dims.height}` }}
+      >
+        {containerSize.width > 0 && (
+          <Stage
+            ref={stageRef}
+            width={containerSize.width}
+            height={containerSize.height}
+            scaleX={scale}
+            scaleY={scale}
+            onClick={handleStageClick}
+            onTap={handleStageClick}
+            onMouseDown={handleStagePointerDown}
+            onTouchStart={handleStagePointerDown}
+            onMouseMove={handleStagePointerMove}
+            onTouchMove={handleStagePointerMove}
+            onMouseUp={handleStagePointerUp}
+            onTouchEnd={handleStagePointerUp}
+          >
+            <PitchBackground
+              mode={pitchMode}
+              width={dims.width}
+              height={dims.height}
+            />
+            <Layer>
+              {history.present.map((el) => (
+                <BoardElementNode
+                  key={el.id}
+                  element={el}
+                  selected={el.id === selectedId}
+                  interactive={activeTool === "select"}
+                  onSelect={setSelectedId}
+                  onDragEnd={handleElementDragEnd}
+                  onRegisterNode={registerNode}
+                  onEditLabel={handleEditLabel}
+                />
+              ))}
+              {drawingLine && (
+                <Arrow
+                  points={[
+                    drawingLine.start.x,
+                    drawingLine.start.y,
+                    drawingLine.end.x,
+                    drawingLine.end.y,
+                  ]}
+                  stroke={drawingLine.type === "passLine" ? "#7c3aed" : "#111827"}
+                  fill={drawingLine.type === "passLine" ? "#7c3aed" : "#111827"}
+                  dash={drawingLine.type === "passLine" ? [14, 10] : undefined}
+                  strokeWidth={4}
+                  pointerLength={14}
+                  pointerWidth={14}
+                  listening={false}
+                  opacity={0.85}
+                />
+              )}
+              <Transformer
+                ref={transformerRef}
+                rotateEnabled
+                enabledAnchors={["middle-left", "middle-right"]}
+                anchorSize={24}
+                anchorCornerRadius={12}
+                rotateAnchorOffset={36}
+                borderStroke="#fbbf24"
+                anchorStroke="#fbbf24"
+                anchorFill="#ffffff"
+                onTransformEnd={handleTransformEnd}
+              />
+            </Layer>
+          </Stage>
+        )}
+      </div>
+
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+        Wskazówka: dwukrotne dotknięcie zawodnika lub przeciwnika nadaje mu
+        numer. Zaznaczoną strzałkę obracasz i skracasz uchwytami na jej
+        końcach.
+      </p>
+    </div>
+  );
+}

--- a/components/board/TacticsBoardLoader.tsx
+++ b/components/board/TacticsBoardLoader.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+// Konva/react-konva touch the canvas APIs at import time, so the editor
+// is loaded client-only and dynamically - it must never be part of the
+// server render.
+import dynamic from "next/dynamic";
+import { BoardSkeleton } from "./BoardSkeleton";
+
+const TacticsBoard = dynamic(
+  () => import("./TacticsBoard").then((mod) => mod.TacticsBoard),
+  { ssr: false, loading: () => <BoardSkeleton /> },
+);
+
+export function TacticsBoardLoader() {
+  return <TacticsBoard />;
+}

--- a/components/board/icons.tsx
+++ b/components/board/icons.tsx
@@ -1,0 +1,143 @@
+export function SelectIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M5 3l14 8-6 1.5L11 19z"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function PlayerIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <circle cx="12" cy="12" r="9" fill="#2563eb" stroke="#fff" strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+export function OpponentIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M12 2.5l10 18H2z"
+        fill="#dc2626"
+        stroke="#fff"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function BallIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <circle cx="12" cy="12" r="9" fill="#ffffff" stroke="#111827" strokeWidth="1.4" />
+      <path d="M12 8l3.2 2.3-1.2 3.7h-4l-1.2-3.7z" fill="#111827" />
+    </svg>
+  );
+}
+
+export function ConeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M12 3l6 18H6z"
+        fill="#f97316"
+        stroke="#fff"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function RunArrowIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <line x1="3" y1="18" x2="18" y2="6" stroke="#111827" strokeWidth="2.5" />
+      <path d="M11 5h8v8z" fill="#111827" />
+    </svg>
+  );
+}
+
+export function PassLineIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <line
+        x1="3"
+        y1="18"
+        x2="18"
+        y2="6"
+        stroke="#7c3aed"
+        strokeWidth="2.5"
+        strokeDasharray="4 3"
+      />
+      <path d="M11 5h8v8z" fill="#7c3aed" />
+    </svg>
+  );
+}
+
+export function UndoIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5">
+      <path
+        d="M7 8H4V5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4 8c1.8-2.6 4.6-4 7.5-4A8.5 8.5 0 1 1 4.4 15.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function RedoIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5 -scale-x-100">
+      <path
+        d="M7 8H4V5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4 8c1.8-2.6 4.6-4 7.5-4A8.5 8.5 0 1 1 4.4 15.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function TrashIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5">
+      <path
+        d="M4 7h16M9 7V4h6v3m-8 0 1 13h8l1-13"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/lib/board/elements.ts
+++ b/lib/board/elements.ts
@@ -1,0 +1,75 @@
+import type {
+  BoardElement,
+  BoardElementType,
+  LineElementType,
+  PointElementType,
+} from "./types";
+
+export const POINT_RADIUS = 18;
+export const DEFAULT_LINE_LENGTH = 110;
+export const MIN_LINE_LENGTH = 24;
+
+const LINE_TYPES: LineElementType[] = ["arrow", "passLine"];
+
+export function isLineElementType(
+  type: BoardElementType,
+): type is LineElementType {
+  return (LINE_TYPES as string[]).includes(type);
+}
+
+function createId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createPointElement(
+  type: PointElementType,
+  x: number,
+  y: number,
+): BoardElement {
+  return { id: createId(), type, x, y, rotation: 0, label: "" };
+}
+
+/**
+ * Line/arrow elements always store their local vector as a horizontal
+ * segment (endY = 0) with the visual direction fully captured by
+ * `rotation`. This keeps the Konva Transformer's left/right anchors
+ * (used to reshape length) aligned with the line's own axis instead of
+ * the stage's, regardless of which way the arrow points.
+ */
+export function createLineElement(
+  type: LineElementType,
+  x: number,
+  y: number,
+  length: number = DEFAULT_LINE_LENGTH,
+  rotationDeg: number = 0,
+): BoardElement {
+  return {
+    id: createId(),
+    type,
+    x,
+    y,
+    rotation: rotationDeg,
+    endX: length,
+    endY: 0,
+  };
+}
+
+export function createLineElementFromDrag(
+  type: LineElementType,
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): BoardElement {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const dragLength = Math.hypot(dx, dy);
+  // A tap without a meaningful drag (dragLength below the minimum) falls
+  // back to the roomier default length instead of a barely-visible stub -
+  // coaches often tap a line tool once before discovering the drag gesture.
+  if (dragLength < MIN_LINE_LENGTH) {
+    return createLineElement(type, start.x, start.y);
+  }
+  const rotationDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
+  return createLineElement(type, start.x, start.y, dragLength, rotationDeg);
+}

--- a/lib/board/historyReducer.ts
+++ b/lib/board/historyReducer.ts
@@ -1,0 +1,75 @@
+import type { BoardElement } from "./types";
+
+export interface BoardHistoryState {
+  past: BoardElement[][];
+  present: BoardElement[];
+  future: BoardElement[][];
+}
+
+export type BoardHistoryAction =
+  | { type: "add"; element: BoardElement }
+  | { type: "update"; id: string; patch: Partial<BoardElement> }
+  | { type: "delete"; id: string }
+  | { type: "clear" }
+  | { type: "undo" }
+  | { type: "redo" };
+
+export const initialBoardHistoryState: BoardHistoryState = {
+  past: [],
+  present: [],
+  future: [],
+};
+
+const MAX_HISTORY = 50;
+
+function commit(
+  state: BoardHistoryState,
+  present: BoardElement[],
+): BoardHistoryState {
+  const past = [...state.past, state.present].slice(-MAX_HISTORY);
+  return { past, present, future: [] };
+}
+
+export function boardHistoryReducer(
+  state: BoardHistoryState,
+  action: BoardHistoryAction,
+): BoardHistoryState {
+  switch (action.type) {
+    case "add":
+      return commit(state, [...state.present, action.element]);
+    case "update":
+      return commit(
+        state,
+        state.present.map((el) =>
+          el.id === action.id ? ({ ...el, ...action.patch } as BoardElement) : el,
+        ),
+      );
+    case "delete":
+      return commit(
+        state,
+        state.present.filter((el) => el.id !== action.id),
+      );
+    case "clear":
+      return state.present.length === 0 ? state : commit(state, []);
+    case "undo": {
+      if (state.past.length === 0) return state;
+      const previous = state.past[state.past.length - 1];
+      return {
+        past: state.past.slice(0, -1),
+        present: previous,
+        future: [state.present, ...state.future],
+      };
+    }
+    case "redo": {
+      if (state.future.length === 0) return state;
+      const [next, ...rest] = state.future;
+      return {
+        past: [...state.past, state.present],
+        present: next,
+        future: rest,
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/lib/board/pitch.ts
+++ b/lib/board/pitch.ts
@@ -1,0 +1,16 @@
+import type { PitchMode } from "./types";
+
+interface PitchDimensions {
+  width: number;
+  height: number;
+}
+
+// Logical (unscaled) pitch sizes. The stage is scaled to fit its container,
+// so these only need to keep a sensible aspect ratio - not real meters.
+export const PITCH_DIMENSIONS: Record<PitchMode, PitchDimensions> = {
+  full: { width: 1040, height: 680 },
+  half: { width: 680, height: 540 },
+};
+
+export const PITCH_LINE_COLOR = "#e5e7eb";
+export const PITCH_FILL_COLOR = "#1f8a4c";

--- a/lib/board/types.ts
+++ b/lib/board/types.ts
@@ -1,0 +1,40 @@
+export type PointElementType = "player" | "opponent" | "ball" | "cone";
+export type LineElementType = "arrow" | "passLine";
+export type BoardElementType = PointElementType | LineElementType;
+
+export type PitchMode = "full" | "half";
+
+export type ActiveTool = "select" | BoardElementType;
+
+interface BoardElementBase {
+  id: string;
+  x: number;
+  y: number;
+  rotation: number;
+}
+
+export interface PointBoardElement extends BoardElementBase {
+  type: PointElementType;
+  label: string;
+}
+
+export interface LineBoardElement extends BoardElementBase {
+  type: LineElementType;
+  /** End point of the line/arrow, relative to (x, y), before rotation. */
+  endX: number;
+  endY: number;
+}
+
+export type BoardElement = PointBoardElement | LineBoardElement;
+
+export function isLineElement(
+  element: BoardElement,
+): element is LineBoardElement {
+  return element.type === "arrow" || element.type === "passLine";
+}
+
+export function isPointElement(
+  element: BoardElement,
+): element is PointBoardElement {
+  return !isLineElement(element);
+}

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "@react-pdf/renderer": "^4.5.1",
     "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.110.1",
+    "konva": "^10.3.0",
     "next": "15.5.20",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-konva": "^19.2.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.110.1
         version: 2.110.1
+      konva:
+        specifier: ^10.3.0
+        version: 10.3.0
       next:
         specifier: 15.5.20
         version: 15.5.20(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -35,6 +38,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-konva:
+        specifier: ^19.2.5
+        version: 19.2.5(@types/react@19.2.17)(konva@10.3.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -624,6 +630,16 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
+  '@types/react-reconciler@0.33.0':
+    resolution: {integrity: sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
@@ -1505,6 +1521,11 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
+
   jay-peg@1.1.1:
     resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
 
@@ -1541,6 +1562,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  konva@10.3.0:
+    resolution: {integrity: sha512-gt19K2gzY4lHbnkvsku7eSmB+A9PTS2jG4F9coBMsdjM1UKfJNxJbDbXVpeCW1wjEGRwBD3nBamcHnqJhAeKlg==}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -1844,6 +1868,19 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-konva@19.2.5:
+    resolution: {integrity: sha512-AdsuDB59GdB86QdenTAqRzr6Tfw3z9x9Opxo4BoqDjdNLsjekF9a1VhN4FlMPvg0qtrMl3d4dNmagaUTGH7fSA==}
+    peerDependencies:
+      konva: ^8.0.1 || ^7.2.5 || ^9.0.0 || ^10.0.0
+      react: ^19.2.0
+      react-dom: ^19.2.0
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -1902,6 +1939,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2653,6 +2693,14 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react-reconciler@0.28.9(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react-reconciler@0.33.0(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
 
@@ -3699,6 +3747,13 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  its-fine@2.0.0(@types/react@19.2.17)(react@19.1.0):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.17)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   jay-peg@1.1.1:
     dependencies:
       restructure: 3.0.2
@@ -3733,6 +3788,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  konva@10.3.0: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -4008,6 +4065,23 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-konva@19.2.5(@types/react@19.2.17)(konva@10.3.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@types/react-reconciler': 0.33.0(@types/react@19.2.17)
+      its-fine: 2.0.0(@types/react@19.2.17)(react@19.1.0)
+      konva: 10.3.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-reconciler: 0.33.0(react@19.1.0)
+      scheduler: 0.27.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  react-reconciler@0.33.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.27.0
+
   react@19.1.0: {}
 
   reflect.getprototypeof@1.0.10:
@@ -4077,6 +4151,8 @@ snapshots:
   scheduler@0.25.0-rc-603e6108-20241029: {}
 
   scheduler@0.26.0: {}
+
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
## Summary

Round 9, Part 1: the interactive tactics board editor, in isolation. This replaces the "redraw the drill in MS Paint" workflow with a real canvas — pitch, players, opponents, ball, cones, movement arrows, and pass lines, all touch-first.

- New sandbox route `/app/board` (behind the existing `/app` auth middleware), linked from the app nav and home page.
- Built on **react-konva** (Konva.js), loaded client-only via `next/dynamic({ ssr: false })` so the canvas library never touches the server render — confirmed the `/app/board` route ships only ~1.5 kB of its own JS, with Konva itself code-split into the client bundle.
- **Pitch background**: full pitch and half pitch, toggleable, drawn as vector Konva shapes (touchlines, halfway line/circle, penalty areas, six-yard boxes, penalty arcs, corner arcs, goals). No image assets.
- **Tools**: Zawodnik (player), Przeciwnik (opponent, red triangle for a clear shape+color distinction), Piłka (ball), Pachołek (cone), Strzałka ruchu (solid movement arrow), Linia podania (dashed pass line) — a compact, horizontally scrollable tool row so it doesn't crowd the canvas on a phone.
- **Manipulation**: click/tap a tool then the canvas to place; select/drag any element; arrows and pass lines rotate and reshape via a Konva Transformer (drag the endpoint handles to change length, the separate rotate handle to turn); double-tap a player/opponent to give it a number (via a simple prompt, intentionally lightweight for this round); Delete key or toolbar button removes the selection; keyboard shortcuts for undo/redo/delete/escape.
- **Undo/redo**: full history stack (`lib/board/historyReducer.ts`), capped at 50 steps.
- **Clear all** and **pitch-mode switch** both show an inline confirmation, and the board visually freezes (dimmed, non-interactive) while that confirmation is pending, so nothing drawn in the meantime can be silently wiped by a stale "Tak".
- **Touch-first**: `touch-action: none` on the canvas, mouse+touch event pairs wired for every gesture (tap-to-place, drag-to-reposition, drag-to-draw a line, double-tap-to-label), and markers carry an enlarged invisible hit target (point markers render quite small relative to the whole pitch, especially in full-pitch mode on a phone).

## Explicitly NOT in this PR

No PNG export, no Supabase Storage, no saving, no attaching to exercises, no `media_url` — that's Round 10, once the drawing experience itself is confirmed good. No formations presets, no animation, no other-sport pitches yet.

## How I tested this

No Supabase project is available in this sandbox, so I could not exercise the real `/app/board` route behind live auth end-to-end. I verified the editor itself by temporarily mounting `<TacticsBoardLoader />` on an unauthenticated route with dummy Supabase env vars (both removed before committing — not part of this diff) and drove it with Playwright:

- **Desktop (mouse)**: placed every element type, drew both arrow types, selected/dragged a player, dragged the transformer's length handle (confirmed it resizes without rotating) and its separate rotate handle (confirmed ~130° rotation), double-click labeling, undo/redo, pitch-mode-switch confirmation, clear-all confirmation — all screenshotted and correct.
- **Mobile (iPhone 13 viewport + touch emulation, including raw CDP `Input.dispatchTouchEvent` for drag gestures, not just `tap()`)**: tap-to-place, touch-drag to reposition a player, touch-drag to draw an arrow, double-tap to label, tap-to-select an arrow and confirm the transformer handles render at a sane, constant size regardless of canvas scale (this was a real bug I caught and fixed — Konva's Transformer already compensates for stage scale internally, so my first attempt at scale-correcting the anchor size double-corrected and produced anchors ~10x too large).
- Also caught and fixed: a plain tap (no drag) with an arrow/pass-line tool selected was producing a nearly-invisible 24-unit stub instead of a usable default-length arrow.

**What I could not verify**: real multi-touch gestures (pinch, two-finger pan — not that any are implemented), real-device touch latency/feel, and the actual `/app/board` route behind live Supabase auth on Vercel. Please check the touch feel on your phone in particular — that's the part CDP-simulated touch can't fully stand in for.

## Manual test script (for the live site)

1. Log in, go to **Tablica taktyczna** in the nav (or `/app/board`).
2. Toggle **Pełne boisko** / **Połowa boiska** — pitch markings redraw; if you have anything drawn, you should get a "Zmiana boiska wyczyści obecny rysunek" confirmation first.
3. Tap **Zawodnik**, tap the pitch a few times — blue circles appear, tool stays active so you can place several in a row.
4. Tap **Przeciwnik**, **Piłka**, **Pachołek** — each places its distinct marker.
5. Tap **Strzałka ruchu**, then **press-drag-release** on the pitch — a solid black arrow is drawn along the drag; a plain tap (no drag) should still give you a reasonably long default arrow, not a tiny stub.
6. Tap **Linia podania**, drag again — a dashed purple line appears (visually distinct from the movement arrow).
7. Tap **Wskaźnik**, drag any placed element to reposition it.
8. Tap an arrow/pass line to select it — two handles appear at its ends (drag either to change length) plus a separate rotate handle above it (drag to turn it).
9. Double-tap a player or opponent — you're prompted for a number/short label; it renders centered in the marker.
10. Select an element, tap the trash icon (or press Delete/Backspace on desktop) — it's removed.
11. Draw a few things, tap **Cofnij** (undo) / **Ponów** (redo) repeatedly — the board steps backward/forward correctly.
12. Tap **Wyczyść** — a confirmation banner appears and the board dims/locks until you confirm or cancel.
13. **On your phone**: repeat placement, dragging, arrow-drawing, and double-tap-labeling by touch. This is the part I most need you to check — flag anything that feels off (hit targets too small, accidental page scroll while drawing, etc).
14. Resize the browser / rotate your phone to portrait — the toolbar stays a compact scrollable row and the pitch keeps its aspect ratio without crowding out.

## Test plan

- [ ] CI green (lint, typecheck, build)
- [ ] `/app/board` loads behind auth on the deployed preview
- [ ] Manual test script above, especially the touch steps on a real phone


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy8Bf5sMXxVyANfdsSiuDT)_