### PR TITLE
Fix mobile route drawing finalizing early + missing steps in workout PDF

### DIFF
--- a/components/board/TacticsBoard.tsx
+++ b/components/board/TacticsBoard.tsx
@@ -65,6 +65,10 @@ function initHistory(elements: BoardElement[]): BoardHistoryState {
 // upload a needlessly large file - keeps Supabase Storage's free tier cheap.
 const EXPORT_TARGET_WIDTH = 900;
 
+// See lastHandledAtRef below - well under DOUBLE_TAP_MS so it never
+// interferes with a genuine fast double-tap-to-finish.
+const DUPLICATE_EVENT_GUARD_MS = 80;
+
 export interface TacticsBoardHandle {
   isEmpty(): boolean;
   getElements(): BoardElement[];
@@ -123,6 +127,17 @@ export function TacticsBoard({
   const containerRef = useRef<HTMLDivElement>(null);
   const stageRef = useRef<Konva.Stage>(null);
   const lastTapRef = useRef<{ time: number; pos: BoardPoint } | null>(null);
+  // Mobile browsers can deliver more than one Konva event ("tap" and
+  // "click") for a single physical touch, especially when a device's
+  // touch-to-mouse compatibility click isn't fully suppressed. Because
+  // lastTapRef is a ref (mutated synchronously, unlike state), a stray
+  // duplicate of the SAME touch would land right after the real one, see
+  // itself as "the previous tap" at distance 0, and get misread as a
+  // deliberate double-tap - closing the route after just one or two real
+  // points. A genuine human double-tap always has more than a few tens of
+  // milliseconds between the two touches; a synthesized duplicate of the
+  // same touch does not. This guard swallows only the latter.
+  const lastHandledAtRef = useRef(0);
 
   const fieldMode =
     config.fieldModes.find((m) => m.id === fieldModeId) ?? config.fieldModes[0];
@@ -307,6 +322,9 @@ export function TacticsBoard({
     e: Konva.KonvaEventObject<MouseEvent | TouchEvent>,
   ) {
     if (e.target !== stageRef.current) return;
+    const now = Date.now();
+    if (now - lastHandledAtRef.current < DUPLICATE_EVENT_GUARD_MS) return;
+    lastHandledAtRef.current = now;
     if (activeTool === "select") {
       setSelectedId(null);
       setSelectedPointIndex(null);
@@ -371,6 +389,13 @@ export function TacticsBoard({
   // that synthetic follow-up.
   function handleStageTouchStart(e: Konva.KonvaEventObject<TouchEvent>) {
     if (e.evt.cancelable) e.evt.preventDefault();
+  }
+
+  // Belt-and-suspenders alongside the container's touch-none/overscroll
+  // CSS: while a route is being drawn, make sure a finger dragging across
+  // the canvas can never be interpreted as a page scroll/zoom gesture.
+  function handleStageTouchMove(e: Konva.KonvaEventObject<TouchEvent>) {
+    if (drawingPath && e.evt.cancelable) e.evt.preventDefault();
   }
 
   function handleElementDragEnd(id: string, pos: { x: number; y: number }) {
@@ -579,8 +604,12 @@ export function TacticsBoard({
 
       <div
         ref={containerRef}
-        className={`w-full touch-none overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950 ${frozenClassName ?? ""}`}
-        style={{ aspectRatio: `${dims.width} / ${dims.height}` }}
+        className={`w-full touch-none overscroll-contain overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950 ${frozenClassName ?? ""}`}
+        style={{
+          aspectRatio: `${dims.width} / ${dims.height}`,
+          touchAction: "none",
+          overscrollBehavior: "contain",
+        }}
       >
         {containerSize.width > 0 && (
           <Stage
@@ -592,6 +621,7 @@ export function TacticsBoard({
             onClick={handleStageClick}
             onTap={handleStageClick}
             onTouchStart={handleStageTouchStart}
+            onTouchMove={handleStageTouchMove}
             onMouseMove={handleStagePointerMove}
           >
             <config.FieldComponent

--- a/components/workouts/SharedWorkoutView.tsx
+++ b/components/workouts/SharedWorkoutView.tsx
@@ -25,6 +25,8 @@ export function SharedWorkoutView({
     assigned_to: item.assigned_to,
     exerciseTitle: item.exercise?.title ?? "Ćwiczenie niedostępne",
     exerciseDescription: item.exercise?.description ?? null,
+    exerciseSteps: item.exercise?.steps ?? [],
+    exerciseEquipment: item.exercise?.equipment ?? [],
     exerciseMediaUrl: item.exercise?.media_url ?? null,
   }));
 

--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -120,6 +120,8 @@ export function WorkoutBuilder({
           exercisesById[item.exercise_id]?.title ?? "Ćwiczenie niedostępne",
         exerciseDescription:
           exercisesById[item.exercise_id]?.description ?? null,
+        exerciseSteps: exercisesById[item.exercise_id]?.steps ?? [],
+        exerciseEquipment: exercisesById[item.exercise_id]?.equipment ?? [],
         exerciseMediaUrl: exercisesById[item.exercise_id]?.media_url ?? null,
       })),
     [items, exercisesById],

--- a/components/workouts/WorkoutPdfDocument.tsx
+++ b/components/workouts/WorkoutPdfDocument.tsx
@@ -96,9 +96,42 @@ const styles = StyleSheet.create({
     fontSize: 9,
     color: "#404040",
   },
-  itemDiagram: {
+  itemEquipment: {
+    marginTop: 3,
+    fontSize: 8.5,
+    color: "#525252",
+  },
+  itemBody: {
     marginTop: 4,
-    width: 180,
+    flexDirection: "row",
+    gap: 12,
+  },
+  itemDiagram: {
+    width: 160,
+  },
+  itemSteps: {
+    flexGrow: 1,
+    flexShrink: 1,
+  },
+  itemStepsTitle: {
+    fontSize: 10,
+    fontWeight: "bold",
+    marginBottom: 3,
+  },
+  stepRow: {
+    flexDirection: "row",
+    marginBottom: 2,
+  },
+  stepNumber: {
+    fontSize: 8.5,
+    fontWeight: "bold",
+    width: 14,
+  },
+  stepText: {
+    fontSize: 8.5,
+    color: "#404040",
+    flexGrow: 1,
+    flexShrink: 1,
   },
   notes: {
     marginTop: 8,
@@ -181,12 +214,35 @@ export function WorkoutPdfDocument({
                     {description && (
                       <Text style={styles.itemDescription}>{description}</Text>
                     )}
-                    {item.exerciseMediaUrl && (
-                      // eslint-disable-next-line jsx-a11y/alt-text -- this is @react-pdf/renderer's Image (PDF node), not an HTML <img>; it has no alt prop
-                      <Image
-                        src={item.exerciseMediaUrl}
-                        style={styles.itemDiagram}
-                      />
+                    {item.exerciseEquipment.length > 0 && (
+                      <Text style={styles.itemEquipment}>
+                        Sprzęt: {item.exerciseEquipment.join(", ")}
+                      </Text>
+                    )}
+                    {(item.exerciseMediaUrl ||
+                      item.exerciseSteps.length > 0) && (
+                      <View style={styles.itemBody}>
+                        {item.exerciseMediaUrl && (
+                          // eslint-disable-next-line jsx-a11y/alt-text -- this is @react-pdf/renderer's Image (PDF node), not an HTML <img>; it has no alt prop
+                          <Image
+                            src={item.exerciseMediaUrl}
+                            style={styles.itemDiagram}
+                          />
+                        )}
+                        {item.exerciseSteps.length > 0 && (
+                          <View style={styles.itemSteps}>
+                            <Text style={styles.itemStepsTitle}>
+                              Przebieg ćwiczenia
+                            </Text>
+                            {item.exerciseSteps.map((step, i) => (
+                              <View key={i} style={styles.stepRow}>
+                                <Text style={styles.stepNumber}>{i + 1}.</Text>
+                                <Text style={styles.stepText}>{step}</Text>
+                              </View>
+                            ))}
+                          </View>
+                        )}
+                      </View>
                     )}
                   </View>
                 );

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -279,6 +279,8 @@ export interface SharedWorkoutItem {
     id: string;
     title: string;
     description: string | null;
+    steps: string[];
+    equipment: string[];
     media_url: string | null;
   } | null;
 }

--- a/lib/workouts.ts
+++ b/lib/workouts.ts
@@ -76,6 +76,8 @@ export interface PdfWorkoutItem {
   assigned_to: string | null;
   exerciseTitle: string;
   exerciseDescription: string | null;
+  exerciseSteps: string[];
+  exerciseEquipment: string[];
   exerciseMediaUrl: string | null;
 }
 

--- a/supabase/migrations/20260711110400_shared_workout_steps_equipment.sql
+++ b/supabase/migrations/20260711110400_shared_workout_steps_equipment.sql
@@ -1,0 +1,48 @@
+-- Coach Zone — shared workout steps + equipment
+-- Migration 12. Run after 20260711110300_exercise_media_storage.sql.
+
+-- The workout PDF (and the public share page it's built from) never
+-- rendered an exercise's "Przebieg ćwiczenia" steps or its equipment list,
+-- because get_shared_workout() never selected those columns in the first
+-- place - extend the embedded exercise object with both, same reasoning as
+-- migration 10 (media_url).
+create or replace function public.get_shared_workout(p_share_id text)
+returns jsonb
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select jsonb_build_object(
+    'workout', to_jsonb(w.*),
+    'items', coalesce(
+      (
+        select jsonb_agg(
+          to_jsonb(wi.*) || jsonb_build_object(
+            'exercise',
+            case
+              when e.id is null then null
+              else jsonb_build_object(
+                'id', e.id,
+                'title', e.title,
+                'description', e.description,
+                'steps', e.steps,
+                'equipment', e.equipment,
+                'media_url', e.media_url
+              )
+            end
+          )
+          order by wi.section, wi.position
+        )
+        from public.workout_items wi
+        left join public.exercises e on e.id = wi.exercise_id
+        where wi.workout_id = w.id
+      ),
+      '[]'::jsonb
+    )
+  )
+  from public.workouts w
+  where w.share_id = p_share_id;
+$$;
+
+grant execute on function public.get_shared_workout(text) to anon, authenticated;


### PR DESCRIPTION
## Summary

**Bug 1 — "Trasa biegu" finalizing mid-gesture on mobile**
- `handleStageClick` in `TacticsBoard.tsx` is bound to both Konva's `onClick` and `onTap`, and route drawing tracks "was the last tap close in time/position" via a ref (`lastTapRef`) to detect a deliberate double-tap-to-finish. If a single physical touch on mobile ever produces two Konva-level events for the same tap (a known class of issue on some mobile browsers/devices — see konvajs/konva#575, #1162), the second event lands right after the first, matches itself as "the previous tap" at distance 0, and gets misread as a double-tap — closing the route after only one or two real points, with the arrowhead appearing and the tool snapping back to Pointer. This reproduces only on touch because desktop only ever fires a single `click` per interaction.
- Added a short (80ms) duplicate-event guard in `handleStageClick`, well under the 400ms double-tap window, so a genuine double-tap-to-finish still works but a stray duplicate of the same touch is swallowed.
- Hardened touch/scroll handling: explicit `touchAction: 'none'` + `overscrollBehavior: 'contain'` on the canvas wrapper (Tailwind `overscroll-contain` + inline style), and an `onTouchMove` handler that calls `preventDefault()` while a route is actively being drawn, so a finger dragging across the board can never be interpreted as a page scroll/zoom gesture.
- No finalize is (or was) wired to `pointercancel`/`pointerleave`/`mouseleave` — an interrupted touch simply leaves the in-progress route untouched, points and all.
- No hard point limit existed in the drawing code, so nothing needed raising there.

**Bug 2 — Exercise steps missing from the workout PDF**
- Root cause: `get_shared_workout()` (the RPC both the public share page and the PDF export read from) never selected `steps` or `equipment` from `exercises`, so neither ever reached `PdfWorkoutItem`.
- Added a migration (`20260711110400_shared_workout_steps_equipment.sql`) that extends the RPC's embedded exercise object with `steps` and `equipment`.
- Extended `PdfWorkoutItem`/`SharedWorkoutItem` types and both call sites (`WorkoutBuilder.tsx`, `SharedWorkoutView.tsx`) that build the PDF payload.
- `WorkoutPdfDocument.tsx` now renders a manually-numbered "Przebieg ćwiczenia" list (heading omitted when `steps` is empty) next to the tactics-board diagram, plus a "Sprzęt: …" line when `equipment` is present. Uses the already-registered Noto Sans font, so Polish characters render correctly.

## Files changed
- `components/board/TacticsBoard.tsx`
- `components/workouts/WorkoutPdfDocument.tsx`
- `components/workouts/WorkoutBuilder.tsx`
- `components/workouts/SharedWorkoutView.tsx`
- `lib/workouts.ts`
- `lib/supabase/types.ts`
- `supabase/migrations/20260711110400_shared_workout_steps_equipment.sql`

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [ ] On a phone (Android/Chrome), draw a slalom route through 6 cones with vertical movement — verify it doesn't finalize early and the page doesn't scroll
- [ ] Undo/redo a route drawn this way
- [ ] Export a workout PDF with a 3-step exercise — verify steps render; verify an exercise with no steps shows no heading
- [ ] Apply the new Supabase migration to a project and confirm the public share page + PDF both include steps/equipment


---
_Generated by [Claude Code](https://claude.ai/code/session_013w6hipcScVqLbMgQCNph4J)_