### PR TITLE
R12: shared exercise library (read path)

### DIFF
--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { AuthorBadge } from "@/components/exercises/AuthorBadge";
 import { CategoryBadge } from "@/components/exercises/CategoryBadge";
 import { SportBadge } from "@/components/exercises/SportBadge";
 import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
@@ -23,7 +24,11 @@ export default async function ExerciseDetailPage({
 
   const [{ data: exercise, error: exerciseError }, { data: userData }] =
     await Promise.all([
-      supabase.from("exercises").select("*").eq("id", id).maybeSingle(),
+      supabase
+        .from("exercises")
+        .select("*, author:profiles(display_name)")
+        .eq("id", id)
+        .maybeSingle(),
       supabase.auth.getUser(),
     ]);
 
@@ -86,6 +91,10 @@ export default async function ExerciseDetailPage({
             <span className="text-sm text-neutral-500 dark:text-neutral-500">
               {formatDuration(exercise.duration_min)}
             </span>
+            <AuthorBadge
+              authorName={exercise.author?.display_name ?? null}
+              isOwner={isOwner}
+            />
             {!exercise.is_public && (
               <span className="rounded-full bg-neutral-100 px-2.5 py-0.5 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
                 Prywatne

--- a/app/app/exercises/page.tsx
+++ b/app/app/exercises/page.tsx
@@ -10,12 +10,18 @@ export const metadata: Metadata = {
 
 export default async function ExercisesPage() {
   const supabase = await createClient();
-  const [{ data: categories }, { data: sports }] = await Promise.all([
-    supabase.from("categories").select("*").order("id", { ascending: true }),
-    supabase.from("sports").select("*").order("id", { ascending: true }),
-  ]);
+  const [{ data: categories }, { data: sports }, { data: userData }] =
+    await Promise.all([
+      supabase.from("categories").select("*").order("id", { ascending: true }),
+      supabase.from("sports").select("*").order("id", { ascending: true }),
+      supabase.auth.getUser(),
+    ]);
 
   return (
-    <ExercisesLibrary categories={categories ?? []} sports={sports ?? []} />
+    <ExercisesLibrary
+      categories={categories ?? []}
+      sports={sports ?? []}
+      currentUserId={userData.user?.id ?? null}
+    />
   );
 }

--- a/components/exercises/AuthorBadge.tsx
+++ b/components/exercises/AuthorBadge.tsx
@@ -1,0 +1,21 @@
+export function AuthorBadge({
+  authorName,
+  isOwner,
+}: {
+  /** null for official library exercises (author_id is null). */
+  authorName: string | null;
+  isOwner: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="text-xs text-neutral-500 dark:text-neutral-500">
+        {authorName ?? "Oficjalne"}
+      </span>
+      {isOwner && (
+        <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400">
+          Twoje
+        </span>
+      )}
+    </span>
+  );
+}

--- a/components/exercises/ExerciseCard.tsx
+++ b/components/exercises/ExerciseCard.tsx
@@ -1,15 +1,18 @@
 import Link from "next/link";
-import type { Category, Exercise } from "@/lib/supabase/types";
+import type { Category, ExerciseWithAuthor } from "@/lib/supabase/types";
 import { formatDuration } from "@/lib/exercises";
+import { AuthorBadge } from "./AuthorBadge";
 import { CategoryBadge } from "./CategoryBadge";
 import { DifficultyIndicator } from "./DifficultyIndicator";
 
 export function ExerciseCard({
   exercise,
   category,
+  currentUserId,
 }: {
-  exercise: Exercise;
+  exercise: ExerciseWithAuthor;
   category: Category | undefined;
+  currentUserId: string | null;
 }) {
   return (
     <Link
@@ -26,6 +29,10 @@ export function ExerciseCard({
         <span className="text-xs text-neutral-500 dark:text-neutral-500">
           {formatDuration(exercise.duration_min)}
         </span>
+        <AuthorBadge
+          authorName={exercise.author?.display_name ?? null}
+          isOwner={exercise.author_id === currentUserId}
+        />
       </div>
 
       {exercise.description && (

--- a/components/exercises/ExercisesLibrary.tsx
+++ b/components/exercises/ExercisesLibrary.tsx
@@ -6,7 +6,7 @@ import { createClient } from "@/lib/supabase/client";
 import type {
   Category,
   Difficulty,
-  Exercise,
+  ExerciseWithAuthor,
   Sport,
 } from "@/lib/supabase/types";
 import { DIFFICULTY_LABELS, DIFFICULTY_OPTIONS } from "@/lib/exercises";
@@ -14,19 +14,23 @@ import { ExerciseCard } from "./ExerciseCard";
 import { ExerciseCardSkeleton } from "./ExerciseCardSkeleton";
 
 const ALL = "all" as const;
+const MINE = "mine" as const;
 
 export function ExercisesLibrary({
   categories,
   sports,
+  currentUserId,
 }: {
   categories: Category[];
   sports: Sport[];
+  currentUserId: string | null;
 }) {
-  const [exercises, setExercises] = useState<Exercise[] | null>(null);
+  const [exercises, setExercises] = useState<ExerciseWithAuthor[] | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
 
   const [search, setSearch] = useState("");
+  const [scopeFilter, setScopeFilter] = useState<typeof ALL | typeof MINE>(ALL);
   const [sportFilter, setSportFilter] = useState<number | typeof ALL>(ALL);
   const [categoryFilter, setCategoryFilter] = useState<number | typeof ALL>(
     ALL,
@@ -44,7 +48,7 @@ export function ExercisesLibrary({
     const supabase = createClient();
     supabase
       .from("exercises")
-      .select("*")
+      .select("*, author:profiles(display_name)")
       .order("title", { ascending: true })
       .then(({ data, error }) => {
         if (cancelled) return;
@@ -88,6 +92,8 @@ export function ExercisesLibrary({
           `${exercise.title} ${exercise.description ?? ""}`.toLowerCase();
         if (!haystack.includes(query)) return false;
       }
+      if (scopeFilter === MINE && exercise.author_id !== currentUserId)
+        return false;
       if (sportFilter !== ALL && exercise.sport_id !== sportFilter)
         return false;
       if (categoryFilter !== ALL && exercise.category_id !== categoryFilter)
@@ -105,6 +111,8 @@ export function ExercisesLibrary({
   }, [
     exercises,
     search,
+    scopeFilter,
+    currentUserId,
     sportFilter,
     categoryFilter,
     difficultyFilter,
@@ -113,6 +121,7 @@ export function ExercisesLibrary({
 
   function clearAll() {
     setSearch("");
+    setScopeFilter(ALL);
     setSportFilter(ALL);
     setCategoryFilter(ALL);
     setDifficultyFilter(ALL);
@@ -125,6 +134,12 @@ export function ExercisesLibrary({
     activeFilters.push({
       label: `Szukaj: „${trimmedSearch}”`,
       onClear: () => setSearch(""),
+    });
+  }
+  if (scopeFilter === MINE) {
+    activeFilters.push({
+      label: "Zakres: Moje",
+      onClear: () => setScopeFilter(ALL),
     });
   }
   if (sportFilter !== ALL) {
@@ -160,7 +175,8 @@ export function ExercisesLibrary({
             Biblioteka ćwiczeń
           </h1>
           <p className="mt-1 text-neutral-600 dark:text-neutral-400">
-            Przeglądaj oficjalną bibliotekę i twórz własne ćwiczenia.
+            Przeglądaj oficjalną bibliotekę, ćwiczenia innych trenerów i twórz
+            własne.
           </p>
         </div>
         <Link
@@ -189,7 +205,17 @@ export function ExercisesLibrary({
           />
         </div>
 
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          <FilterSelect
+            id="scope-filter"
+            label="Zakres"
+            value={scopeFilter}
+            onChange={(value) => setScopeFilter(value === MINE ? MINE : ALL)}
+            options={[
+              { value: ALL, label: "Wszystkie" },
+              { value: MINE, label: "Moje" },
+            ]}
+          />
           <FilterSelect
             id="sport-filter"
             label="Dyscyplina"
@@ -314,6 +340,7 @@ export function ExercisesLibrary({
                 key={exercise.id}
                 exercise={exercise}
                 category={categoriesById.get(exercise.category_id)}
+                currentUserId={currentUserId}
               />
             ))}
           </div>

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -258,6 +258,14 @@ export interface Database {
 }
 
 export type Exercise = Database["public"]["Tables"]["exercises"]["Row"];
+
+// Exercise row with the author's display name embedded via the
+// exercises_author_id_fkey relationship (`author:profiles(display_name)`).
+// author is null for official library exercises (author_id is null there).
+export type ExerciseWithAuthor = Exercise & {
+  author: { display_name: string } | null;
+};
+
 export type Category = Database["public"]["Tables"]["categories"]["Row"];
 export type Sport = Database["public"]["Tables"]["sports"]["Row"];
 export type Workout = Database["public"]["Tables"]["workouts"]["Row"];


### PR DESCRIPTION
## Summary

Recon found the database side of this round was already done in R10/R11 — the `exercises` SELECT policy, `exercise-media` storage read access, and `profiles` read access already support the shared library. **No migration is included; see the recon report below for exactly which existing migrations already satisfy each requirement.**

The remaining gap was entirely in the UI:
- Added a "Zakres" (scope) filter to the exercise library — Wszystkie (default) / Moje — that composes with the existing sport/category/difficulty/equipment filters.
- Exercise queries (library list + detail page) now embed the author's `display_name` via `author:profiles(display_name)`.
- New `AuthorBadge` component shows the author's name on cards and the detail page, with a "Twoje" badge for the current coach's own exercises, and "Oficjalne" for the seeded library (`author_id` null).
- Verified the existing "Duplikuj" flow already works correctly on someone else's public exercise: the insert always sets `author_id` to the current user, and `board_state` is carried into the new row regardless of who authored the original.
- Verified "Usuń" was already hidden (and RLS-blocked) for exercises the current user doesn't own.

## Recon report

**1. RLS SELECT on `exercises`** (already correct, from `20260709100200_rls_policies.sql`, untouched by later migrations):
```sql
create policy "exercises_select_own_or_public"
  on public.exercises for select
  to authenticated
  using (is_public or author_id = auth.uid());
```
No change needed — this already allows a coach to read any public exercise plus their own private ones.

**2. Public/private flag**: `exercises.is_public boolean not null default true` (`20260709100100_schema.sql`). Defaults to public with `ExerciseForm`'s "Zachowaj jako prywatne" checkbox flipping it — matches the R10 "public by default, keep-private checkbox" description.

**3. Exercise library query (before this change)**: `ExercisesLibrary.tsx` already did `select("*")` with no `author_id` filter, so RLS alone already returned "mine + others' public" — i.e. the "Wszystkie" behavior was already the (unlabeled) default. There was no way to narrow to "Moje" and no author attribution shown.

**4. Author / attribution**: `exercises.author_id` references `profiles.id` (`exercises_author_id_fkey`, nullable — null for the seeded official library). `profiles` already has an open SELECT policy for any authenticated user:
```sql
create policy "profiles_select_authenticated"
  on public.profiles for select
  to authenticated
  using (true);
```
This already exposes `display_name` (and `club_name`/`avatar_url`) — more than attribution strictly needs, but it's a pre-existing R1 decision, not something this round should narrow. No new policy added.

**5. Storage (`exercise-media`)**: bucket is fully public (`public: true` on the bucket, plus an explicit `to public using (bucket_id = 'exercise-media')` SELECT policy on `storage.objects`, from `20260711110300_exercise_media_storage.sql`). Any coach can already load another coach's diagram image via a plain `<img>` src — no signed URLs needed, no change required.

**Conclusion**: all three DB requirements (exercises SELECT, storage read, profiles read) were already shipped ahead of schedule in R10/R11. This PR is UI-only.

## Files changed
- `app/app/exercises/page.tsx` — fetch and pass `currentUserId` to `ExercisesLibrary`.
- `components/exercises/ExercisesLibrary.tsx` — scope filter (Wszystkie/Moje), embed `author:profiles(display_name)` in the query.
- `components/exercises/ExerciseCard.tsx` — render `AuthorBadge`.
- `components/exercises/AuthorBadge.tsx` (new) — author name + "Twoje"/"Oficjalne" badge, shared by card and detail page.
- `app/app/exercises/[id]/page.tsx` — embed author in the detail query, render `AuthorBadge`.
- `lib/supabase/types.ts` — `ExerciseWithAuthor` type for the embedded query shape.

## Test plan
- [x] `pnpm typecheck` — clean (confirms the `author:profiles(display_name)` embed types correctly against the hand-written `Database` relationships).
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — succeeds.
- [ ] Manual verification against a live Supabase project with two coach accounts (not possible in this sandbox — no Supabase credentials configured): Coach A creates a public exercise, Coach B sees it under "Wszystkie" with A's name, opens the detail page + diagram, duplicates it into an editable copy, and cannot see/delete A's private exercises.


---
_Generated by [Claude Code](https://claude.ai/code/session_018gEWN1BdYvUyYoXU4b7yVP)_