### PR TITLE
fix(db): correct name_en casing in american_football seed migration

### DIFF
--- a/supabase/migrations/20260711100000_add_american_football_sport.sql
+++ b/supabase/migrations/20260711100000_add_american_football_sport.sql
@@ -6,5 +6,5 @@
 -- environment (local, CI, other devs) gets the same reference row instead
 -- of relying on an undocumented manual edit.
 insert into public.sports (slug, name_pl, name_en) values
-  ('american_football', 'Futbol amerykański', 'American Football')
+  ('american_football', 'Futbol amerykański', 'American football')
 on conflict (slug) do nothing;


### PR DESCRIPTION
## Summary

Round 14 was meant to backfill the American football row (introduced in Round 7) into a migration file, since it had been added by hand directly in the production Supabase database. Recon showed this was already done: `supabase/migrations/20260711100000_add_american_football_sport.sql` (merged in an earlier round) already inserts the row with an idempotent `on conflict (slug) do nothing` guard.

Cross-checking the migration's values against the actual production row (owner confirmed via direct query) surfaced one drift: the migration seeds `name_en = 'American Football'`, but production has `name_en = 'American football'` (lowercase "f"). `slug` and `name_pl` already matched exactly.

- Corrects the migration's `name_en` value to match production exactly (`'American football'`)
- Production itself is left untouched — the insert is `on conflict (slug) do nothing`, so it never touched the live row anyway, and `name_en` isn't rendered anywhere in the UI (grepped `app/` and `components/`; only referenced in types/seed for categories)

## Other findings (no action needed)

- `sports` table columns: `id serial primary key`, `slug text not null unique`, `name_pl text not null`, `name_en text not null` — no other columns or constraints.
- `slug = 'american_football'` is confirmed correct against app usage (`lib/board/sports/americanFootball.tsx`, `components/board/TacticsBoard.tsx`); nothing in the app depends on the numeric `id`.
- Grepped all migrations and the repo for other signs of hand-applied/undocumented schema drift (`by hand`, `manually`, `SQL Editor`, `workaround`, `hardcoded`) — found none beyond this one, already-migrated case.

## Test plan

- [x] `git diff` reviewed — single-character text change, no schema/DDL touched
- [x] Confirmed `on conflict (slug) do nothing` keeps the migration a no-op against the existing production row
- [x] Confirmed `name_en` has no UI rendering path (Polish UI copy is what's shown)
- [ ] Owner: re-run the migration SQL below in the Supabase SQL Editor against a fresh/staging database to confirm idempotency and correct seeding

```sql
insert into public.sports (slug, name_pl, name_en) values
  ('american_football', 'Futbol amerykański', 'American football')
on conflict (slug) do nothing;
```


---
_Generated by [Claude Code](https://claude.ai/code/session_011a8wuv8cBSMWAs3YRWi8wX)_