### PR TITLE
feat(board): add basketball, volleyball and handball tactics boards

### DIFF
--- a/components/board/PathElementNode.tsx
+++ b/components/board/PathElementNode.tsx
@@ -7,6 +7,7 @@ import {
   flattenPoints,
   nearestPointOnPath,
   smoothPathPoints,
+  wavyPathPoints,
 } from "@/lib/board/path";
 import type { BoardPoint, PathBoardElement } from "@/lib/board/types";
 
@@ -36,12 +37,14 @@ export function PathElementNode({
   onPointDragEnd,
   onInsertPoint,
 }: PathElementNodeProps) {
-  const { points, color, strokeWidth, headStyle, dash, curved } = element;
+  const { points, color, strokeWidth, headStyle, dash, curved, wavy } =
+    element;
   // Render points are pre-curved (centripetal Catmull-Rom) when smooth, so
   // Konva always draws with tension 0 - its own `tension` spline overshoots
   // past the tapped points for anything but perfectly even spacing.
-  const renderPoints =
-    curved && points.length >= 3 ? smoothPathPoints(points) : points;
+  const curvedPoints =
+    curved && points.length >= 2 ? smoothPathPoints(points) : points;
+  const renderPoints = wavy ? wavyPathPoints(curvedPoints) : curvedPoints;
   const flat = flattenPoints(renderPoints);
 
   const select = (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {

--- a/components/board/TacticsBoard.tsx
+++ b/components/board/TacticsBoard.tsx
@@ -26,6 +26,7 @@ import {
   flattenPoints,
   smoothPathPoints,
   translatePoints,
+  wavyPathPoints,
 } from "@/lib/board/path";
 import { getSportConfig } from "@/lib/board/sports/registry";
 import type { PathToolStyle, ToolDef } from "@/lib/board/sports/types";
@@ -508,10 +509,13 @@ export function TacticsBoard({
     drawingPath && previewCursor
       ? [...drawingPath.points, previewCursor]
       : (drawingPath?.points ?? []);
-  const drawingPreviewRenderPoints =
-    drawingPath?.curved && drawingPreviewPoints.length >= 3
+  const drawingPreviewCurvedPoints =
+    drawingPath?.curved && drawingPreviewPoints.length >= 2
       ? smoothPathPoints(drawingPreviewPoints)
       : drawingPreviewPoints;
+  const drawingPreviewRenderPoints = drawingPath?.style.wavy
+    ? wavyPathPoints(drawingPreviewCurvedPoints)
+    : drawingPreviewCurvedPoints;
 
   const drawingTool = drawingPath ? findTool(drawingPath.toolId) : null;
   const drawingToolCurvable =

--- a/components/board/fields/BasketballField.tsx
+++ b/components/board/fields/BasketballField.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { Arc, Circle, Group, Layer, Line, Rect } from "react-konva";
+import type { FieldRendererProps } from "@/lib/board/sports/types";
+
+const MARGIN = 24;
+const LINE_COLOR = "#f8fafc";
+const LINE_WIDTH = 3;
+const FLOOR_DARK = "#c8823a";
+const FLOOR_LIGHT = "#d4914a";
+
+// FIBA reference dimensions (metres), used the same way SoccerField uses
+// 105x68 - realistic proportions, not tournament-grade precision.
+const COURT_LENGTH = 28;
+const COURT_WIDTH = 15;
+const HALF_DEPTH = 14; // centre line to baseline
+const CENTER_CIRCLE_R = 1.8;
+const KEY_WIDTH = 4.9;
+const FT_LINE_DEPTH = 5.8;
+const FT_CIRCLE_R = 1.8;
+const THREE_POINT_R = 6.75;
+const BASKET_DEPTH = 1.575; // baseline to hoop centre
+const BACKBOARD_DEPTH = 1.2;
+const BACKBOARD_WIDTH = 1.8;
+
+export function BasketballField({ modeId, width, height }: FieldRendererProps) {
+  return (
+    <Layer listening={false}>
+      <Floor width={width} height={height} />
+      <Rect
+        x={MARGIN}
+        y={MARGIN}
+        width={width - MARGIN * 2}
+        height={height - MARGIN * 2}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      {modeId === "half" ? (
+        <HalfCourtMarkings width={width} height={height} />
+      ) : (
+        <FullCourtMarkings width={width} height={height} />
+      )}
+    </Layer>
+  );
+}
+
+function Floor({ width, height }: { width: number; height: number }) {
+  return (
+    <Group>
+      <Rect x={0} y={0} width={width} height={height} fill={FLOOR_DARK} />
+      <Rect
+        x={MARGIN}
+        y={MARGIN}
+        width={width - MARGIN * 2}
+        height={height - MARGIN * 2}
+        fill={FLOOR_LIGHT}
+      />
+    </Group>
+  );
+}
+
+// One basket end's markings: key, free-throw circle, three-point arc and
+// hoop. `goalX`/`dir` follow SoccerField's convention (dir=1 grows into
+// the court from a goal on the left, -1 from the right); `scaleX` maps
+// the length axis, `scaleY`/`avgScale` the width axis and radii.
+function EndMarkings({
+  goalX,
+  centerY,
+  dir,
+  scaleX,
+  scaleY,
+  avgScale,
+}: {
+  goalX: number;
+  centerY: number;
+  dir: 1 | -1;
+  scaleX: number;
+  scaleY: number;
+  avgScale: number;
+}) {
+  const keyHalfWidth = (KEY_WIDTH * scaleY) / 2;
+  const ftDepth = FT_LINE_DEPTH * scaleX;
+  const ftCircleR = FT_CIRCLE_R * avgScale;
+  const threeR = THREE_POINT_R * avgScale;
+  const basketX = goalX + dir * BASKET_DEPTH * scaleX;
+  const backboardX = goalX + dir * BACKBOARD_DEPTH * scaleX;
+  const backboardHalf = (BACKBOARD_WIDTH * scaleY) / 2;
+
+  // Three-point arc: centred on the hoop, clipped by the baseline. The
+  // half-angle from the "into the court" direction to where the arc
+  // meets the baseline is arccos(-depth/radius); see BasketballField's
+  // sibling handball derivation in HandballField for the same technique.
+  const depthRatio = (BASKET_DEPTH * scaleX) / threeR;
+  const halfAngleDeg = (Math.acos(-depthRatio) * 180) / Math.PI;
+  const rotation = dir === 1 ? -halfAngleDeg : 180 - halfAngleDeg;
+
+  return (
+    <Group>
+      <Rect
+        x={dir === 1 ? goalX : goalX - ftDepth}
+        y={centerY - keyHalfWidth}
+        width={ftDepth}
+        height={keyHalfWidth * 2}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle
+        x={goalX + dir * ftDepth}
+        y={centerY}
+        radius={ftCircleR}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Arc
+        x={basketX}
+        y={centerY}
+        innerRadius={threeR}
+        outerRadius={threeR}
+        rotation={rotation}
+        angle={halfAngleDeg * 2}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Line
+        points={[
+          backboardX,
+          centerY - backboardHalf,
+          backboardX,
+          centerY + backboardHalf,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle x={basketX} y={centerY} radius={5} stroke={LINE_COLOR} strokeWidth={2} />
+    </Group>
+  );
+}
+
+function FullCourtMarkings({ width, height }: { width: number; height: number }) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const scaleX = playW / COURT_LENGTH;
+  const scaleY = playH / COURT_WIDTH;
+  const avgScale = (scaleX + scaleY) / 2;
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  return (
+    <Group>
+      <Line
+        points={[centerX, MARGIN, centerX, height - MARGIN]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle
+        x={centerX}
+        y={centerY}
+        radius={CENTER_CIRCLE_R * avgScale}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <EndMarkings
+        goalX={MARGIN}
+        centerY={centerY}
+        dir={1}
+        scaleX={scaleX}
+        scaleY={scaleY}
+        avgScale={avgScale}
+      />
+      <EndMarkings
+        goalX={width - MARGIN}
+        centerY={centerY}
+        dir={-1}
+        scaleX={scaleX}
+        scaleY={scaleY}
+        avgScale={avgScale}
+      />
+    </Group>
+  );
+}
+
+// Half court: x = sideline-to-sideline (width axis), y = centre line
+// (top) to baseline (bottom) - same rotation SoccerField uses for its
+// half-pitch view.
+function HalfCourtMarkings({ width, height }: { width: number; height: number }) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const scaleX = playW / COURT_WIDTH;
+  const scaleY = playH / HALF_DEPTH;
+  const avgScale = (scaleX + scaleY) / 2;
+  const centerX = width / 2;
+  const goalY = height - MARGIN;
+
+  const keyHalfWidth = (KEY_WIDTH * scaleX) / 2;
+  const ftDepth = FT_LINE_DEPTH * scaleY;
+  const ftCircleR = FT_CIRCLE_R * avgScale;
+  const threeR = THREE_POINT_R * avgScale;
+  const basketY = goalY - BASKET_DEPTH * scaleY;
+  const backboardY = goalY - BACKBOARD_DEPTH * scaleY;
+  const backboardHalf = (BACKBOARD_WIDTH * scaleX) / 2;
+
+  const depthRatio = (BASKET_DEPTH * scaleY) / threeR;
+  const halfAngleDeg = (Math.acos(-depthRatio) * 180) / Math.PI;
+
+  return (
+    <Group>
+      <Arc
+        x={centerX}
+        y={MARGIN}
+        innerRadius={CENTER_CIRCLE_R * avgScale}
+        outerRadius={CENTER_CIRCLE_R * avgScale}
+        rotation={0}
+        angle={180}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Rect
+        x={centerX - keyHalfWidth}
+        y={goalY - ftDepth}
+        width={keyHalfWidth * 2}
+        height={ftDepth}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle
+        x={centerX}
+        y={goalY - ftDepth}
+        radius={ftCircleR}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Arc
+        x={centerX}
+        y={basketY}
+        innerRadius={threeR}
+        outerRadius={threeR}
+        rotation={270 - halfAngleDeg}
+        angle={halfAngleDeg * 2}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Line
+        points={[
+          centerX - backboardHalf,
+          backboardY,
+          centerX + backboardHalf,
+          backboardY,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Circle x={centerX} y={basketY} radius={5} stroke={LINE_COLOR} strokeWidth={2} />
+    </Group>
+  );
+}

--- a/components/board/fields/GenericField.tsx
+++ b/components/board/fields/GenericField.tsx
@@ -8,9 +8,9 @@ const LINE_COLOR = "#f8fafc";
 const LINE_WIDTH = 3;
 const FLOOR_COLOR = "#3f6212";
 
-// Plain placeholder surface for any sport without a dedicated field yet
-// (basketball/volleyball/handball this round) - degrades gracefully
-// instead of guessing at a court it hasn't been built for.
+// Plain placeholder surface for any sport without a dedicated field yet -
+// degrades gracefully instead of guessing at a court it hasn't been
+// built for.
 export function GenericField({ width, height }: FieldRendererProps) {
   return (
     <Layer listening={false}>

--- a/components/board/fields/HandballField.tsx
+++ b/components/board/fields/HandballField.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { Arc, Group, Layer, Line, Rect } from "react-konva";
+import type { FieldRendererProps } from "@/lib/board/sports/types";
+
+const MARGIN = 24;
+const LINE_COLOR = "#f8fafc";
+const LINE_WIDTH = 3;
+const FLOOR_COLOR = "#2563a8";
+
+// IHF reference dimensions (metres) - realistic proportions, same spirit
+// as SoccerField's 105x68, not tournament-grade precision.
+const COURT_LENGTH = 40;
+const COURT_WIDTH = 20;
+const HALF_DEPTH = 20; // centre line to goal line
+const GOAL_AREA_R = 6;
+const FREE_THROW_R = 9;
+const FREE_THROW_DASH = [10, 8];
+const PENALTY_MARK_DEPTH = 7;
+const PENALTY_MARK_LEN = 1;
+const GOAL_WIDTH = 3;
+const GOAL_DEPTH = 0.8;
+
+export function HandballField({ modeId, width, height }: FieldRendererProps) {
+  return (
+    <Layer listening={false}>
+      <Rect x={0} y={0} width={width} height={height} fill={FLOOR_COLOR} />
+      <Rect
+        x={MARGIN}
+        y={MARGIN}
+        width={width - MARGIN * 2}
+        height={height - MARGIN * 2}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      {modeId === "half" ? (
+        <HalfCourtMarkings width={width} height={height} />
+      ) : (
+        <FullCourtMarkings width={width} height={height} />
+      )}
+    </Layer>
+  );
+}
+
+// One goal's area/free-throw lines: each is a curve made of two quarter
+// circles centred on the goalposts (radius R) joined by a straight
+// segment parallel to the goal line - the D shape used for both the 6m
+// and 9m lines, which share the same post centres and only differ in R.
+// `goalX`/`dir` follow SoccerField's left/right goal convention.
+function GoalCurve({
+  goalX,
+  centerY,
+  dir,
+  goalHalfWidth,
+  radiusScale,
+  dash,
+}: {
+  goalX: number;
+  centerY: number;
+  dir: 1 | -1;
+  goalHalfWidth: number;
+  radiusScale: number;
+  dash?: number[];
+}) {
+  const post1Y = centerY - goalHalfWidth;
+  const post2Y = centerY + goalHalfWidth;
+  const lineX = goalX + dir * radiusScale;
+
+  return (
+    <Group>
+      <Arc
+        x={goalX}
+        y={post1Y}
+        innerRadius={radiusScale}
+        outerRadius={radiusScale}
+        rotation={dir === 1 ? 270 : 180}
+        angle={90}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+        dash={dash}
+      />
+      <Arc
+        x={goalX}
+        y={post2Y}
+        innerRadius={radiusScale}
+        outerRadius={radiusScale}
+        rotation={dir === 1 ? 0 : 90}
+        angle={90}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+        dash={dash}
+      />
+      <Line
+        points={[lineX, post1Y, lineX, post2Y]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+        dash={dash}
+      />
+    </Group>
+  );
+}
+
+function EndMarkings({
+  goalX,
+  centerY,
+  dir,
+  scaleX,
+  scaleY,
+  avgScale,
+}: {
+  goalX: number;
+  centerY: number;
+  dir: 1 | -1;
+  scaleX: number;
+  scaleY: number;
+  avgScale: number;
+}) {
+  const goalHalfWidth = (GOAL_WIDTH * scaleY) / 2;
+  const penaltyX = goalX + dir * PENALTY_MARK_DEPTH * scaleX;
+  const penaltyHalfLen = (PENALTY_MARK_LEN * scaleY) / 2;
+  const goalDepth = GOAL_DEPTH * scaleX;
+
+  return (
+    <Group>
+      <GoalCurve
+        goalX={goalX}
+        centerY={centerY}
+        dir={dir}
+        goalHalfWidth={goalHalfWidth}
+        radiusScale={GOAL_AREA_R * avgScale}
+      />
+      <GoalCurve
+        goalX={goalX}
+        centerY={centerY}
+        dir={dir}
+        goalHalfWidth={goalHalfWidth}
+        radiusScale={FREE_THROW_R * avgScale}
+        dash={FREE_THROW_DASH}
+      />
+      <Line
+        points={[
+          penaltyX,
+          centerY - penaltyHalfLen,
+          penaltyX,
+          centerY + penaltyHalfLen,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Rect
+        x={dir === 1 ? goalX - goalDepth : goalX}
+        y={centerY - goalHalfWidth}
+        width={goalDepth}
+        height={goalHalfWidth * 2}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+    </Group>
+  );
+}
+
+// Same shapes as EndMarkings, rotated 90°: the goal sits at the bottom
+// (y axis is now the depth/goal axis, x is the width axis) - the
+// orientation SoccerField and BasketballField use for their half views.
+function HalfEndMarkings({
+  centerX,
+  goalY,
+  scaleX,
+  scaleY,
+  avgScale,
+}: {
+  centerX: number;
+  goalY: number;
+  scaleX: number;
+  scaleY: number;
+  avgScale: number;
+}) {
+  const goalHalfWidth = (GOAL_WIDTH * scaleX) / 2;
+  const penaltyY = goalY - PENALTY_MARK_DEPTH * scaleY;
+  const penaltyHalfLen = (PENALTY_MARK_LEN * scaleX) / 2;
+  const goalDepth = GOAL_DEPTH * scaleY;
+  const post1X = centerX - goalHalfWidth;
+  const post2X = centerX + goalHalfWidth;
+
+  function halfGoalCurve(radiusScale: number, dash?: number[]) {
+    const lineY = goalY - radiusScale;
+    return (
+      <Group>
+        <Arc
+          x={post1X}
+          y={goalY}
+          innerRadius={radiusScale}
+          outerRadius={radiusScale}
+          rotation={180}
+          angle={90}
+          stroke={LINE_COLOR}
+          strokeWidth={LINE_WIDTH}
+          dash={dash}
+        />
+        <Arc
+          x={post2X}
+          y={goalY}
+          innerRadius={radiusScale}
+          outerRadius={radiusScale}
+          rotation={270}
+          angle={90}
+          stroke={LINE_COLOR}
+          strokeWidth={LINE_WIDTH}
+          dash={dash}
+        />
+        <Line
+          points={[post1X, lineY, post2X, lineY]}
+          stroke={LINE_COLOR}
+          strokeWidth={LINE_WIDTH}
+          dash={dash}
+        />
+      </Group>
+    );
+  }
+
+  return (
+    <Group>
+      {halfGoalCurve(GOAL_AREA_R * avgScale)}
+      {halfGoalCurve(FREE_THROW_R * avgScale, FREE_THROW_DASH)}
+      <Line
+        points={[
+          centerX - penaltyHalfLen,
+          penaltyY,
+          centerX + penaltyHalfLen,
+          penaltyY,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Rect
+        x={centerX - goalHalfWidth}
+        y={goalY}
+        width={goalHalfWidth * 2}
+        height={goalDepth}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+    </Group>
+  );
+}
+
+function FullCourtMarkings({ width, height }: { width: number; height: number }) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const scaleX = playW / COURT_LENGTH;
+  const scaleY = playH / COURT_WIDTH;
+  const avgScale = (scaleX + scaleY) / 2;
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  return (
+    <Group>
+      <Line
+        points={[centerX, MARGIN, centerX, height - MARGIN]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <EndMarkings
+        goalX={MARGIN}
+        centerY={centerY}
+        dir={1}
+        scaleX={scaleX}
+        scaleY={scaleY}
+        avgScale={avgScale}
+      />
+      <EndMarkings
+        goalX={width - MARGIN}
+        centerY={centerY}
+        dir={-1}
+        scaleX={scaleX}
+        scaleY={scaleY}
+        avgScale={avgScale}
+      />
+    </Group>
+  );
+}
+
+// Half court: x = sideline-to-sideline (width axis), y = centre line
+// (top) to goal line (bottom) - the same rotation SoccerField and
+// BasketballField use for their half views.
+function HalfCourtMarkings({ width, height }: { width: number; height: number }) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const scaleX = playW / COURT_WIDTH;
+  const scaleY = playH / HALF_DEPTH;
+  const avgScale = (scaleX + scaleY) / 2;
+  const centerX = width / 2;
+  const goalY = height - MARGIN;
+
+  return (
+    <HalfEndMarkings
+      centerX={centerX}
+      goalY={goalY}
+      scaleX={scaleX}
+      scaleY={scaleY}
+      avgScale={avgScale}
+    />
+  );
+}

--- a/components/board/fields/VolleyballField.tsx
+++ b/components/board/fields/VolleyballField.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Group, Layer, Line, Rect } from "react-konva";
+import type { FieldRendererProps } from "@/lib/board/sports/types";
+
+// Wider than the other fields' 24px - a volleyball court is always shown
+// whole (no half-court mode), so the margin doubles as room to draw the
+// service zone markers and net posts just outside the court boundary
+// without them running off the canvas.
+const MARGIN = 48;
+const LINE_COLOR = "#f8fafc";
+const LINE_WIDTH = 3;
+const FLOOR_DARK = "#b45309";
+const FLOOR_LIGHT = "#c2670f";
+
+// 18m x 9m FIVB court - FULL_WIDTH/FULL_HEIGHT below are chosen so
+// scaleX derived from this matches the vertical scale implied by the
+// canvas dimensions exactly (no separate scaleY needed).
+const COURT_LENGTH = 18;
+const ATTACK_LINE_DEPTH = 3;
+const NET_POST_LENGTH = 16;
+const SERVICE_ZONE_MARK = 18;
+
+export function VolleyballField({ width, height }: FieldRendererProps) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const scaleX = playW / COURT_LENGTH;
+  const centerX = width / 2;
+  const attackOffset = ATTACK_LINE_DEPTH * scaleX;
+
+  return (
+    <Layer listening={false}>
+      <Rect x={0} y={0} width={width} height={height} fill={FLOOR_DARK} />
+      <Rect
+        x={MARGIN}
+        y={MARGIN}
+        width={playW}
+        height={playH}
+        fill={FLOOR_LIGHT}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+
+      {/* Centre line, directly under the net. */}
+      <Line
+        points={[centerX, MARGIN, centerX, height - MARGIN]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      {/* Net posts, just outside the sidelines on the centre line's axis. */}
+      <Line
+        points={[centerX, MARGIN - NET_POST_LENGTH, centerX, MARGIN]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+      <Line
+        points={[
+          centerX,
+          height - MARGIN,
+          centerX,
+          height - MARGIN + NET_POST_LENGTH,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
+
+      {/* Attack (3m) lines on both sides of the net. */}
+      <Line
+        points={[
+          centerX - attackOffset,
+          MARGIN,
+          centerX - attackOffset,
+          height - MARGIN,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH * 0.7}
+      />
+      <Line
+        points={[
+          centerX + attackOffset,
+          MARGIN,
+          centerX + attackOffset,
+          height - MARGIN,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH * 0.7}
+      />
+
+      {/* Service zones: sideline continuations just behind each end line. */}
+      {[MARGIN, width - MARGIN].map((x) => (
+        <Group key={x}>
+          <Line
+            points={[
+              x,
+              MARGIN,
+              x + (x === MARGIN ? -SERVICE_ZONE_MARK : SERVICE_ZONE_MARK),
+              MARGIN,
+            ]}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH * 0.7}
+          />
+          <Line
+            points={[
+              x,
+              height - MARGIN,
+              x + (x === MARGIN ? -SERVICE_ZONE_MARK : SERVICE_ZONE_MARK),
+              height - MARGIN,
+            ]}
+            stroke={LINE_COLOR}
+            strokeWidth={LINE_WIDTH * 0.7}
+          />
+        </Group>
+      ))}
+    </Layer>
+  );
+}

--- a/components/board/icons.tsx
+++ b/components/board/icons.tsx
@@ -142,6 +142,105 @@ export function ScrimmageIcon() {
   );
 }
 
+export function DribbleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M3 18c2-4 3 4 5 0s3-4 5 0 3-4 5 0 2-2 2-2"
+        fill="none"
+        stroke="#ea580c"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="4" cy="6" r="2.4" fill="#ea580c" />
+    </svg>
+  );
+}
+
+export function ShotArcIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M3 17c4-11 14-11 18 0"
+        fill="none"
+        stroke="#dc2626"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeDasharray="3.5 3"
+      />
+      <circle cx="21" cy="17.5" r="2.2" fill="none" stroke="#dc2626" strokeWidth="1.6" />
+    </svg>
+  );
+}
+
+export function BallArcIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M3 18c4-12 14-12 18 0"
+        fill="none"
+        stroke="#0891b2"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+      />
+      <circle cx="3" cy="18" r="2.3" fill="#ffffff" stroke="#0891b2" strokeWidth="1.4" />
+    </svg>
+  );
+}
+
+export function ServeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <line
+        x1="4"
+        y1="20"
+        x2="18"
+        y2="6"
+        stroke="#f59e0b"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeDasharray="4 3"
+      />
+      <path d="M11 5h8v8z" fill="#f59e0b" />
+    </svg>
+  );
+}
+
+export function AttackIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <line
+        x1="5"
+        y1="6"
+        x2="16"
+        y2="17"
+        stroke="#b91c1c"
+        strokeWidth="3.2"
+        strokeLinecap="round"
+      />
+      <path d="M18 10V19H9z" fill="#b91c1c" />
+    </svg>
+  );
+}
+
+export function HandballShotIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <line
+        x1="3"
+        y1="17"
+        x2="15"
+        y2="7"
+        stroke="#dc2626"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+      />
+      <path d="M9 6h9v9z" fill="#dc2626" />
+    </svg>
+  );
+}
+
 export function UndoIcon() {
   return (
     <svg viewBox="0 0 24 24" className="h-5 w-5">

--- a/lib/board/elements.ts
+++ b/lib/board/elements.ts
@@ -37,6 +37,7 @@ export interface PathStylePreset {
   strokeWidth: number;
   headStyle: PathHeadStyle;
   dash?: number[];
+  wavy?: boolean;
 }
 
 export function createPathElement(

--- a/lib/board/path.ts
+++ b/lib/board/path.ts
@@ -44,20 +44,46 @@ const SAMPLES_PER_SEGMENT = 12;
 const CENTRIPETAL_ALPHA = 0.5;
 const EPS = 1e-4;
 
+// How far a synthesized midpoint bulges off the straight line between two
+// points, as a fraction of their distance apart - gives a 2-point curved
+// path (e.g. a basketball shot or a volleyball trajectory, tapped as just
+// a start and end point) a visible arc instead of rendering dead straight,
+// since Catmull-Rom needs 3 points to bend at all.
+const ARC_BULGE_RATIO = 0.18;
+
+function withArcMidpoint(points: BoardPoint[]): BoardPoint[] {
+  const [a, b] = points;
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const len = Math.hypot(dx, dy) || 1;
+  // Perpendicular to a->b, rotated so the bulge is consistently on one
+  // side regardless of which direction the coach happened to draw in.
+  const perpX = -dy / len;
+  const perpY = dx / len;
+  const bulge = len * ARC_BULGE_RATIO;
+  return [
+    a,
+    { x: (a.x + b.x) / 2 + perpX * bulge, y: (a.y + b.y) / 2 + perpY * bulge },
+    b,
+  ];
+}
+
 /**
  * Samples a dense polyline that curves smoothly through every point in
  * `points` (a centripetal Catmull-Rom spline), passed straight through to
  * Konva with tension 0 - Konva's own `tension` prop is a uniform spline
  * that overshoots and self-intersects for the kind of unevenly-spaced
  * points a coach taps out by hand, so this replaces it entirely rather
- * than trying to tune it.
+ * than trying to tune it. Exactly 2 points get a synthesized midpoint
+ * bulge first (see withArcMidpoint) so a curved 2-point path still arcs.
  */
 export function smoothPathPoints(points: BoardPoint[]): BoardPoint[] {
-  if (points.length < 3) return points;
+  if (points.length < 2) return points;
+  const source = points.length === 2 ? withArcMidpoint(points) : points;
 
   // Duplicate the end points so every real point gets a full 4-point
   // window (p0,p1,p2,p3) to interpolate between p1 and p2.
-  const padded = [points[0], ...points, points[points.length - 1]];
+  const padded = [source[0], ...source, source[source.length - 1]];
   const result: BoardPoint[] = [padded[1]];
 
   for (let i = 0; i < padded.length - 3; i++) {
@@ -137,4 +163,45 @@ export function nearestPointOnPath(
   // points always has >=2 entries whenever this is called (paths are
   // never created/rendered with fewer), so best is always set.
   return best as NearestPointResult;
+}
+
+const WAVE_AMPLITUDE = 9;
+const WAVE_LENGTH = 26;
+const WAVE_STEP = 6;
+
+/**
+ * Samples a zigzag/squiggle along the polyline `points` describe, offset
+ * perpendicular to the direction of travel by a sine wave - used for the
+ * basketball dribble tool, where a plain line would look like a pass
+ * rather than a ball being bounced along the way. Arc length (not per-
+ * segment progress) drives the wave phase, so it stays continuous across
+ * unevenly spaced tapped points instead of resetting at each one.
+ */
+export function wavyPathPoints(points: BoardPoint[]): BoardPoint[] {
+  if (points.length < 2) return points;
+  const result: BoardPoint[] = [];
+  let travelled = 0;
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    const segLen = distance(a, b);
+    if (segLen < EPS) continue;
+    const dirX = (b.x - a.x) / segLen;
+    const dirY = (b.y - a.y) / segLen;
+    const perpX = -dirY;
+    const perpY = dirX;
+    const steps = Math.max(1, Math.round(segLen / WAVE_STEP));
+    for (let s = i === 0 ? 0 : 1; s <= steps; s++) {
+      const d = (s / steps) * segLen;
+      const along = travelled + d;
+      const offset =
+        Math.sin((along / WAVE_LENGTH) * Math.PI * 2) * WAVE_AMPLITUDE;
+      result.push({
+        x: a.x + dirX * d + perpX * offset,
+        y: a.y + dirY * d + perpY * offset,
+      });
+    }
+    travelled += segLen;
+  }
+  return result;
 }

--- a/lib/board/sports/basketball.tsx
+++ b/lib/board/sports/basketball.tsx
@@ -1,0 +1,91 @@
+import { BasketballField } from "@/components/board/fields/BasketballField";
+import {
+  BallIcon,
+  ConeIcon,
+  DribbleIcon,
+  OpponentIcon,
+  PassLineIcon,
+  PlayerIcon,
+  RunArrowIcon,
+  ShotArcIcon,
+} from "@/components/board/icons";
+import type { SportBoardConfig } from "./types";
+
+export const basketballConfig: SportBoardConfig = {
+  slug: "basketball",
+  fieldModes: [
+    { id: "full", label: "Całe boisko", width: 940, height: 540 },
+    { id: "half", label: "Połowa boiska", width: 560, height: 520 },
+  ],
+  defaultFieldModeId: "full",
+  FieldComponent: BasketballField,
+  tools: [
+    {
+      id: "player",
+      label: "Zawodnik",
+      icon: <PlayerIcon />,
+      kind: { create: "point", elementKind: "player" },
+    },
+    {
+      id: "opponent",
+      label: "Przeciwnik",
+      icon: <OpponentIcon />,
+      kind: { create: "point", elementKind: "opponent" },
+    },
+    {
+      id: "ball",
+      label: "Piłka",
+      icon: <BallIcon />,
+      kind: { create: "point", elementKind: "ball" },
+    },
+    {
+      id: "cone",
+      label: "Pachołek",
+      icon: <ConeIcon />,
+      kind: { create: "point", elementKind: "cone" },
+    },
+    {
+      id: "dribble",
+      label: "Kozłowanie",
+      icon: <DribbleIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#ea580c", strokeWidth: 4, headStyle: "none", wavy: true },
+      },
+    },
+    {
+      id: "passLine",
+      label: "Podanie",
+      icon: <PassLineIcon />,
+      kind: {
+        create: "path",
+        style: {
+          color: "#7c3aed",
+          strokeWidth: 4,
+          headStyle: "arrow",
+          dash: [14, 10],
+        },
+      },
+    },
+    {
+      id: "shot",
+      label: "Rzut",
+      icon: <ShotArcIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#dc2626", strokeWidth: 4, headStyle: "arrow" },
+        curvable: true,
+      },
+    },
+    {
+      id: "route",
+      label: "Trasa biegu",
+      icon: <RunArrowIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#111827", strokeWidth: 4, headStyle: "arrow" },
+        curvable: true,
+      },
+    },
+  ],
+};

--- a/lib/board/sports/handball.tsx
+++ b/lib/board/sports/handball.tsx
@@ -1,21 +1,23 @@
-import { GenericField } from "@/components/board/fields/GenericField";
+import { HandballField } from "@/components/board/fields/HandballField";
 import {
   BallIcon,
   ConeIcon,
+  HandballShotIcon,
   OpponentIcon,
+  PassLineIcon,
   PlayerIcon,
   RunArrowIcon,
 } from "@/components/board/icons";
 import type { SportBoardConfig } from "./types";
 
-// Used for any sport without a dedicated config yet - a plain field with
-// the same generic tool set every sport shares, so the board never
-// crashes on an unrecognized sport.
-export const fallbackConfig: SportBoardConfig = {
-  slug: "fallback",
-  fieldModes: [{ id: "full", label: "Boisko", width: 900, height: 600 }],
+export const handballConfig: SportBoardConfig = {
+  slug: "handball",
+  fieldModes: [
+    { id: "full", label: "Całe boisko", width: 1008, height: 528 },
+    { id: "half", label: "Połowa boiska", width: 528, height: 528 },
+  ],
   defaultFieldModeId: "full",
-  FieldComponent: GenericField,
+  FieldComponent: HandballField,
   tools: [
     {
       id: "player",
@@ -42,12 +44,36 @@ export const fallbackConfig: SportBoardConfig = {
       kind: { create: "point", elementKind: "cone" },
     },
     {
-      id: "movement",
-      label: "Strzałka ruchu",
+      id: "passLine",
+      label: "Podanie",
+      icon: <PassLineIcon />,
+      kind: {
+        create: "path",
+        style: {
+          color: "#7c3aed",
+          strokeWidth: 4,
+          headStyle: "arrow",
+          dash: [14, 10],
+        },
+      },
+    },
+    {
+      id: "shot",
+      label: "Rzut",
+      icon: <HandballShotIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#dc2626", strokeWidth: 4, headStyle: "arrow" },
+      },
+    },
+    {
+      id: "route",
+      label: "Trasa biegu",
       icon: <RunArrowIcon />,
       kind: {
         create: "path",
         style: { color: "#111827", strokeWidth: 4, headStyle: "arrow" },
+        curvable: true,
       },
     },
   ],

--- a/lib/board/sports/registry.ts
+++ b/lib/board/sports/registry.ts
@@ -1,11 +1,17 @@
 import { americanFootballConfig } from "./americanFootball";
+import { basketballConfig } from "./basketball";
 import { fallbackConfig } from "./fallback";
 import { footballConfig } from "./football";
+import { handballConfig } from "./handball";
+import { volleyballConfig } from "./volleyball";
 import type { SportBoardConfig } from "./types";
 
 const configsBySlug: Record<string, SportBoardConfig> = {
   [footballConfig.slug]: footballConfig,
   [americanFootballConfig.slug]: americanFootballConfig,
+  [basketballConfig.slug]: basketballConfig,
+  [volleyballConfig.slug]: volleyballConfig,
+  [handballConfig.slug]: handballConfig,
 };
 
 /**

--- a/lib/board/sports/types.ts
+++ b/lib/board/sports/types.ts
@@ -21,6 +21,7 @@ export interface PathToolStyle {
   strokeWidth: number;
   headStyle: PathHeadStyle;
   dash?: number[];
+  wavy?: boolean;
 }
 
 export type ToolKind =

--- a/lib/board/sports/volleyball.tsx
+++ b/lib/board/sports/volleyball.tsx
@@ -1,0 +1,92 @@
+import { VolleyballField } from "@/components/board/fields/VolleyballField";
+import {
+  AttackIcon,
+  BallArcIcon,
+  BallIcon,
+  BlockIcon,
+  OpponentIcon,
+  PlayerIcon,
+  RunArrowIcon,
+  ServeIcon,
+} from "@/components/board/icons";
+import type { SportBoardConfig } from "./types";
+
+export const volleyballConfig: SportBoardConfig = {
+  slug: "volleyball",
+  // A volleyball court is small enough to always show whole - no half-court mode.
+  fieldModes: [{ id: "full", label: "Boisko", width: 852, height: 474 }],
+  defaultFieldModeId: "full",
+  FieldComponent: VolleyballField,
+  tools: [
+    {
+      id: "player",
+      label: "Zawodnik",
+      icon: <PlayerIcon />,
+      kind: { create: "point", elementKind: "player" },
+    },
+    {
+      id: "opponent",
+      label: "Przeciwnik",
+      icon: <OpponentIcon />,
+      kind: { create: "point", elementKind: "opponent" },
+    },
+    {
+      id: "ball",
+      label: "Piłka",
+      icon: <BallIcon />,
+      kind: { create: "point", elementKind: "ball" },
+    },
+    {
+      id: "trajectory",
+      label: "Trajektoria piłki",
+      icon: <BallArcIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#0891b2", strokeWidth: 4, headStyle: "none" },
+        curvable: true,
+      },
+    },
+    {
+      id: "serve",
+      label: "Zagrywka",
+      icon: <ServeIcon />,
+      kind: {
+        create: "path",
+        style: {
+          color: "#f59e0b",
+          strokeWidth: 4,
+          headStyle: "arrow",
+          dash: [14, 10],
+        },
+      },
+    },
+    {
+      id: "attack",
+      label: "Atak",
+      icon: <AttackIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#b91c1c", strokeWidth: 5, headStyle: "arrow" },
+      },
+    },
+    {
+      id: "block",
+      label: "Blok",
+      icon: <BlockIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#b91c1c", strokeWidth: 5, headStyle: "bar" },
+      },
+    },
+    {
+      id: "route",
+      label: "Trasa biegu",
+      icon: <RunArrowIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#111827", strokeWidth: 4, headStyle: "arrow" },
+        curvable: true,
+      },
+    },
+  ],
+};

--- a/lib/board/types.ts
+++ b/lib/board/types.ts
@@ -27,6 +27,8 @@ export interface PathBoardElement {
   dash?: number[];
   /** Sharp (straight segments, hard cuts) vs smooth (curved through points). */
   curved: boolean;
+  /** Renders as a zigzag along its length (e.g. a dribble) instead of a plain stroke. */
+  wavy?: boolean;
 }
 
 export type BoardElement = PointBoardElement | PathBoardElement;


### PR DESCRIPTION
## Summary

The "Dyscyplina" selector has offered Basketball, Volleyball and Handball since R9.5/9.6, but the tactics board had no field config for any of them, so picking one silently fell back to a plain rectangle with the generic tool set. This fills in all three using the same per-sport architecture soccer and American football already use — no changes to the board engine itself.

- **Fields**: `BasketballField`/`VolleyballField`/`HandballField` (`components/board/fields/`), each with realistic proportions in the spirit of the existing `SoccerField`/`AmericanFootballField`:
  - Basketball: full + half court, centre circle/line, two keys with free-throw circles, two three-point arcs, baskets/backboards.
  - Volleyball: full court only (no half view — a volleyball court is small enough to always show whole), net + centre line, both 3m attack lines, service zone markers behind both end lines.
  - Handball: full + half court, two 6m goal areas (D-shaped, arc+straight+arc) with dashed 9m free-throw lines sharing the same post centres, 7m marks, centre line, goals.
- **Two new path primitives** (`lib/board/path.ts`), reused across sports rather than sport-specific:
  - `wavyPathPoints` — a sine-wave stroke offset along arc length, used for the basketball dribble tool (nothing existing rendered a squiggle).
  - A synthesized midpoint bulge inside `smoothPathPoints` for exactly 2 curved points — without it, a "shot to the basket" or "ball trajectory" tapped as just two points rendered dead straight even in smooth mode, since Catmull-Rom needs ≥3 points to bend.
- **Per-sport tool sets**, reusing existing primitives wherever the semantics matched:
  - Reused as-is: point tools (zawodnik/przeciwnik/piłka/pachołek), dashed-arrow pass (podanie/zagrywka), bar-ended block (blok), curvable route (trasa biegu).
  - New: dribble (wavy), shot arc / ball trajectory (2-point curve bulge), a few new icons (`components/board/icons.tsx`) for tools with no existing visual analogue.
- Registered all three in `lib/board/sports/registry.ts`; updated the fallback's comments since it no longer covers these three sports.

## Manual test script

1. `Utwórz ćwiczenie` → pick **Koszykówka** → confirm real court renders (not a rectangle), toggle Całe boisko/Połowa boiska.
2. Place each basketball tool (zawodnik, przeciwnik, piłka, pachołek, kozłowanie, podanie, rzut, trasa biegu) — confirm each persists, drags, and deletes. Toggle "Trasa gładka" before drawing rzut/trasa biegu to see the arc.
3. Repeat for **Siatkówka** (no half-court toggle should appear) and **Piłka ręczna** (both views).
4. Undo/redo through several placements on each sport; confirm history is per-element as before.
5. Save an exercise with a diagram on each new sport; confirm the exported PNG thumbnail shows the diagram, then use "Duplikuj" and confirm the board re-opens editable with the same elements.
6. Add one of the duplicated exercises to a workout and download the PDF; confirm the diagram appears embedded.
7. Switch a board with elements on it between full/half view; confirm the existing "this will clear the board" confirmation still appears (unchanged behavior, just re-verifying no regression).
8. Spot-check soccer and American football still work exactly as before (fields, tools, route curve toggle, full/half and full/redzone view switches).

Steps 1-4 and 7-8 were verified visually via a throwaway local preview page (not part of this diff) rendering `TacticsBoard` directly with headless Chromium screenshots, confirming field geometry and tool rendering/interaction. Steps 5-6 rely on Supabase Storage + `@react-pdf/renderer`, which weren't available in this environment to exercise end-to-end — the code path is unchanged from how soccer/American football already do it (plain `BoardElement[]` JSON + PNG export), so it should round-trip identically, but I could not verify it directly.

## Flagged for the owner

- **Not verified on a real device**: the R11 touch fixes (80ms duplicate-event guard, `touch-action: none`) are untouched by this PR and apply identically to the new fields, but I have no physical phone to confirm feel/behavior on the new courts specifically.
- Tool choices (colors, exact primitives) are a first pass per the brief, expected to be revised after real coach feedback.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NbMXbDepg8gPGJwcCz3egz)_