### PR TITLE
Fix R11 duplicate-tap guard dropping fast successive taps at distinct cones

### DIFF
--- a/components/board/TacticsBoard.tsx
+++ b/components/board/TacticsBoard.tsx
@@ -28,6 +28,7 @@ import {
 import {
   isDoubleTapToFinish,
   isDuplicateStageEvent,
+  type LastStageEvent,
 } from "@/lib/board/tapGuard";
 import { getSportConfig } from "@/lib/board/sports/registry";
 import type { PathToolStyle, ToolDef } from "@/lib/board/sports/types";
@@ -135,7 +136,11 @@ export function TacticsBoard({
   // points. A genuine human double-tap always has more than a few tens of
   // milliseconds between the two touches; a synthesized duplicate of the
   // same touch does not. This guard swallows only the latter.
-  const lastHandledAtRef = useRef(0);
+  //
+  // R15.3: lastHandledRef also stores position (see isDuplicateStageEvent) -
+  // a time-only guard was dropping the second of two genuine fast taps at
+  // different coordinates (a tight cone slalom), not just misreading it.
+  const lastHandledRef = useRef<LastStageEvent | null>(null);
 
   const fieldMode =
     config.fieldModes.find((m) => m.id === fieldModeId) ?? config.fieldModes[0];
@@ -317,8 +322,11 @@ export function TacticsBoard({
   ) {
     if (e.target !== stageRef.current) return;
     const now = Date.now();
-    if (isDuplicateStageEvent(now, lastHandledAtRef.current)) return;
-    lastHandledAtRef.current = now;
+    const pos = getPointer();
+    if (pos && isDuplicateStageEvent(now, pos, lastHandledRef.current, scale)) {
+      return;
+    }
+    lastHandledRef.current = pos ? { time: now, pos } : null;
     if (activeTool === "select") {
       setSelectedId(null);
       setSelectedPointIndex(null);
@@ -326,7 +334,6 @@ export function TacticsBoard({
     }
     const tool = findTool(activeTool);
     if (!tool) return;
-    const pos = getPointer();
     if (!pos) return;
 
     if (tool.kind.create === "point") {

--- a/lib/board/tapGuard.test.ts
+++ b/lib/board/tapGuard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { DOUBLE_TAP_DIST, DOUBLE_TAP_MS } from "./elements";
 import {
+  DUPLICATE_EVENT_GUARD_DIST,
   DUPLICATE_EVENT_GUARD_MS,
   isDoubleTapToFinish,
   isDuplicateStageEvent,
@@ -16,15 +17,72 @@ import {
 
 describe("isDuplicateStageEvent (R11 guard)", () => {
   it("treats a second event at the same coordinates within the guard window as a duplicate", () => {
-    const lastHandledAt = 1_000;
-    const now = lastHandledAt + DUPLICATE_EVENT_GUARD_MS - 1;
-    expect(isDuplicateStageEvent(now, lastHandledAt)).toBe(true);
+    const last = { time: 1_000, pos: { x: 100, y: 100 } };
+    const now = last.time + DUPLICATE_EVENT_GUARD_MS - 1;
+    const pos = { x: 100, y: 100 };
+    expect(isDuplicateStageEvent(now, pos, last, 1)).toBe(true);
   });
 
-  it("does not flag an event at or beyond the guard window as a duplicate", () => {
-    const lastHandledAt = 1_000;
-    const now = lastHandledAt + DUPLICATE_EVENT_GUARD_MS;
-    expect(isDuplicateStageEvent(now, lastHandledAt)).toBe(false);
+  it("does not flag an event at or beyond the guard window as a duplicate, even at the same spot", () => {
+    const last = { time: 1_000, pos: { x: 100, y: 100 } };
+    const now = last.time + DUPLICATE_EVENT_GUARD_MS;
+    const pos = { x: 100, y: 100 };
+    expect(isDuplicateStageEvent(now, pos, last, 1)).toBe(false);
+  });
+
+  it("does not flag the very first stage event (no previous event recorded)", () => {
+    expect(isDuplicateStageEvent(1_000, { x: 0, y: 0 }, null, 1)).toBe(false);
+  });
+
+  // R15.3: this is the actual bug. The guard exists to swallow a stray
+  // synthesized duplicate of the SAME physical touch (tap + compat click),
+  // which lands at essentially the same coordinates. A time-only guard also
+  // swallows a genuine second tap at DISTINCT coordinates - e.g. two cones
+  // in a tight slalom tapped well under 80ms apart - silently dropping a
+  // real route point before it ever reaches handlePathTap / the
+  // double-tap-to-finish check.
+  it("does NOT flag a fast second tap at clearly distinct coordinates as a duplicate", () => {
+    const last = { time: 1_000, pos: { x: 100, y: 100 } };
+    const now = last.time + 50; // well within DUPLICATE_EVENT_GUARD_MS
+    const pos = { x: 100 + DUPLICATE_EVENT_GUARD_DIST * 5, y: 100 };
+    expect(isDuplicateStageEvent(now, pos, last, 1)).toBe(false);
+  });
+
+  it("is scale-aware: converts logical-space distance to real screen pixels before comparing", () => {
+    const scale = 3;
+    const last = { time: 1_000, pos: { x: 100, y: 100 } };
+    const now = last.time + 50;
+    // Logical gap alone is tiny, but at this scale the real on-screen gap
+    // is well past DUPLICATE_EVENT_GUARD_DIST - a genuinely distinct tap.
+    const logicalGap = DUPLICATE_EVENT_GUARD_DIST;
+    const pos = { x: 100 + logicalGap, y: 100 };
+    expect(isDuplicateStageEvent(now, pos, last, scale)).toBe(false);
+  });
+
+  it("simulates a fast-tap sequence: N distinct, closely-spaced taps under the guard window each register as separate stage events, none swallowed", () => {
+    // Mirrors a real tight cone-slalom sequence: every tap lands well
+    // within DUPLICATE_EVENT_GUARD_MS of the previous one, but at a
+    // distinct coordinate. This exercises event-level logic only (the pure
+    // decision function against a sequence of (time, position) inputs) -
+    // it does not drive a real Konva Stage or a real touchscreen, so it
+    // cannot prove real-device touch/compat-event behaviour.
+    const taps = [
+      { time: 0, pos: { x: 0, y: 0 } },
+      { time: 30, pos: { x: 40, y: 0 } },
+      { time: 65, pos: { x: 80, y: 5 } },
+      { time: 100, pos: { x: 120, y: 0 } },
+      { time: 140, pos: { x: 160, y: 8 } },
+    ];
+
+    let last: { time: number; pos: { x: number; y: number } } | null = null;
+    const registered: typeof taps = [];
+    for (const tap of taps) {
+      const duplicate = isDuplicateStageEvent(tap.time, tap.pos, last, 1);
+      expect(duplicate).toBe(false);
+      registered.push(tap);
+      last = tap;
+    }
+    expect(registered).toHaveLength(taps.length);
   });
 });
 

--- a/lib/board/tapGuard.test.ts
+++ b/lib/board/tapGuard.test.ts
@@ -59,6 +59,54 @@ describe("isDuplicateStageEvent (R11 guard)", () => {
     expect(isDuplicateStageEvent(now, pos, last, scale)).toBe(false);
   });
 
+  // R15.3 follow-up: this is the case the position-aware guard exists to
+  // still catch. Traced in Konva's Stage.js (setPointersPositions /
+  // _pointerup): "tap" is synthesized from the native touchend event's
+  // touch.clientX/clientY, "click" from a browser-synthesized compat
+  // mouseup's evt.clientX/clientY - two DIFFERENT native events, computed
+  // through the same content-rect math, not one shared coordinate read. Per
+  // the universally-implemented touch-to-mouse compatibility-event
+  // convention the synthetic click reuses the ending touch's screen
+  // position, so real-world drift between the two is expected to be near
+  // 0px - but it is not literally the same object, so a test must exercise
+  // it as two independent events with a small (non-zero) coordinate delta,
+  // not as one mocked position reused for both.
+  it("still catches a same-touch onTap+onClick pair even with a few pixels of realistic coordinate drift", () => {
+    // "tap" from touchend at the physical touch point.
+    const tapEvent = { time: 1_000, pos: { x: 200, y: 150 } };
+    // Browser-synthesized "click" moments later, for the SAME physical
+    // touch - clientX/clientY nominally match the touch, but allow a small
+    // realistic drift (sub-pixel rect rounding etc.), well under
+    // DUPLICATE_EVENT_GUARD_DIST.
+    const clickEvent = {
+      time: tapEvent.time + 20,
+      pos: { x: tapEvent.pos.x + 3, y: tapEvent.pos.y - 2 },
+    };
+    expect(
+      isDuplicateStageEvent(clickEvent.time, clickEvent.pos, tapEvent, 1),
+    ).toBe(true);
+  });
+
+  it("still catches a same-touch pair at the largest realistic AF end-zone scale with drift", () => {
+    // Combine the R15.2 scale correction with the R15.3 same-touch drift
+    // case: even at the largest observed AF scale, a few real screen px of
+    // drift between tap and click must still be swallowed as a duplicate.
+    const scale = 900 / 384; // ~2.34, AF end-zone (Strefa końcowa)
+    const tapEvent = { time: 1_000, pos: { x: 200, y: 150 } };
+    const screenDriftX = 4;
+    const screenDriftY = 3;
+    const clickEvent = {
+      time: tapEvent.time + 20,
+      pos: {
+        x: tapEvent.pos.x + screenDriftX / scale,
+        y: tapEvent.pos.y - screenDriftY / scale,
+      },
+    };
+    expect(
+      isDuplicateStageEvent(clickEvent.time, clickEvent.pos, tapEvent, scale),
+    ).toBe(true);
+  });
+
   it("simulates a fast-tap sequence: N distinct, closely-spaced taps under the guard window each register as separate stage events, none swallowed", () => {
     // Mirrors a real tight cone-slalom sequence: every tap lands well
     // within DUPLICATE_EVENT_GUARD_MS of the previous one, but at a

--- a/lib/board/tapGuard.ts
+++ b/lib/board/tapGuard.ts
@@ -5,19 +5,38 @@ import type { BoardPoint } from "./types";
 // Mobile browsers can deliver more than one Konva event ("tap" and "click")
 // for a single physical touch, especially when a device's touch-to-mouse
 // compatibility click isn't fully suppressed. A stray duplicate of the SAME
-// touch lands right after the real one, at distance 0, and would get
-// misread as a deliberate double-tap-to-finish. A genuine human double-tap
-// always has more than a few tens of milliseconds between the two touches;
-// a synthesized duplicate of the same touch does not. This guard - well
-// under DOUBLE_TAP_MS so it never interferes with a genuine fast
+// touch lands right after the real one, at essentially the same coordinates,
+// and would get misread as a deliberate double-tap-to-finish (or, worse,
+// just silently swallowed if the guard were time-only). A genuine human
+// double-tap always has more than a few tens of milliseconds between the two
+// touches; a synthesized duplicate of the same touch does not. This guard -
+// well under DOUBLE_TAP_MS so it never interferes with a genuine fast
 // double-tap-to-finish - swallows only the latter.
+//
+// R15.3: the guard MUST also check position, not just elapsed time. A tight
+// cone slalom produces genuine physical taps well under 80ms apart but at
+// clearly distinct coordinates; a time-only guard drops that second real tap
+// entirely (never even reaching the double-tap-to-finish distance check),
+// which reads on-device as a lost route point / early finish. Only a
+// same-touch synthetic duplicate lands within DUPLICATE_EVENT_GUARD_DIST
+// real screen pixels of the previous event.
 export const DUPLICATE_EVENT_GUARD_MS = 80;
+export const DUPLICATE_EVENT_GUARD_DIST = 8;
+
+export interface LastStageEvent {
+  time: number;
+  pos: BoardPoint;
+}
 
 export function isDuplicateStageEvent(
   now: number,
-  lastHandledAt: number,
+  pos: BoardPoint,
+  last: LastStageEvent | null,
+  scale: number,
 ): boolean {
-  return now - lastHandledAt < DUPLICATE_EVENT_GUARD_MS;
+  if (last === null) return false;
+  if (now - last.time >= DUPLICATE_EVENT_GUARD_MS) return false;
+  return distance(pos, last.pos) * scale < DUPLICATE_EVENT_GUARD_DIST;
 }
 
 export interface LastTap {


### PR DESCRIPTION
## Summary

Round 15.3 investigation into the fast cone-slalom early-finish bug that still reproduced in "Strefa końcowa" mode after the R15.1 scale fix and R15.2 verification.

Root cause was **not** the distance/scale math (left untouched). It was the R11 duplicate-event guard, `isDuplicateStageEvent` in `lib/board/tapGuard.ts`:

- It compared **elapsed time only** — no position at all — and gated the *entire* `handleStageClick` handler in `components/board/TacticsBoard.tsx`, before `pos` was even computed.
- Two genuine physical taps under 80ms apart at **different** coordinates (routine in a tight cone slalom) had the second tap's handler invocation skipped entirely — the point was silently dropped before it ever reached `handlePathTap` or the (already scale-correct) `isDoubleTapToFinish` check.

Two other candidate causes were investigated and ruled out:
- **pointercancel / gesture hijack**: the container already sets `touch-action: none` / `overscrollBehavior: contain`, and no handler finalizes or aborts `drawingPath` on `pointercancel`/`pointerleave`/outside `pointerup`.
- **Stale `last.pos`**: it's stored in a `ref` (`lastTapRef`), mutated synchronously — not React state — so there's no stale-read window between fast taps.

## Changes

- `lib/board/tapGuard.ts`: `isDuplicateStageEvent` now also takes `pos`, the previous `{ time, pos }`, and `scale`, and only reports a duplicate when the two events are within `DUPLICATE_EVENT_GUARD_MS` **and** within a small (`DUPLICATE_EVENT_GUARD_DIST = 8`), scale-corrected real-screen-pixel radius — i.e. only a true same-touch synthetic duplicate, never a genuine second tap elsewhere.
- `components/board/TacticsBoard.tsx`: `lastHandledAtRef` (a bare timestamp) becomes `lastHandledRef` (a `LastStageEvent | null`, `{ time, pos }`), and `pos` is computed before the dedup check so it can be compared.
- `lib/board/tapGuard.test.ts`: updated existing guard tests for the new signature, plus new regression tests including one that simulates a sequence of fast, distinct-coordinate taps (all well under 80ms apart) and asserts none are swallowed. Commented as event-level logic only, not a real-device touch test.

## Test plan

- [x] `pnpm test` — all 14 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual on-device verification of fast cone-slalom in Strefa końcowa mode (event-level fix only; real touchscreen behavior still needs manual confirmation per existing test-file caveat)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGUwaRUQ52nRo62j8GAKJH)_