### PR TITLE
fix(board): reserve PathDrawingControls space to stop mid-draw layout shift

### DIFF
--- a/components/board/PathDrawingControls.tsx
+++ b/components/board/PathDrawingControls.tsx
@@ -1,58 +1,77 @@
 "use client";
 
 interface PathDrawingControlsProps {
+  /**
+   * Whether a route is actually being drawn right now. This component is
+   * ALWAYS mounted (see TacticsBoard) so its reserved layout space never
+   * appears/disappears mid-draw - `active` only toggles visibility and
+   * interactivity, never whether the element is in the document flow.
+   */
+  active: boolean;
   pointCount: number;
   onFinish: () => void;
   onUndoPoint: () => void;
   onCancel: () => void;
-  /** null when the tool being drawn doesn't support a curve toggle. */
-  curveMode: "sharp" | "smooth" | null;
+  curveMode: "sharp" | "smooth";
+  /** false when the tool being drawn doesn't support a curve toggle. */
+  curveEnabled: boolean;
   onCurveModeChange: (mode: "sharp" | "smooth") => void;
 }
 
 export function PathDrawingControls({
+  active,
   pointCount,
   onFinish,
   onUndoPoint,
   onCancel,
   curveMode,
+  curveEnabled,
   onCurveModeChange,
 }: PathDrawingControlsProps) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-emerald-300 bg-emerald-50 px-4 py-2.5 text-sm dark:border-emerald-900/50 dark:bg-emerald-950/30">
+    <div
+      aria-hidden={!active}
+      className={`flex flex-wrap items-center justify-between gap-3 rounded-xl border border-emerald-300 bg-emerald-50 px-4 py-2.5 text-sm dark:border-emerald-900/50 dark:bg-emerald-950/30 ${
+        active ? "" : "invisible"
+      }`}
+    >
       <div className="flex flex-wrap items-center gap-3">
         <span className="text-emerald-800 dark:text-emerald-300">
           Stukaj kolejne punkty trasy (zaznaczono: {pointCount}). Zakończ
           dwukrotnym dotknięciem ekranu lub przyciskiem „Gotowe”.
         </span>
-        {curveMode && (
-          <div className="flex shrink-0 overflow-hidden rounded-full border border-emerald-300 text-xs dark:border-emerald-800">
-            <button
-              type="button"
-              onClick={() => onCurveModeChange("sharp")}
-              aria-pressed={curveMode === "sharp"}
-              className={`px-2.5 py-1 font-medium transition-colors ${
-                curveMode === "sharp"
-                  ? "bg-emerald-600 text-white"
-                  : "bg-white text-emerald-800 hover:bg-emerald-50 dark:bg-neutral-900 dark:text-emerald-300"
-              }`}
-            >
-              Trasa ostra
-            </button>
-            <button
-              type="button"
-              onClick={() => onCurveModeChange("smooth")}
-              aria-pressed={curveMode === "smooth"}
-              className={`px-2.5 py-1 font-medium transition-colors ${
-                curveMode === "smooth"
-                  ? "bg-emerald-600 text-white"
-                  : "bg-white text-emerald-800 hover:bg-emerald-50 dark:bg-neutral-900 dark:text-emerald-300"
-              }`}
-            >
-              Trasa gładka
-            </button>
-          </div>
-        )}
+        {/* Always rendered (never mounted/unmounted based on curveEnabled) so
+            the flex-wrap layout - and therefore this bar's height - is
+            identical whether or not the active tool supports curves. Only
+            `disabled` toggles, never presence. */}
+        <div className="flex shrink-0 overflow-hidden rounded-full border border-emerald-300 text-xs dark:border-emerald-800">
+          <button
+            type="button"
+            onClick={() => onCurveModeChange("sharp")}
+            disabled={!curveEnabled}
+            aria-pressed={curveMode === "sharp"}
+            className={`px-2.5 py-1 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+              curveMode === "sharp"
+                ? "bg-emerald-600 text-white"
+                : "bg-white text-emerald-800 hover:bg-emerald-50 dark:bg-neutral-900 dark:text-emerald-300"
+            }`}
+          >
+            Trasa ostra
+          </button>
+          <button
+            type="button"
+            onClick={() => onCurveModeChange("smooth")}
+            disabled={!curveEnabled}
+            aria-pressed={curveMode === "smooth"}
+            className={`px-2.5 py-1 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+              curveMode === "smooth"
+                ? "bg-emerald-600 text-white"
+                : "bg-white text-emerald-800 hover:bg-emerald-50 dark:bg-neutral-900 dark:text-emerald-300"
+            }`}
+          >
+            Trasa gładka
+          </button>
+        </div>
       </div>
       <div className="flex shrink-0 gap-2">
         <button
@@ -74,7 +93,8 @@ export function PathDrawingControls({
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-full border border-neutral-300 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          disabled={!active}
+          className="rounded-full border border-neutral-300 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700 dark:hover:bg-neutral-800"
         >
           Anuluj
         </button>

--- a/components/board/TacticsBoard.tsx
+++ b/components/board/TacticsBoard.tsx
@@ -592,19 +592,24 @@ export function TacticsBoard({
         </div>
       )}
 
-      {drawingPath && !pendingAction && (
-        <PathDrawingControls
-          pointCount={drawingPath.points.length}
-          onFinish={finishDrawingPath}
-          onUndoPoint={undoLastPathPoint}
-          onCancel={() => {
-            cancelDrawingPath();
-            setActiveTool("select");
-          }}
-          curveMode={drawingToolCurvable ? curveMode : null}
-          onCurveModeChange={handleCurveModeChange}
-        />
-      )}
+      {/* Always mounted - see PathDrawingControls' `active` prop. Toggling
+          this bar's mere presence (rather than its visibility) is what used
+          to shove the canvas down the instant a route's first point landed:
+          a fast second tap, already aimed at the pre-shift screen position,
+          would land on this bar instead of the canvas (R15.4). */}
+      <PathDrawingControls
+        active={Boolean(drawingPath) && !pendingAction}
+        pointCount={drawingPath?.points.length ?? 0}
+        onFinish={finishDrawingPath}
+        onUndoPoint={undoLastPathPoint}
+        onCancel={() => {
+          cancelDrawingPath();
+          setActiveTool("select");
+        }}
+        curveMode={curveMode}
+        curveEnabled={drawingToolCurvable}
+        onCurveModeChange={handleCurveModeChange}
+      />
 
       <div
         ref={containerRef}


### PR DESCRIPTION
## Summary

R15.0-15.3 diagnosed the "early finish" bug as American-Football-specific (narrow end-zone scale, double-tap distance math). R15.4 disproved that: the bug reproduces on any sport, on fast tapping, and 16 green Vitest tests (which only exercise the pure `isDoubleTapToFinish`/`isDuplicateStageEvent` functions against mocked `(time, pos)` tuples) never caught it because it isn't a distance/timing bug at all.

**Real mechanism**, captured with a real touch-event trace (CDP-dispatched `Input.dispatchTouchEvent`, not mocked, driving the actual rendered component tree):

`PathDrawingControls` (the "Cofnij punkt / Gotowe / Anuluj" bar) only mounted once `drawingPath` went `null` -> non-null, i.e. the instant the *first* tap of a route landed. That mount pushed the canvas down in the page's normal document flow (116px in one run, more on narrow phone widths where the Polish instruction text wraps to 2+ lines). A coach fast-tapping a cone slalom aims at fixed *screen* positions for each subsequent cone; by the time tap 2 lands, the canvas has already shifted under their finger. The tap lands on the newly-inserted bar instead - its text (point silently lost) or, worse, one of its buttons (`Anuluj` destroys the route outright and reverts the active tool to `"select"`, so nothing thereafter can finish it either).

This explains every symptom from the bug report: sport-agnostic (the bar is shared across all sports), speed-dependent (only fast tapping outruns the coach's visual reaction to the reflow), and untouched by the R15.3 scale fix (this never reaches the double-tap distance check at all).

## Fix

- `PathDrawingControls` is now always mounted. A new `active` prop toggles visibility/interactivity via CSS (`visibility: hidden`, which reserves layout space and blocks pointer/focus) instead of the bar appearing/disappearing from the document flow.
- The curve-mode toggle buttons are likewise always rendered (previously conditionally mounted based on whether the active tool supports curves) and now `disabled` via a new `curveEnabled` prop instead - so the flex-wrap layout, and therefore the bar's height, never changes shape between "idle" and "drawing a curvable tool" (exactly where the tallest, 2-line-wrapped state lives on narrow viewports).
- `TacticsBoard.tsx` updated to always render `PathDrawingControls` with `active={Boolean(drawingPath) && !pendingAction}`.

## Verification

Built a temporary debug harness (not committed) rendering `TacticsBoard` directly, driven by real CDP-dispatched touch events at 375px and 500px viewport widths:

- `canvas.getBoundingClientRect().y` is **identical** before the first tap and after `PathDrawingControls` becomes visible, at both widths (`before.y === after.y` -> `true`).
- The always-mounted bar's own height is identical whether invisible (idle) or visible (drawing), at 375px: `162px` both times, confirming the reserved space matches the 2-line-wrapped state exactly.
- All taps in a fast 6-tap sequence land on `CANVAS` (verified via `document.elementFromPoint`), none stray onto the control bar.
- A full 4-point fast-tap route completes correctly via "Gotowe" (point count reaches 4, bar hides again after finish, canvas position still unchanged throughout).

`pnpm test` (16/16) and `tsc --noEmit` pass, but per the investigation notes, these are not the proof of the fix - the real-event trace above is.

## Test plan

- [x] `pnpm test` - 16/16 passing
- [x] `tsc --noEmit` - clean
- [x] `eslint` on changed files - clean
- [x] Real touch-event trace at 375px and 500px confirms zero canvas shift and correct fast multi-tap route completion
- [ ] On-device re-test (soccer and AF end-zone) - pending user verification before merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01JL4q1BBcdBszy8vbRGQF8D)_