### PR TITLE
fix(exercises): correct AF backfill, persist Dyscyplina filter in URL

### DIFF
--- a/app/app/exercises/page.tsx
+++ b/app/app/exercises/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { ExercisesLibrary } from "@/components/exercises/ExercisesLibrary";
 import { createClient } from "@/lib/supabase/server";
 
@@ -18,10 +19,12 @@ export default async function ExercisesPage() {
     ]);
 
   return (
-    <ExercisesLibrary
-      categories={categories ?? []}
-      sports={sports ?? []}
-      currentUserId={userData.user?.id ?? null}
-    />
+    <Suspense fallback={null}>
+      <ExercisesLibrary
+        categories={categories ?? []}
+        sports={sports ?? []}
+        currentUserId={userData.user?.id ?? null}
+      />
+    </Suspense>
   );
 }

--- a/components/exercises/ExerciseCard.tsx
+++ b/components/exercises/ExerciseCard.tsx
@@ -1,18 +1,26 @@
 import Link from "next/link";
-import type { Category, Exercise, PublicProfile } from "@/lib/supabase/types";
+import type {
+  Category,
+  Exercise,
+  PublicProfile,
+  Sport,
+} from "@/lib/supabase/types";
 import { formatDuration } from "@/lib/exercises";
 import { AuthorBadge } from "./AuthorBadge";
 import { CategoryBadge } from "./CategoryBadge";
 import { DifficultyIndicator } from "./DifficultyIndicator";
+import { SportBadge } from "./SportBadge";
 
 export function ExerciseCard({
   exercise,
   category,
+  sport,
   authorsById,
   currentUserId,
 }: {
   exercise: Exercise;
   category: Category | undefined;
+  sport: Sport | undefined;
   authorsById: Map<string, PublicProfile>;
   currentUserId: string | null;
 }) {
@@ -24,6 +32,7 @@ export function ExerciseCard({
       <h3 className="font-semibold tracking-tight">{exercise.title}</h3>
 
       <div className="mt-3 flex flex-wrap items-center gap-2">
+        {sport && <SportBadge name={sport.name_pl} />}
         {category && (
           <CategoryBadge name={category.name_pl} slug={category.slug} />
         )}

--- a/components/exercises/ExerciseForm.tsx
+++ b/components/exercises/ExerciseForm.tsx
@@ -68,7 +68,11 @@ export function ExerciseForm({
     duplicateFrom?.category_id ?? "",
   );
   const [sportId, setSportId] = useState<number | "">(
+    // Prefer American football: it's the sport this coach actually runs
+    // today. Fall back to football (the original single-sport default) if
+    // the AF row is ever missing, so the select never silently opens blank.
     duplicateFrom?.sport_id ??
+      sports.find((sport) => sport.slug === "american_football")?.id ??
       sports.find((sport) => sport.slug === "football")?.id ??
       "",
   );

--- a/components/exercises/ExercisesLibrary.tsx
+++ b/components/exercises/ExercisesLibrary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type {
@@ -26,6 +27,10 @@ export function ExercisesLibrary({
   sports: Sport[];
   currentUserId: string | null;
 }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
   const [exercises, setExercises] = useState<Exercise[] | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
@@ -33,7 +38,15 @@ export function ExercisesLibrary({
 
   const [search, setSearch] = useState("");
   const [scopeFilter, setScopeFilter] = useState<typeof ALL | typeof MINE>(ALL);
-  const [sportFilter, setSportFilter] = useState<number | typeof ALL>(ALL);
+  // Sport is the one filter a coach expects to survive a page reload or a
+  // shared link (e.g. "here's our AF library view") - initialize it from
+  // the URL and keep the URL in sync via setSportFilter below.
+  const [sportFilter, setSportFilterState] = useState<number | typeof ALL>(
+    () => {
+      const fromUrl = Number(searchParams.get("sport"));
+      return fromUrl && Number.isInteger(fromUrl) ? fromUrl : ALL;
+    },
+  );
   const [categoryFilter, setCategoryFilter] = useState<number | typeof ALL>(
     ALL,
   );
@@ -97,6 +110,20 @@ export function ExercisesLibrary({
     for (const sport of sports) map.set(sport.id, sport);
     return map;
   }, [sports]);
+
+  function setSportFilter(value: number | typeof ALL) {
+    setSportFilterState(value);
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === ALL) {
+      params.delete("sport");
+    } else {
+      params.set("sport", String(value));
+    }
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }
 
   const equipmentOptions = useMemo(() => {
     const values = new Set<string>();
@@ -362,6 +389,7 @@ export function ExercisesLibrary({
                 key={exercise.id}
                 exercise={exercise}
                 category={categoriesById.get(exercise.category_id)}
+                sport={sportsById.get(exercise.sport_id)}
                 authorsById={authorsById}
                 currentUserId={currentUserId}
               />

--- a/supabase/migrations/20260716100000_backfill_af_exercises.sql
+++ b/supabase/migrations/20260716100000_backfill_af_exercises.sql
@@ -1,0 +1,14 @@
+-- Coach Zone — correct the sport_id backfill for existing exercises
+-- Migration 13. Run after 20260712100000_coach_pseudonyms.sql.
+
+-- Migration 6 (20260710100000_sports_and_exercise_sport_id.sql) backfilled
+-- every pre-existing exercise to 'football' (soccer) because that was the
+-- only sport row that existed at the time. 'american_football' was only
+-- added afterward, in migration 7 (20260711100000). Every exercise in the
+-- library today is actually American football content authored by the
+-- single coach using this instance, so re-point them now that the correct
+-- sport row exists. New exercises created since then already carry the
+-- sport the coach picked explicitly in the form and are unaffected.
+update public.exercises
+set sport_id = (select id from public.sports where slug = 'american_football')
+where sport_id = (select id from public.sports where slug = 'football');


### PR DESCRIPTION
## Summary

Round 16 asked for sport segmentation on exercises — but that groundwork (`sport_id` column + FK, the "Dyscyplina" selector on create, the "Dyscyplina" filter dropdown in the library) was already built in round 15 (`15229f1`, `d194f26`). This PR closes the two real gaps left over:

1. **Wrong backfill data.** The original backfill (migration 6) set every existing exercise's `sport_id` to `football` (soccer), because `american_football` didn't exist as a sport row yet at that point in the migration sequence. Every exercise in the library today is actually American football content — this was a data bug, not a schema gap.
2. **Sport filter didn't survive navigation.** `sportFilter` in `ExercisesLibrary` was plain component state, reset on every remount (back/forward nav, reload, sharing a link).

Also added: the sport badge is now shown on each `ExerciseCard`, so a filtered result set is visually confirmable at a glance.

## Changes

- **`supabase/migrations/20260716100000_backfill_af_exercises.sql`** — new migration, **for manual paste into the Supabase SQL Editor** (no DB token available here). Re-points exercises from `football` to `american_football`.
- **`components/exercises/ExerciseForm.tsx`** — new-exercise default now prefers `american_football`, falling back to `football` only if that row is somehow missing.
- **`components/exercises/ExercisesLibrary.tsx`** — the sport filter now syncs to a `?sport=<id>` URL query param via `useSearchParams` + `router.replace({ scroll: false })`, so it survives reload/back-forward and is shareable as a link.
- **`app/app/exercises/page.tsx`** — wraps `ExercisesLibrary` in `<Suspense>`, required by Next.js when a client component calls `useSearchParams`.
- **`components/exercises/ExerciseCard.tsx`** — renders `SportBadge` alongside the category badge.

## Migration to run manually (Supabase SQL Editor)

**Step 1 — confirm the AF sport id first:**
```sql
select id, slug, name_pl, name_en from public.sports where slug = 'american_football';
```

**Step 2 — once confirmed, run the backfill** (also committed as `supabase/migrations/20260716100000_backfill_af_exercises.sql`):
```sql
update public.exercises
set sport_id = (select id from public.sports where slug = 'american_football')
where sport_id = (select id from public.sports where slug = 'football');
```
This only touches rows still on the old default (`football`); any exercise a coach has since created with an explicit sport choice is untouched.

## Filter state storage

`sportFilter` lives in React state as before, but is now initialized from and kept in sync with the `sport` URL search param (id, or absent for "all"). Other filters (search, scope, category, difficulty, equipment) remain local-only, matching what this round asked for.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 16/16 passing
- [x] `pnpm build` — succeeds, `/app/exercises` renders as a dynamic route with the new Suspense boundary
- [ ] Manual verification on prod (coach will test Tuesday): run the migration, confirm existing exercises show "Futbol amerykański", confirm the Dyscyplina filter narrows results and survives reload/back-nav, confirm new/duplicated exercises still respect the immutability model (create requires a sport; edit goes through duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196v1swbk1yba42tbf5u7ap

---
_Generated by [Claude Code](https://claude.ai/code/session_0196v1swbk1yba42tbf5u7ap)_