### PR TITLE
Animated product showcase, wired into first-login onboarding

### DIFF
--- a/app/app/actions.ts
+++ b/app/app/actions.ts
@@ -1,10 +1,29 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 
 export async function logout() {
   const supabase = await createClient();
   await supabase.auth.signOut();
   redirect("/login");
+}
+
+// Marks the animated showcase as seen so it never shows again for this
+// account - server-side and per-profile, not a client-side flag, so it
+// holds across devices and sessions.
+export async function completeOnboarding() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  await supabase
+    .from("profiles")
+    .update({ onboarding_completed: true })
+    .eq("id", user.id);
+
+  revalidatePath("/app");
 }

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { OnboardingOverlay } from "@/components/onboarding/OnboardingOverlay";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -37,7 +38,7 @@ export default async function AppHomePage() {
   const { data: profile } = user
     ? await supabase
         .from("profiles")
-        .select("display_name")
+        .select("display_name, onboarding_completed")
         .eq("id", user.id)
         .single()
     : { data: null };
@@ -50,6 +51,8 @@ export default async function AppHomePage() {
 
   return (
     <main className="mx-auto max-w-3xl px-6 pt-8 pb-20">
+      {profile && !profile.onboarding_completed && <OnboardingOverlay />}
+
       <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
         Witaj, {displayName}
       </h1>

--- a/components/onboarding/OnboardingOverlay.tsx
+++ b/components/onboarding/OnboardingOverlay.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { completeOnboarding } from "@/app/app/actions";
+import { OnboardingShowcaseLoader } from "@/components/showcase/ShowcaseLoader";
+
+/**
+ * Full-screen, first-login-only welcome. Rendered by app/app/page.tsx only
+ * when the profile's `onboarding_completed` flag is still false - once
+ * dismissed (either control), that flag flips server-side so this never
+ * shows again for this account, on any device.
+ */
+export function OnboardingOverlay() {
+  const [dismissed, setDismissed] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function finish() {
+    // Dismiss immediately - the coach shouldn't wait on a network
+    // round-trip to get into the app. The write still happens; if it's
+    // ever lost mid-flight the next login just shows this once more.
+    setDismissed(true);
+    startTransition(() => {
+      completeOnboarding();
+    });
+  }
+
+  if (dismissed) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-neutral-950 text-white">
+      <div className="flex items-center justify-between px-5 pt-5 sm:px-8 sm:pt-8">
+        <span className="text-sm font-semibold tracking-tight text-neutral-300">
+          Coach Zone
+        </span>
+        <button
+          type="button"
+          onClick={finish}
+          className="text-sm text-neutral-400 transition-colors hover:text-white"
+        >
+          Pomiń
+        </button>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center px-4 py-6 sm:px-10">
+        <div className="w-full max-w-3xl">
+          <OnboardingShowcaseLoader className="aspect-[4/3] w-full sm:aspect-[16/9]" />
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-4 px-6 pb-10 text-center sm:pb-14">
+        <p className="max-w-md text-sm text-neutral-400">
+          Tak wygląda tablica taktyczna Coach Zone — narysujesz na niej akcję
+          dla dowolnej dyscypliny w kilka sekund.
+        </p>
+        <button
+          type="button"
+          onClick={finish}
+          disabled={isPending}
+          className="rounded-full bg-emerald-600 px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-emerald-500 disabled:opacity-60"
+        >
+          Zacznij
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/showcase/AnimatedPath.tsx
+++ b/components/showcase/AnimatedPath.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Arrow, Circle, Line } from "react-konva";
+import { flattenPoints } from "@/lib/board/path";
+import { easeInOutCubic, easeOutCubic, timedProgress } from "@/lib/board/showcase/easing";
+import { revealPathPoints } from "@/lib/board/showcase/reveal";
+import type { ShowcasePath } from "@/lib/board/showcase/types";
+
+// Same styling TacticsBoard.tsx uses for the in-progress point markers
+// while a coach is actively drawing a route on the real board (line 690) -
+// reusing it here signals "this is being drawn right now", the same way it
+// does live.
+const DRAWING_TIP_COLOR = "#10b981";
+const ARROWHEAD_SETTLE_MS = 220;
+
+export function AnimatedPath({ path, elapsed }: { path: ShowcasePath; elapsed: number }) {
+  const progress = timedProgress(elapsed, path.startAt, path.duration, easeInOutCubic);
+  if (progress <= 0) return null;
+
+  const revealed = revealPathPoints(path.points, Boolean(path.curved), Boolean(path.wavy), progress);
+  if (revealed.points.length < 2) return null;
+
+  const flat = flattenPoints(revealed.points);
+  const arrowheadProgress = revealed.complete
+    ? timedProgress(elapsed, path.startAt + path.duration, ARROWHEAD_SETTLE_MS, easeOutCubic)
+    : 0;
+
+  return (
+    <>
+      {path.headStyle === "arrow" && revealed.complete ? (
+        <Arrow
+          points={flat}
+          tension={0}
+          stroke={path.color}
+          fill={path.color}
+          strokeWidth={path.strokeWidth}
+          dash={path.dash}
+          pointerLength={14 * arrowheadProgress}
+          pointerWidth={14 * arrowheadProgress}
+          lineCap="round"
+          lineJoin="round"
+          listening={false}
+        />
+      ) : (
+        <Line
+          points={flat}
+          tension={0}
+          stroke={path.color}
+          strokeWidth={path.strokeWidth}
+          dash={path.dash}
+          lineCap="round"
+          lineJoin="round"
+          listening={false}
+        />
+      )}
+      {!revealed.complete && revealed.tip && (
+        <Circle
+          x={revealed.tip.x}
+          y={revealed.tip.y}
+          radius={7}
+          fill={DRAWING_TIP_COLOR}
+          stroke="#ffffff"
+          strokeWidth={1.5}
+          listening={false}
+        />
+      )}
+    </>
+  );
+}

--- a/components/showcase/AnimatedPoint.tsx
+++ b/components/showcase/AnimatedPoint.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Group } from "react-konva";
+import { BoardElementNode } from "@/components/board/BoardElementNode";
+import { easeOutCubic, timedProgress } from "@/lib/board/showcase/easing";
+import type { ShowcaseMarker } from "@/lib/board/showcase/types";
+
+const FADE_DURATION = 450;
+const noop = () => {};
+
+/**
+ * Fades and settles a real board marker (same BoardElementNode used by the
+ * live editor - same glyphs, same colors) into place at `marker.appearAt`.
+ * Scales in from 0.7x to 1x around the marker's own position, not the
+ * stage origin, so it reads as a calm "settle" rather than a pop.
+ */
+export function AnimatedPoint({
+  marker,
+  elapsed,
+}: {
+  marker: ShowcaseMarker;
+  elapsed: number;
+}) {
+  const progress = timedProgress(elapsed, marker.appearAt, FADE_DURATION, easeOutCubic);
+  if (progress <= 0) return null;
+
+  const scale = 0.7 + progress * 0.3;
+
+  return (
+    <Group x={marker.x} y={marker.y} opacity={progress} scaleX={scale} scaleY={scale}>
+      <BoardElementNode
+        element={{
+          id: marker.id,
+          type: "point",
+          kind: marker.kind,
+          x: 0,
+          y: 0,
+          label: marker.label ?? "",
+        }}
+        selected={false}
+        interactive={false}
+        onSelect={noop}
+        onDragEnd={noop}
+        onEditLabel={noop}
+      />
+    </Group>
+  );
+}

--- a/components/showcase/BoardShowcaseEngine.tsx
+++ b/components/showcase/BoardShowcaseEngine.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { paceScene } from "@/lib/board/showcase/scale";
+import type { ShowcaseScene } from "@/lib/board/showcase/types";
+import { BoardShowcaseScene } from "./BoardShowcaseScene";
+
+interface Slot {
+  key: number;
+  sceneIndex: number;
+  startedAt: number;
+}
+
+export interface BoardShowcaseEngineProps {
+  scenes: ShowcaseScene[];
+  /** Duration multiplier: >1 slower/calmer, <1 tighter. */
+  pace: number;
+  /** Extra pause after a scene's choreography finishes, before it starts fading out. */
+  holdMs: number;
+  /** Crossfade duration between scenes. */
+  transitionMs: number;
+  loop: boolean;
+  showCaptions: boolean;
+  className?: string;
+}
+
+/**
+ * The one shared animation engine behind both the onboarding and landing
+ * showcases. Owns the playback clock and the scene sequence/crossfade;
+ * everything sport-specific (field, colors, choreography) comes from
+ * `scenes`, and everything about pacing/looping/captions comes from props -
+ * so the two call sites only differ in what they pass in here.
+ */
+export function BoardShowcaseEngine({
+  scenes,
+  pace,
+  holdMs,
+  transitionMs,
+  loop,
+  showCaptions,
+  className,
+}: BoardShowcaseEngineProps) {
+  const pacedScenes = useMemo(() => scenes.map((s) => paceScene(s, pace)), [scenes, pace]);
+
+  const [now, setNow] = useState(() => performance.now());
+  const [slots, setSlots] = useState<Slot[]>(() => [
+    { key: 0, sceneIndex: 0, startedAt: performance.now() },
+  ]);
+  const [frontKey, setFrontKey] = useState(0);
+  // Deliberately separate from frontKey: frontKey flips at the *start* of
+  // a crossfade (so the CSS opacity transition has something to animate
+  // toward), but swapping the caption text at that same moment made it
+  // announce the next sport while the board was still visually showing the
+  // previous one for the whole transition. This instead updates once the
+  // crossfade has actually finished, alongside the old slot's removal.
+  const [captionSceneIndex, setCaptionSceneIndex] = useState(0);
+  const nextKeyRef = useRef(1);
+  const transitioningRef = useRef(false);
+  // Only cleared by the unmount effect below - deliberately *not* tied to
+  // the polling effect's own re-runs. That polling effect re-fires every
+  // animation frame (it depends on `now`), and a cleanup returned from it
+  // would rerun on every one of those frames too - canceling this timeout
+  // the instant it was scheduled, before it ever got a chance to fire, and
+  // permanently wedging transitioningRef at true after the first swap.
+  const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let raf: number;
+    const tick = (t: number) => {
+      setNow(t);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (pendingTimeoutRef.current) clearTimeout(pendingTimeoutRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (transitioningRef.current) return;
+    const front = slots.find((s) => s.key === frontKey);
+    if (!front) return;
+    const scene = pacedScenes[front.sceneIndex];
+    const elapsed = now - front.startedAt;
+    const total = scene.scriptedDuration + holdMs;
+    if (elapsed < total) return;
+
+    const atEnd = front.sceneIndex === scenes.length - 1;
+    if (atEnd && !loop) return;
+
+    transitioningRef.current = true;
+    const nextIndex = (front.sceneIndex + 1) % scenes.length;
+    const newKey = nextKeyRef.current++;
+    setSlots((prev) => [...prev, { key: newKey, sceneIndex: nextIndex, startedAt: now }]);
+
+    // Let the new slot mount (and paint) at opacity 0 first, so flipping
+    // `frontKey` a frame later is what the CSS transition actually
+    // animates - flipping in the same tick would skip straight to the end
+    // state with no crossfade.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setFrontKey(newKey));
+    });
+
+    pendingTimeoutRef.current = setTimeout(() => {
+      setSlots((prev) => prev.filter((s) => s.key === newKey));
+      setCaptionSceneIndex(nextIndex);
+      transitioningRef.current = false;
+      pendingTimeoutRef.current = null;
+    }, transitionMs + 80);
+  }, [now, frontKey, slots, pacedScenes, scenes.length, loop, holdMs, transitionMs]);
+
+  const activeCaption = pacedScenes[captionSceneIndex]?.caption;
+
+  return (
+    <div className={`relative ${className ?? ""}`}>
+      <div className="relative h-full w-full">
+        {slots.map((slot) => (
+          <div
+            key={slot.key}
+            className="absolute inset-0 transition-opacity ease-in-out"
+            style={{
+              transitionDuration: `${transitionMs}ms`,
+              opacity: slot.key === frontKey ? 1 : 0,
+            }}
+          >
+            <BoardShowcaseScene scene={pacedScenes[slot.sceneIndex]} elapsed={now - slot.startedAt} />
+          </div>
+        ))}
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-4 flex flex-col items-center gap-3 sm:bottom-6">
+        {showCaptions && (
+          <p
+            key={captionSceneIndex}
+            className="showcase-caption rounded-full bg-neutral-950/70 px-4 py-2 text-sm font-medium text-white backdrop-blur-sm sm:text-base"
+          >
+            {activeCaption}
+          </p>
+        )}
+        <div className="flex items-center gap-2">
+          {scenes.map((_, i) => (
+            <span
+              key={i}
+              className="h-1.5 w-1.5 rounded-full transition-colors duration-700"
+              style={{
+                backgroundColor:
+                  i === captionSceneIndex ? "#10b981" : "rgba(255,255,255,0.25)",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <style jsx>{`
+        .showcase-caption {
+          animation: showcase-caption-in 500ms ease-out;
+        }
+        @keyframes showcase-caption-in {
+          from {
+            opacity: 0;
+            transform: translateY(6px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/components/showcase/BoardShowcaseScene.tsx
+++ b/components/showcase/BoardShowcaseScene.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Layer, Stage } from "react-konva";
+import { getSportConfig } from "@/lib/board/sports/registry";
+import type { ShowcaseScene } from "@/lib/board/showcase/types";
+import { AnimatedPath } from "./AnimatedPath";
+import { AnimatedPoint } from "./AnimatedPoint";
+
+/**
+ * Renders one scripted scene at a given point in time, using the exact same
+ * engine as the real tactics board: react-konva Stage/Layer, the real
+ * per-sport FieldComponent, and the real field dimensions/scaling approach
+ * (a ResizeObserver-driven scale, same as TacticsBoard.tsx) - so what's on
+ * screen here is pixel-identical to the board the coach edits next.
+ */
+export function BoardShowcaseScene({
+  scene,
+  elapsed,
+}: {
+  scene: ShowcaseScene;
+  elapsed: number;
+}) {
+  const config = getSportConfig(scene.sportSlug);
+  const fieldMode =
+    config.fieldModes.find((m) => m.id === scene.fieldModeId) ?? config.fieldModes[0];
+  const dims = { width: fieldMode.width, height: fieldMode.height };
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setContainerSize({ width, height });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const scale = containerSize.width > 0 ? containerSize.width / dims.width : 1;
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full w-full overflow-hidden rounded-2xl sm:rounded-3xl"
+      style={{ aspectRatio: `${dims.width} / ${dims.height}` }}
+    >
+      {containerSize.width > 0 && (
+        <Stage width={containerSize.width} height={containerSize.height} scaleX={scale} scaleY={scale}>
+          <config.FieldComponent modeId={fieldMode.id} width={dims.width} height={dims.height} />
+          <Layer listening={false}>
+            {scene.markers.map((m) => (
+              <AnimatedPoint key={m.id} marker={m} elapsed={elapsed} />
+            ))}
+            {scene.paths.map((p) => (
+              <AnimatedPath key={p.id} path={p} elapsed={elapsed} />
+            ))}
+          </Layer>
+        </Stage>
+      )}
+    </div>
+  );
+}

--- a/components/showcase/LandingShowcase.tsx
+++ b/components/showcase/LandingShowcase.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { showcaseScenes } from "@/lib/board/showcase/scenes";
+import { BoardShowcaseEngine } from "./BoardShowcaseEngine";
+
+/**
+ * Tighter, caption-free, single looping cycle meant to sit inside a landing
+ * page hero - not wired into any page yet (that's a future round), but the
+ * engine underneath is the exact same one the onboarding variant uses.
+ */
+export function LandingShowcase({ className }: { className?: string }) {
+  return (
+    <BoardShowcaseEngine
+      scenes={showcaseScenes}
+      pace={0.85}
+      holdMs={550}
+      transitionMs={500}
+      loop
+      showCaptions={false}
+      className={className ?? "h-full w-full"}
+    />
+  );
+}

--- a/components/showcase/OnboardingShowcase.tsx
+++ b/components/showcase/OnboardingShowcase.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { showcaseScenes } from "@/lib/board/showcase/scenes";
+import { BoardShowcaseEngine } from "./BoardShowcaseEngine";
+
+/**
+ * Full-screen, calm-paced variant with captions - shown once, right after
+ * signup. Slower than the landing loop and holds a beat longer on each
+ * sport so a coach can actually read the caption before it moves on.
+ */
+export function OnboardingShowcase({ className }: { className?: string }) {
+  return (
+    <BoardShowcaseEngine
+      scenes={showcaseScenes}
+      pace={1.15}
+      holdMs={1500}
+      transitionMs={750}
+      loop
+      showCaptions
+      className={className ?? "h-full w-full"}
+    />
+  );
+}

--- a/components/showcase/ShowcaseLoader.tsx
+++ b/components/showcase/ShowcaseLoader.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+// Same reason as TacticsBoardLoader.tsx: react-konva touches canvas APIs at
+// import time, so both showcase variants must load client-only and
+// dynamically, never as part of the server render.
+import dynamic from "next/dynamic";
+
+export const OnboardingShowcaseLoader = dynamic(
+  () => import("./OnboardingShowcase").then((mod) => mod.OnboardingShowcase),
+  { ssr: false, loading: () => <ShowcaseLoadingFallback /> },
+);
+
+export const LandingShowcaseLoader = dynamic(
+  () => import("./LandingShowcase").then((mod) => mod.LandingShowcase),
+  { ssr: false, loading: () => <ShowcaseLoadingFallback /> },
+);
+
+function ShowcaseLoadingFallback() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="h-8 w-8 animate-pulse rounded-full bg-emerald-600/40" />
+    </div>
+  );
+}

--- a/lib/board/showcase/easing.ts
+++ b/lib/board/showcase/easing.ts
@@ -1,0 +1,38 @@
+/**
+ * Easing curves for the board showcase animation. Everything here favours
+ * "calm and deliberate" over "snappy" - no bounce, no overshoot - since the
+ * whole point of the showcase is to read as a premium, unhurried product
+ * moment rather than a flashy demo.
+ */
+
+export type Easing = (t: number) => number;
+
+export function clamp01(t: number): number {
+  return Math.min(1, Math.max(0, t));
+}
+
+export const easeInOutCubic: Easing = (t) => {
+  const x = clamp01(t);
+  return x < 0.5 ? 4 * x * x * x : 1 - (-2 * x + 2) ** 3 / 2;
+};
+
+export const easeOutCubic: Easing = (t) => {
+  const x = clamp01(t);
+  return 1 - (1 - x) ** 3;
+};
+
+export const easeOutQuint: Easing = (t) => {
+  const x = clamp01(t);
+  return 1 - (1 - x) ** 5;
+};
+
+/** Maps `elapsed` into [0,1] progress over [startAt, startAt+duration], then applies an easing curve. */
+export function timedProgress(
+  elapsed: number,
+  startAt: number,
+  duration: number,
+  easing: Easing = easeInOutCubic,
+): number {
+  if (duration <= 0) return elapsed >= startAt ? 1 : 0;
+  return easing(clamp01((elapsed - startAt) / duration));
+}

--- a/lib/board/showcase/reveal.ts
+++ b/lib/board/showcase/reveal.ts
@@ -1,0 +1,71 @@
+import {
+  distance,
+  smoothPathPoints,
+  wavyPathPoints,
+} from "@/lib/board/path";
+import type { BoardPoint } from "@/lib/board/types";
+
+export interface RevealedPath {
+  /** Points to render so far - always starts at the path's true start. */
+  points: BoardPoint[];
+  /** The current drawing tip (last revealed point), or null before anything is revealed. */
+  tip: BoardPoint | null;
+  complete: boolean;
+}
+
+/**
+ * Same render pipeline the real board uses (PathElementNode /
+ * TacticsBoard's drawing preview): curve through the tapped points first
+ * (centripetal Catmull-Rom), then apply the wavy offset on top - then walks
+ * the resulting polyline by arc length up to `progress` (0..1), so a path
+ * "draws itself" as a smooth, constant-speed line growing from its start
+ * rather than jumping vertex to vertex.
+ */
+export function revealPathPoints(
+  points: BoardPoint[],
+  curved: boolean,
+  wavy: boolean,
+  progress: number,
+): RevealedPath {
+  if (points.length < 2 || progress <= 0) {
+    return { points: points.slice(0, points.length > 0 ? 1 : 0), tip: points[0] ?? null, complete: false };
+  }
+
+  const curvedPoints = curved ? smoothPathPoints(points) : points;
+  const renderPoints = wavy ? wavyPathPoints(curvedPoints) : curvedPoints;
+
+  if (progress >= 1) {
+    return { points: renderPoints, tip: renderPoints[renderPoints.length - 1], complete: true };
+  }
+
+  const segmentLengths: number[] = [];
+  let total = 0;
+  for (let i = 0; i < renderPoints.length - 1; i++) {
+    const len = distance(renderPoints[i], renderPoints[i + 1]);
+    segmentLengths.push(len);
+    total += len;
+  }
+  if (total <= 0) {
+    return { points: [renderPoints[0]], tip: renderPoints[0], complete: false };
+  }
+
+  const targetLen = total * progress;
+  const result: BoardPoint[] = [renderPoints[0]];
+  let travelled = 0;
+  for (let i = 0; i < segmentLengths.length; i++) {
+    const segLen = segmentLengths[i];
+    if (travelled + segLen >= targetLen) {
+      const t = segLen > 0 ? (targetLen - travelled) / segLen : 0;
+      const a = renderPoints[i];
+      const b = renderPoints[i + 1];
+      const tip = { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+      result.push(tip);
+      return { points: result, tip, complete: false };
+    }
+    travelled += segLen;
+    result.push(renderPoints[i + 1]);
+  }
+
+  const tip = renderPoints[renderPoints.length - 1];
+  return { points: result, tip, complete: false };
+}

--- a/lib/board/showcase/scale.ts
+++ b/lib/board/showcase/scale.ts
@@ -1,0 +1,20 @@
+import type { ShowcaseScene } from "./types";
+
+/**
+ * Scales every timing in a scene by `pace` (>1 = slower/calmer, <1 =
+ * tighter) without touching positions, colors, or any other authored
+ * detail - lets the onboarding and landing variants share one choreography
+ * while moving at different speeds.
+ */
+export function paceScene(scene: ShowcaseScene, pace: number): ShowcaseScene {
+  return {
+    ...scene,
+    markers: scene.markers.map((m) => ({ ...m, appearAt: m.appearAt * pace })),
+    paths: scene.paths.map((p) => ({
+      ...p,
+      startAt: p.startAt * pace,
+      duration: p.duration * pace,
+    })),
+    scriptedDuration: scene.scriptedDuration * pace,
+  };
+}

--- a/lib/board/showcase/scenes.ts
+++ b/lib/board/showcase/scenes.ts
@@ -1,0 +1,167 @@
+import { AF_FULL_HEIGHT, AF_FULL_WIDTH } from "@/components/board/fields/AmericanFootballField";
+import { americanFootballConfig } from "@/lib/board/sports/americanFootball";
+import { basketballConfig } from "@/lib/board/sports/basketball";
+import { footballConfig } from "@/lib/board/sports/football";
+import type { SportBoardConfig } from "@/lib/board/sports/types";
+import type { ShowcaseScene } from "./types";
+
+// Every stroke color/width/dash below is read directly off the real
+// per-sport tool defs (lib/board/sports/*.tsx) - never invented - so what
+// animates here is styled identically to what the coach draws with that
+// same tool moments later on the real board.
+function toolStyle(config: SportBoardConfig, toolId: string) {
+  const tool = config.tools.find((t) => t.id === toolId);
+  if (!tool || tool.kind.create !== "path") {
+    throw new Error(`Showcase: tool "${toolId}" not found or not a path tool`);
+  }
+  return tool.kind.style;
+}
+
+// ---------------------------------------------------------------------------
+// American football: QB + WR appear, the WR's route draws itself, then a
+// pass arcs from the QB to where the route ends.
+// ---------------------------------------------------------------------------
+const afRoute = toolStyle(americanFootballConfig, "route");
+
+const wrStart = { x: 560, y: 96 };
+const routeEnd = { x: 900, y: 236 };
+const qbPos = { x: 500, y: 320 };
+
+export const americanFootballScene: ShowcaseScene = {
+  sportSlug: "american_football",
+  fieldModeId: "full",
+  caption: "Tak rysujesz trasę zawodnika.",
+  markers: [
+    { id: "qb", kind: "qb", x: qbPos.x, y: qbPos.y, label: "QB", appearAt: 0 },
+    { id: "wr", kind: "player", x: wrStart.x, y: wrStart.y, label: "WR", appearAt: 200 },
+  ],
+  paths: [
+    {
+      id: "route",
+      points: [wrStart, { x: 760, y: 96 }, routeEnd],
+      color: afRoute.color,
+      strokeWidth: afRoute.strokeWidth,
+      headStyle: afRoute.headStyle,
+      curved: true,
+      startAt: 900,
+      duration: 1700,
+    },
+    {
+      id: "pass",
+      points: [qbPos, routeEnd],
+      color: afRoute.color,
+      strokeWidth: afRoute.strokeWidth,
+      headStyle: afRoute.headStyle,
+      curved: true,
+      startAt: 3100,
+      duration: 1000,
+    },
+  ],
+  scriptedDuration: 4100,
+};
+
+export const AF_FIELD_SIZE = { width: AF_FULL_WIDTH, height: AF_FULL_HEIGHT };
+
+// ---------------------------------------------------------------------------
+// Basketball: a player dribbles (wavy path, matching the real dribble
+// tool), then a shot line arcs to the hoop.
+// ---------------------------------------------------------------------------
+const bbDribble = toolStyle(basketballConfig, "dribble");
+const bbShot = toolStyle(basketballConfig, "shot");
+
+const ballStart = { x: 470, y: 270 };
+const dribbleEnd = { x: 790, y: 270 };
+// Right-side hoop centre for the "full" court mode - see BasketballField's
+// EndMarkings: basketX = goalX + dir * BASKET_DEPTH * scaleX, dir=-1 at the
+// right edge, matching the constants used there.
+const hoop = { x: 866, y: 270 };
+
+export const basketballScene: ShowcaseScene = {
+  sportSlug: "basketball",
+  fieldModeId: "full",
+  caption: "Tak powstaje akcja pod koszem.",
+  markers: [{ id: "player", kind: "player", x: ballStart.x, y: ballStart.y, appearAt: 0 }],
+  paths: [
+    {
+      id: "dribble",
+      points: [ballStart, { x: 600, y: 200 }, { x: 700, y: 330 }, dribbleEnd],
+      color: bbDribble.color,
+      strokeWidth: bbDribble.strokeWidth,
+      headStyle: bbDribble.headStyle,
+      wavy: true,
+      startAt: 500,
+      duration: 1700,
+    },
+    {
+      id: "shot",
+      points: [dribbleEnd, hoop],
+      color: bbShot.color,
+      strokeWidth: bbShot.strokeWidth,
+      headStyle: bbShot.headStyle,
+      curved: true,
+      startAt: 2700,
+      duration: 950,
+    },
+  ],
+  scriptedDuration: 3650,
+};
+
+// ---------------------------------------------------------------------------
+// Soccer: a player dribbles through a slalom of cones, the weaving path
+// drawing itself smoothly between them.
+// ---------------------------------------------------------------------------
+const soccerMove = toolStyle(footballConfig, "movement");
+
+const slalomCones = [
+  { x: 650, y: 340 },
+  { x: 720, y: 340 },
+  { x: 790, y: 340 },
+  { x: 860, y: 340 },
+];
+const slalomStart = { x: 580, y: 340 };
+const slalomEnd = { x: 920, y: 340 };
+
+export const soccerScene: ShowcaseScene = {
+  sportSlug: "football",
+  fieldModeId: "full",
+  caption: "Tak prowadzisz zawodnika przez pachołki.",
+  markers: [
+    { id: "player", kind: "player", x: slalomStart.x, y: slalomStart.y, appearAt: 0 },
+    ...slalomCones.map((c, i) => ({
+      id: `cone-${i}`,
+      kind: "cone" as const,
+      x: c.x,
+      y: c.y,
+      appearAt: 150 + i * 90,
+    })),
+  ],
+  paths: [
+    {
+      id: "slalom",
+      points: [
+        slalomStart,
+        { x: slalomCones[0].x, y: 296 },
+        { x: slalomCones[1].x, y: 384 },
+        { x: slalomCones[2].x, y: 296 },
+        { x: slalomCones[3].x, y: 384 },
+        slalomEnd,
+      ],
+      color: soccerMove.color,
+      strokeWidth: soccerMove.strokeWidth,
+      headStyle: soccerMove.headStyle,
+      // The real "movement" tool isn't curvable on the live board, but the
+      // showcase wants a smooth weave rather than sharp zig-zag turns -
+      // this only affects how this scripted demo renders, not the tool.
+      curved: true,
+      startAt: 700,
+      duration: 2200,
+    },
+  ],
+  scriptedDuration: 2900,
+};
+
+export const showcaseScenes: ShowcaseScene[] = [
+  americanFootballScene,
+  basketballScene,
+  soccerScene,
+];

--- a/lib/board/showcase/types.ts
+++ b/lib/board/showcase/types.ts
@@ -1,0 +1,45 @@
+import type { BoardPoint, PathHeadStyle, PointElementType } from "@/lib/board/types";
+
+/** A player/ball/cone marker that fades in at a given moment in the scene. */
+export interface ShowcaseMarker {
+  id: string;
+  kind: PointElementType;
+  x: number;
+  y: number;
+  label?: string;
+  /** ms into the scene when the fade-in begins. */
+  appearAt: number;
+}
+
+/**
+ * A path (route / dribble / shot / pass) that draws itself progressively.
+ * Styling mirrors `PathToolStyle` from the real per-sport tool defs exactly,
+ * so a route drawn here uses the identical color/width/dash the real board
+ * uses for that same tool.
+ */
+export interface ShowcasePath {
+  id: string;
+  points: BoardPoint[];
+  color: string;
+  strokeWidth: number;
+  headStyle: PathHeadStyle;
+  dash?: number[];
+  curved?: boolean;
+  wavy?: boolean;
+  /** ms into the scene when drawing starts. */
+  startAt: number;
+  /** how long the reveal animation takes, in ms. */
+  duration: number;
+}
+
+export interface ShowcaseScene {
+  /** Sport slug, resolved via getSportConfig - the same lookup the real board uses. */
+  sportSlug: string;
+  fieldModeId: string;
+  /** Polish caption describing the moment, shown only in the onboarding variant. */
+  caption: string;
+  markers: ShowcaseMarker[];
+  paths: ShowcasePath[];
+  /** Total scripted duration (last animation end), excluding the hold/pause after it. */
+  scriptedDuration: number;
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -19,6 +19,7 @@ export interface Database {
           display_name: string;
           club_name: string | null;
           avatar_url: string | null;
+          onboarding_completed: boolean;
           created_at: string;
         };
         Insert: {
@@ -26,6 +27,7 @@ export interface Database {
           display_name: string;
           club_name?: string | null;
           avatar_url?: string | null;
+          onboarding_completed?: boolean;
           created_at?: string;
         };
         Update: {
@@ -33,6 +35,7 @@ export interface Database {
           display_name?: string;
           club_name?: string | null;
           avatar_url?: string | null;
+          onboarding_completed?: boolean;
           created_at?: string;
         };
         Relationships: [];

--- a/supabase/migrations/20260716110000_add_onboarding_completed.sql
+++ b/supabase/migrations/20260716110000_add_onboarding_completed.sql
@@ -1,0 +1,11 @@
+-- Coach Zone — onboarding-seen flag
+-- Migration 16. Run after 20260716100000_backfill_af_exercises.sql.
+--
+-- Round 18: the post-signup animated showcase must only ever show once per
+-- account, on first login, and that has to survive across devices/sessions
+-- - not a client-side flag. `default false` means every existing row is
+-- treated as "hasn't seen it yet" (fine - it's a new feature, nobody has),
+-- and handle_new_user() needs no changes since it only inserts
+-- (id, display_name) and this column's default fills in the rest.
+alter table public.profiles
+  add column onboarding_completed boolean not null default false;


### PR DESCRIPTION
## Summary

A premium, calm-paced animated showcase built on the **real** tactics board engine — same react-konva Stage, same per-sport field configs, same tool colors/styles — so what a coach sees animating is the same board they use seconds later, not a lookalike.

- **`BoardShowcaseEngine`** (`components/showcase/BoardShowcaseEngine.tsx`): the one shared engine — owns the playback clock, scene sequencing, and CSS crossfades between scenes.
- Three choreographed scenes (`lib/board/showcase/scenes.ts`), each drawing on its real field via `getSportConfig`:
  - **American football**: QB + WR appear, the WR's route draws itself, then a pass arcs from QB to the route's end.
  - **Basketball**: a player dribbles (wavy path, real `dribble` tool style), then a shot arcs to the hoop (real `shot` tool style).
  - **Soccer**: a player weaves a slalom through cones (smooth curve).
  - All stroke colors/widths/dash come directly from the real per-sport `ToolDef`s in `lib/board/sports/*.tsx` — nothing invented. The "drawing tip" dot reuses the exact `#10b981` marker TacticsBoard already shows while a coach is mid-route.
- Two thin wrappers on top of that one engine: **`OnboardingShowcase`** (slower pace, held beats, Polish captions, loops) and **`LandingShowcase`** (tighter, caption-free, loop-ready — not wired into a page yet, per this round's scope).
- **`OnboardingOverlay`**: full-screen, first-login-only welcome with "Zacznij" / "Pomiń" controls, rendered from `app/app/page.tsx` when `profile.onboarding_completed` is false.
- New `profiles.onboarding_completed` column (migration `20260716110000_add_onboarding_completed.sql`, defaults to `false`) plus a `completeOnboarding()` server action — persisted server-side per account, so it never reshows regardless of device.

### Recon (done before writing code)
- Real board: `components/board/TacticsBoard.tsx` (react-konva Stage/Layer), sport configs in `lib/board/sports/{football,americanFootball,basketball}.tsx` via `getSportConfig()`, field renderers in `components/board/fields/*.tsx`, path math in `lib/board/path.ts`.
- No onboarding flow existed. `profiles` table had no flag column — added one via migration rather than localStorage.
- Design tokens: Tailwind v4, dark surfaces via `dark:bg-neutral-950`, green accent = Tailwind `emerald` (`#10b981`/`emerald-600`), font Geist.

### Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build` all pass.
- Manually drove the onboarding overlay in a real browser (Playwright against the dev server) across multiple full loop cycles and confirmed: all three scenes draw and crossfade correctly, captions stay in sync with the visible board, and the loop continues indefinitely. Fixed two bugs found this way: a stuck-after-first-transition timer (effect cleanup was canceling its own completion timeout every frame) and a caption/board sync mismatch during crossfades.

## Test plan
- [ ] Run the migration against a real Supabase project and confirm `profiles.onboarding_completed` defaults to `false` for existing rows.
- [ ] Log in as a coach who hasn't seen onboarding and confirm the full-screen showcase appears once, plays through all three sports, and "Zacznij"/"Pomiń" both dismiss it and mark it seen (check it doesn't reappear on next login, including from a different device/session).
- [ ] Confirm the real tactics board (`/app/exercises/new` or similar) still behaves identically — no shared files were modified, only new files were added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ABSQ2CyJQQGmmcGRy6FvGb)_