### PR TITLE
Round 19: add training-equipment tools to the tactics board

### DIFF
--- a/components/board/BoardElementNode.tsx
+++ b/components/board/BoardElementNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type Konva from "konva";
-import { Circle, Group, RegularPolygon, Text } from "react-konva";
+import { Circle, Group, Line, RegularPolygon, Rect, Text } from "react-konva";
 import { POINT_RADIUS } from "@/lib/board/elements";
 import {
   LABELABLE_POINT_KINDS,
@@ -144,5 +144,62 @@ function PointGlyph({
           strokeWidth={strokeWidth}
         />
       );
+    case "partner":
+      return (
+        <Circle
+          radius={POINT_RADIUS}
+          fill="#0d9488"
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
+      );
+    case "shield": {
+      const r = POINT_RADIUS * 0.95;
+      return (
+        <Group>
+          <Line
+            points={[
+              -r, -r * 0.75,
+              r, -r * 0.75,
+              r, r * 0.15,
+              0, r * 1.05,
+              -r, r * 0.15,
+            ]}
+            closed
+            fill="#059669"
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            lineJoin="round"
+          />
+          <Line
+            points={[0, -r * 0.55, 0, r * 0.55]}
+            stroke="#ffffff"
+            strokeWidth={1.5}
+            opacity={0.7}
+            listening={false}
+          />
+        </Group>
+      );
+    }
+    case "gate": {
+      const w = POINT_RADIUS * 1.7;
+      const h = POINT_RADIUS * 1.15;
+      return (
+        <Group>
+          <Rect
+            x={-w / 2}
+            y={-h / 2}
+            width={w}
+            height={h}
+            cornerRadius={4}
+            fill="rgba(5, 150, 105, 0.15)"
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+          />
+          <Circle x={-w / 2} y={h / 2} radius={3.5} fill="#059669" stroke="#ffffff" strokeWidth={1} />
+          <Circle x={w / 2} y={h / 2} radius={3.5} fill="#059669" stroke="#ffffff" strokeWidth={1} />
+        </Group>
+      );
+    }
   }
 }

--- a/components/board/PathDrawingControls.tsx
+++ b/components/board/PathDrawingControls.tsx
@@ -16,6 +16,10 @@ interface PathDrawingControlsProps {
   /** false when the tool being drawn doesn't support a curve toggle. */
   curveEnabled: boolean;
   onCurveModeChange: (mode: "sharp" | "smooth") => void;
+  /** Overrides the default multi-point-route instructions - used by
+   * two-point stretch tools (ladder, hurdle row) whose gesture is just
+   * "tap start, tap end", not "tap points, then finish". */
+  hint?: string;
 }
 
 export function PathDrawingControls({
@@ -27,6 +31,7 @@ export function PathDrawingControls({
   curveMode,
   curveEnabled,
   onCurveModeChange,
+  hint,
 }: PathDrawingControlsProps) {
   return (
     <div
@@ -37,8 +42,10 @@ export function PathDrawingControls({
     >
       <div className="flex flex-wrap items-center gap-3">
         <span className="text-emerald-800 dark:text-emerald-300">
-          Stukaj kolejne punkty trasy (zaznaczono: {pointCount}). Zakończ
-          dwukrotnym dotknięciem ekranu lub przyciskiem „Gotowe”.
+          {hint ??
+            "Stukaj kolejne punkty trasy (zaznaczono: " +
+              pointCount +
+              "). Zakończ dwukrotnym dotknięciem ekranu lub przyciskiem „Gotowe”."}
         </span>
         {/* Always rendered (never mounted/unmounted based on curveEnabled) so
             the flex-wrap layout - and therefore this bar's height - is

--- a/components/board/PathElementNode.tsx
+++ b/components/board/PathElementNode.tsx
@@ -5,6 +5,7 @@ import { Arrow, Circle, Group, Line } from "react-konva";
 import {
   endTangent,
   flattenPoints,
+  markPointsAlongPolyline,
   nearestPointOnPath,
   smoothPathPoints,
   wavyPathPoints,
@@ -13,6 +14,12 @@ import type { BoardPoint, PathBoardElement } from "@/lib/board/types";
 
 const HANDLE_RADIUS = 9;
 const BLOCK_BAR_HALF_LENGTH = 11;
+const LADDER_RUNG_SPACING = 20;
+const LADDER_RAIL_GAP = 24;
+const LADDER_RUNG_OVERHANG = 5;
+const HURDLE_SPACING = 42;
+const HURDLE_BAR_HALF_WIDTH = 11;
+const HURDLE_LEG_LENGTH = 7;
 
 interface PathElementNodeProps {
   element: PathBoardElement;
@@ -88,7 +95,21 @@ export function PathElementNode({
       onDblClick={insertPoint}
       onDblTap={insertPoint}
     >
-      {headStyle === "arrow" ? (
+      {element.kind === "ladder" ? (
+        <LadderShape
+          points={points}
+          color={color}
+          strokeWidth={strokeWidth}
+          highlight={highlight}
+        />
+      ) : element.kind === "hurdles" ? (
+        <HurdleRow
+          points={points}
+          color={color}
+          strokeWidth={strokeWidth}
+          highlight={highlight}
+        />
+      ) : headStyle === "arrow" ? (
         <Arrow
           points={flat}
           tension={0}
@@ -190,5 +211,146 @@ function BlockBar({
       strokeWidth={strokeWidth}
       lineCap="round"
     />
+  );
+}
+
+type ShadowHighlight = {
+  shadowColor?: string;
+  shadowOpacity?: number;
+  shadowBlur?: number;
+};
+
+/**
+ * Agility ladder: two parallel rails the full length of the element, with
+ * perpendicular rungs at even spacing between them. Marks are re-derived
+ * from `points` on every render, so dragging either endpoint (the generic
+ * path point-handles above) stretches/rotates the whole ladder for free.
+ */
+function LadderShape({
+  points,
+  color,
+  strokeWidth,
+  highlight,
+}: {
+  points: BoardPoint[];
+  color: string;
+  strokeWidth: number;
+  highlight: ShadowHighlight;
+}) {
+  const marks = markPointsAlongPolyline(points, LADDER_RUNG_SPACING);
+  const half = LADDER_RAIL_GAP / 2;
+  const railSide = (side: 1 | -1) =>
+    flattenPoints(
+      marks.map((m) => {
+        const perp = { x: -m.dir.y, y: m.dir.x };
+        return {
+          x: m.point.x + perp.x * half * side,
+          y: m.point.y + perp.y * half * side,
+        };
+      }),
+    );
+
+  return (
+    <Group {...highlight}>
+      <Line
+        points={railSide(1)}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        lineCap="round"
+        lineJoin="round"
+      />
+      <Line
+        points={railSide(-1)}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        lineCap="round"
+        lineJoin="round"
+      />
+      {marks.map((m, i) => {
+        const perp = { x: -m.dir.y, y: m.dir.x };
+        const rungHalf = half + LADDER_RUNG_OVERHANG;
+        return (
+          <Line
+            key={i}
+            points={[
+              m.point.x - perp.x * rungHalf,
+              m.point.y - perp.y * rungHalf,
+              m.point.x + perp.x * rungHalf,
+              m.point.y + perp.y * rungHalf,
+            ]}
+            stroke={color}
+            strokeWidth={Math.max(2, strokeWidth - 1)}
+            lineCap="round"
+            hitStrokeWidth={20}
+          />
+        );
+      })}
+    </Group>
+  );
+}
+
+/**
+ * A row of hurdles: small "H"-shaped marks (crossbar + two legs pointing
+ * along the direction of travel) at even spacing along `points`. Same
+ * stretch-by-endpoint model as the ladder above.
+ */
+function HurdleRow({
+  points,
+  color,
+  strokeWidth,
+  highlight,
+}: {
+  points: BoardPoint[];
+  color: string;
+  strokeWidth: number;
+  highlight: ShadowHighlight;
+}) {
+  const marks = markPointsAlongPolyline(points, HURDLE_SPACING);
+
+  return (
+    <Group {...highlight}>
+      {marks.map((m, i) => {
+        const perp = { x: -m.dir.y, y: m.dir.x };
+        const barA = {
+          x: m.point.x - perp.x * HURDLE_BAR_HALF_WIDTH,
+          y: m.point.y - perp.y * HURDLE_BAR_HALF_WIDTH,
+        };
+        const barB = {
+          x: m.point.x + perp.x * HURDLE_BAR_HALF_WIDTH,
+          y: m.point.y + perp.y * HURDLE_BAR_HALF_WIDTH,
+        };
+        const legA = {
+          x: barA.x + m.dir.x * HURDLE_LEG_LENGTH,
+          y: barA.y + m.dir.y * HURDLE_LEG_LENGTH,
+        };
+        const legB = {
+          x: barB.x + m.dir.x * HURDLE_LEG_LENGTH,
+          y: barB.y + m.dir.y * HURDLE_LEG_LENGTH,
+        };
+        return (
+          <Group key={i}>
+            <Line
+              points={[barA.x, barA.y, barB.x, barB.y]}
+              stroke={color}
+              strokeWidth={strokeWidth}
+              lineCap="round"
+              hitStrokeWidth={20}
+            />
+            <Line
+              points={[barA.x, barA.y, legA.x, legA.y]}
+              stroke={color}
+              strokeWidth={strokeWidth}
+              lineCap="round"
+            />
+            <Line
+              points={[barB.x, barB.y, legB.x, legB.y]}
+              stroke={color}
+              strokeWidth={strokeWidth}
+              lineCap="round"
+            />
+          </Group>
+        );
+      })}
+    </Group>
   );
 }

--- a/components/board/TacticsBoard.tsx
+++ b/components/board/TacticsBoard.tsx
@@ -262,17 +262,29 @@ export function TacticsBoard({
     setSelectedPointIndex(null);
   }
 
+  function commitPath(
+    toolId: string,
+    style: PathToolStyle,
+    points: BoardPoint[],
+    curved: boolean,
+  ) {
+    const el = createPathElement(toolId, style, points, curved);
+    dispatch({ type: "add", element: el });
+    setSelectedId(el.id);
+    setSelectedPointIndex(null);
+    cancelDrawingPath();
+    setActiveTool("select");
+  }
+
   function finishDrawingPath() {
     if (drawingPath && drawingPath.points.length >= 2) {
-      const el = createPathElement(
+      commitPath(
         drawingPath.toolId,
         drawingPath.style,
         drawingPath.points,
         drawingPath.curved,
       );
-      dispatch({ type: "add", element: el });
-      setSelectedId(el.id);
-      setSelectedPointIndex(null);
+      return;
     }
     cancelDrawingPath();
     setActiveTool("select");
@@ -303,7 +315,13 @@ export function TacticsBoard({
         finishDrawingPath();
         return;
       }
-      setDrawingPath({ ...drawingPath, points: [...drawingPath.points, pos] });
+      const nextPoints = [...drawingPath.points, pos];
+      const maxPoints = tool.kind.maxPoints;
+      if (maxPoints && nextPoints.length >= maxPoints) {
+        commitPath(tool.id, drawingPath.style, nextPoints, drawingPath.curved);
+        return;
+      }
+      setDrawingPath({ ...drawingPath, points: nextPoints });
       lastTapRef.current = { time: now, pos };
       return;
     }
@@ -520,6 +538,12 @@ export function TacticsBoard({
   const drawingTool = drawingPath ? findTool(drawingPath.toolId) : null;
   const drawingToolCurvable =
     drawingTool?.kind.create === "path" && Boolean(drawingTool.kind.curvable);
+  const drawingToolMaxPoints =
+    drawingTool?.kind.create === "path" ? drawingTool.kind.maxPoints : undefined;
+  const drawingHint =
+    drawingToolMaxPoints === 2
+      ? "Dotknij drugi punkt, aby ustawić długość i kąt."
+      : undefined;
 
   return (
     <div className="flex flex-col gap-3">
@@ -609,6 +633,7 @@ export function TacticsBoard({
         curveMode={curveMode}
         curveEnabled={drawingToolCurvable}
         onCurveModeChange={handleCurveModeChange}
+        hint={drawingHint}
       />
 
       <div

--- a/components/board/icons.tsx
+++ b/components/board/icons.tsx
@@ -241,6 +241,101 @@ export function HandballShotIcon() {
   );
 }
 
+export function PartnerIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <circle cx="12" cy="12" r="9" fill="#0d9488" stroke="#fff" strokeWidth="1.5" />
+      <text
+        x="12"
+        y="15.5"
+        fontSize="9"
+        fontWeight="bold"
+        textAnchor="middle"
+        fill="#fff"
+      >
+        P
+      </text>
+    </svg>
+  );
+}
+
+export function ShieldIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M4 4h16v8c0 6-8 8-8 8s-8-2-8-8z"
+        fill="#059669"
+        stroke="#fff"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <line x1="12" y1="5" x2="12" y2="18" stroke="#fff" strokeWidth="1.2" opacity="0.7" />
+    </svg>
+  );
+}
+
+export function GateIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <rect
+        x="4"
+        y="6"
+        width="16"
+        height="10"
+        rx="1.5"
+        fill="none"
+        stroke="#059669"
+        strokeWidth="2.2"
+      />
+      <circle cx="4" cy="16" r="1.8" fill="#059669" />
+      <circle cx="20" cy="16" r="1.8" fill="#059669" />
+    </svg>
+  );
+}
+
+export function LadderIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <line x1="6" y1="2" x2="6" y2="22" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
+      <line x1="18" y1="2" x2="18" y2="22" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
+      <line x1="6" y1="6" x2="18" y2="6" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
+      <line x1="6" y1="12" x2="18" y2="12" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
+      <line x1="6" y1="18" x2="18" y2="18" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function HurdlesIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-6 w-6">
+      <path
+        d="M4 20V14M4 14h4M8 20V14"
+        fill="none"
+        stroke="#059669"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11 20V14M11 14h4M15 20V14"
+        fill="none"
+        stroke="#059669"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 20V14M18 14h4M22 20V14"
+        fill="none"
+        stroke="#059669"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function UndoIcon() {
   return (
     <svg viewBox="0 0 24 24" className="h-5 w-5">

--- a/lib/board/path.ts
+++ b/lib/board/path.ts
@@ -165,6 +165,63 @@ export function nearestPointOnPath(
   return best as NearestPointResult;
 }
 
+export interface PolylineMark {
+  point: BoardPoint;
+  /** Unit tangent of the segment this mark falls on. */
+  dir: BoardPoint;
+}
+
+/**
+ * Walks the polyline `points` describe and drops evenly-spaced marks along
+ * its total arc length (roughly every `spacing` px - the actual step is
+ * `total / round(total / spacing)` so a mark always lands exactly on both
+ * endpoints). Used to lay out ladder rungs and a hurdle row along a
+ * stretchable 2-point (start -> end) element: since length/angle come
+ * entirely from `points`, dragging either endpoint to resize/rotate the
+ * element is enough to reflow every mark - no extra geometry to persist.
+ */
+export function markPointsAlongPolyline(
+  points: BoardPoint[],
+  spacing: number,
+): PolylineMark[] {
+  if (points.length < 2) return [];
+  const segs: { a: BoardPoint; b: BoardPoint; len: number }[] = [];
+  let total = 0;
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    const len = distance(a, b);
+    segs.push({ a, b, len });
+    total += len;
+  }
+  if (total < EPS) return [{ point: points[0], dir: { x: 1, y: 0 } }];
+
+  const steps = Math.max(1, Math.round(total / spacing));
+  const marks: PolylineMark[] = [];
+  let segIndex = 0;
+  let segStart = 0;
+  for (let s = 0; s <= steps; s++) {
+    const d = (s / steps) * total;
+    while (
+      segIndex < segs.length - 1 &&
+      d > segStart + segs[segIndex].len + EPS
+    ) {
+      segStart += segs[segIndex].len;
+      segIndex++;
+    }
+    const seg = segs[segIndex];
+    const len = seg.len || 1;
+    const t = seg.len > EPS ? (d - segStart) / seg.len : 0;
+    const dx = seg.b.x - seg.a.x;
+    const dy = seg.b.y - seg.a.y;
+    marks.push({
+      point: { x: seg.a.x + dx * t, y: seg.a.y + dy * t },
+      dir: { x: dx / len, y: dy / len },
+    });
+  }
+  return marks;
+}
+
 const WAVE_AMPLITUDE = 9;
 const WAVE_LENGTH = 26;
 const WAVE_STEP = 6;

--- a/lib/board/sports/americanFootball.tsx
+++ b/lib/board/sports/americanFootball.tsx
@@ -9,11 +9,16 @@ import {
   BallIcon,
   BlockIcon,
   ConeIcon,
+  GateIcon,
+  HurdlesIcon,
+  LadderIcon,
   OpponentIcon,
+  PartnerIcon,
   PlayerIcon,
   QbIcon,
   RunArrowIcon,
   ScrimmageIcon,
+  ShieldIcon,
 } from "@/components/board/icons";
 import type { SportBoardConfig } from "./types";
 
@@ -60,6 +65,44 @@ export const americanFootballConfig: SportBoardConfig = {
       label: "Pachołek",
       icon: <ConeIcon />,
       kind: { create: "point", elementKind: "cone" },
+    },
+    {
+      id: "partner",
+      label: "Partner",
+      icon: <PartnerIcon />,
+      kind: { create: "point", elementKind: "partner", defaultLabel: "P" },
+    },
+    {
+      id: "shield",
+      label: "Tarcza",
+      icon: <ShieldIcon />,
+      kind: { create: "point", elementKind: "shield" },
+    },
+    {
+      id: "gate",
+      label: "Bramka",
+      icon: <GateIcon />,
+      kind: { create: "point", elementKind: "gate" },
+    },
+    {
+      id: "ladder",
+      label: "Drabinka",
+      icon: <LadderIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
+    },
+    {
+      id: "hurdles",
+      label: "Płotki",
+      icon: <HurdlesIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
     },
     {
       id: "route",

--- a/lib/board/sports/basketball.tsx
+++ b/lib/board/sports/basketball.tsx
@@ -3,7 +3,10 @@ import {
   BallIcon,
   ConeIcon,
   DribbleIcon,
+  HurdlesIcon,
+  LadderIcon,
   OpponentIcon,
+  PartnerIcon,
   PassLineIcon,
   PlayerIcon,
   RunArrowIcon,
@@ -43,6 +46,32 @@ export const basketballConfig: SportBoardConfig = {
       label: "Pachołek",
       icon: <ConeIcon />,
       kind: { create: "point", elementKind: "cone" },
+    },
+    {
+      id: "partner",
+      label: "Partner",
+      icon: <PartnerIcon />,
+      kind: { create: "point", elementKind: "partner", defaultLabel: "P" },
+    },
+    {
+      id: "ladder",
+      label: "Drabinka",
+      icon: <LadderIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
+    },
+    {
+      id: "hurdles",
+      label: "Płotki",
+      icon: <HurdlesIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
     },
     {
       id: "dribble",

--- a/lib/board/sports/football.tsx
+++ b/lib/board/sports/football.tsx
@@ -2,7 +2,10 @@ import { SoccerField } from "@/components/board/fields/SoccerField";
 import {
   BallIcon,
   ConeIcon,
+  HurdlesIcon,
+  LadderIcon,
   OpponentIcon,
+  PartnerIcon,
   PassLineIcon,
   PlayerIcon,
   RunArrowIcon,
@@ -41,6 +44,32 @@ export const footballConfig: SportBoardConfig = {
       label: "Pachołek",
       icon: <ConeIcon />,
       kind: { create: "point", elementKind: "cone" },
+    },
+    {
+      id: "partner",
+      label: "Partner",
+      icon: <PartnerIcon />,
+      kind: { create: "point", elementKind: "partner", defaultLabel: "P" },
+    },
+    {
+      id: "ladder",
+      label: "Drabinka",
+      icon: <LadderIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
+    },
+    {
+      id: "hurdles",
+      label: "Płotki",
+      icon: <HurdlesIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
     },
     {
       id: "movement",

--- a/lib/board/sports/handball.tsx
+++ b/lib/board/sports/handball.tsx
@@ -3,7 +3,10 @@ import {
   BallIcon,
   ConeIcon,
   HandballShotIcon,
+  HurdlesIcon,
+  LadderIcon,
   OpponentIcon,
+  PartnerIcon,
   PassLineIcon,
   PlayerIcon,
   RunArrowIcon,
@@ -42,6 +45,32 @@ export const handballConfig: SportBoardConfig = {
       label: "Pachołek",
       icon: <ConeIcon />,
       kind: { create: "point", elementKind: "cone" },
+    },
+    {
+      id: "partner",
+      label: "Partner",
+      icon: <PartnerIcon />,
+      kind: { create: "point", elementKind: "partner", defaultLabel: "P" },
+    },
+    {
+      id: "ladder",
+      label: "Drabinka",
+      icon: <LadderIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
+    },
+    {
+      id: "hurdles",
+      label: "Płotki",
+      icon: <HurdlesIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
     },
     {
       id: "passLine",

--- a/lib/board/sports/types.ts
+++ b/lib/board/sports/types.ts
@@ -26,7 +26,16 @@ export interface PathToolStyle {
 
 export type ToolKind =
   | { create: "point"; elementKind: PointElementType; defaultLabel?: string }
-  | { create: "path"; style: PathToolStyle; curvable?: boolean }
+  | {
+      create: "path";
+      style: PathToolStyle;
+      curvable?: boolean;
+      /** Auto-finishes the path as soon as this many points are placed,
+       * instead of waiting for a double-tap or "Gotowe" - used for
+       * stretchable equipment (ladder, hurdle row) drawn as a single
+       * start -> end gesture rather than a multi-point route. */
+      maxPoints?: number;
+    }
   | {
       create: "fullWidthLine";
       style: PathToolStyle;

--- a/lib/board/sports/volleyball.tsx
+++ b/lib/board/sports/volleyball.tsx
@@ -4,7 +4,10 @@ import {
   BallArcIcon,
   BallIcon,
   BlockIcon,
+  HurdlesIcon,
+  LadderIcon,
   OpponentIcon,
+  PartnerIcon,
   PlayerIcon,
   RunArrowIcon,
   ServeIcon,
@@ -35,6 +38,32 @@ export const volleyballConfig: SportBoardConfig = {
       label: "Piłka",
       icon: <BallIcon />,
       kind: { create: "point", elementKind: "ball" },
+    },
+    {
+      id: "partner",
+      label: "Partner",
+      icon: <PartnerIcon />,
+      kind: { create: "point", elementKind: "partner", defaultLabel: "P" },
+    },
+    {
+      id: "ladder",
+      label: "Drabinka",
+      icon: <LadderIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
+    },
+    {
+      id: "hurdles",
+      label: "Płotki",
+      icon: <HurdlesIcon />,
+      kind: {
+        create: "path",
+        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        maxPoints: 2,
+      },
     },
     {
       id: "trajectory",

--- a/lib/board/types.ts
+++ b/lib/board/types.ts
@@ -1,4 +1,12 @@
-export type PointElementType = "player" | "opponent" | "ball" | "cone" | "qb";
+export type PointElementType =
+  | "player"
+  | "opponent"
+  | "ball"
+  | "cone"
+  | "qb"
+  | "partner"
+  | "shield"
+  | "gate";
 export type PathHeadStyle = "arrow" | "bar" | "none";
 
 export interface BoardPoint {
@@ -41,6 +49,7 @@ export const LABELABLE_POINT_KINDS: PointElementType[] = [
   "player",
   "opponent",
   "qb",
+  "partner",
 ];
 
 export function isPathElement(


### PR DESCRIPTION
## Summary
- Adds two AF-only static markers: **Tarcza** (contact shield) and **Bramka** (PVC gate), same behavior class as the existing pachołek/blok markers.
- Adds three universal tools to every sport (football, american_football, basketball, volleyball, handball): **Drabinka** (agility ladder), **Płotki** (hurdle row), and **Partner** (a labeled training-partner variant of the player marker).
- Ladder and hurdles are stretchable/rotatable: place a start point, tap an end point, then drag either endpoint afterward to resize/rotate — reusing the path element's existing per-point drag handles rather than inventing a new interaction.

## Recon findings (per the task)
- **ToolDefs & pipeline**: per-sport `SportBoardConfig.tools: ToolDef[]` in `lib/board/sports/{sport}.tsx`, looked up via `getSportConfig()` (`lib/board/sports/registry.ts`). A `ToolDef.kind` is `"point" | "path" | "fullWidthLine"` (`lib/board/sports/types.ts`). Tap → `createPointElement`/`createPathElement` (`lib/board/elements.ts`) → `BoardElement` added to history. Cone/block are plain `"point"`/`"path"` tools rendered via `BoardElementNode`'s `PointGlyph` switch and `PathElementNode`.
- **Interaction model**: identical everywhere — tap tool places one element and resets to "select"; a draggable Konva `Group` handles move; toolbar delete removes the selected id.
- **Stretch/rotate already existed**: `PathElementNode` already renders a draggable handle per point when a path is selected (used by the route tool to reshape it), so a 2-point path is already resizable/rotatable by dragging its endpoints. Ladder and hurdles are built on exactly this — no new drag/rotate code needed.

## Implementation
- `lib/board/sports/types.ts`: added optional `maxPoints` to the `"path"` `ToolKind` variant — auto-commits the path as soon as that many points are placed (2, for ladder/hurdles), instead of requiring the route tool's multi-tap + double-tap-to-finish.
- `components/board/TacticsBoard.tsx`: `handlePathTap` now auto-finishes at `maxPoints`; `PathDrawingControls` gets a `hint` override so the placement bar reads "Dotknij drugi punkt, aby ustawić długość i kąt." for these tools instead of the multi-point route instructions.
- `lib/board/path.ts`: new `markPointsAlongPolyline(points, spacing)` walks the element's current points and drops evenly-spaced marks (with local tangent) along the total arc length. Used by both new path renderers, so dragging an endpoint reflows the rungs/hurdles for free.
- `components/board/PathElementNode.tsx`: renders `kind === "ladder"` as two parallel rails + perpendicular rungs, and `kind === "hurdles"` as a row of small "H"-shaped hurdle marks, both driven by the helper above.
- `components/board/BoardElementNode.tsx`: added `PointGlyph` cases for `"partner"` (teal circle, mirrors the QB pattern — default label "P" via the existing generic label rendering), `"shield"` (filled shield silhouette), `"gate"` (outlined frame with two pole dots).
- `components/board/icons.tsx`: new palette icons `PartnerIcon`, `ShieldIcon`, `GateIcon`, `LadderIcon`, `HurdlesIcon`.
- `lib/board/types.ts`: extended `PointElementType` with `partner | shield | gate`; added `partner` to `LABELABLE_POINT_KINDS`.
- Wired the three universal tools into `football.tsx`, `americanFootball.tsx`, `basketball.tsx`, `volleyball.tsx`, `handball.tsx`, and the two AF-only tools into `americanFootball.tsx` only.
- Equipment tools use a consistent emerald accent (`#059669`) to read as one family, distinct from player/ball/opponent colors.

## Persistence / schema
**No migration needed.** `exercises.board_state` is `jsonb` holding `BoardElement[]` as-is (see `20260711110000_exercise_board_state.sql`), and length/angle for the ladder/hurdles are fully encoded by the existing `points: BoardPoint[]` field — nothing new to store.

## Verification
- `npm run typecheck`, `npm run lint`, `npm test` (16 tests), and `npm run build` all pass.
- Sanity-checked the new `markPointsAlongPolyline` geometry directly (even spacing across full length incl. endpoints, correct tangent on a rotated segment).
- **Not yet tested on a real device** — the drag-to-stretch/rotate gesture for the ladder and hurdle row needs real touch testing (per task instructions, green CI isn't "done" for this).

## Test plan
- [ ] On a touch device: place a Drabinka (ladder) in each sport, drag each endpoint to confirm it stretches/rotates and rungs reflow
- [ ] Same for Płotki (hurdle row)
- [ ] Confirm Tarcza/Bramka only appear in the American Football tool palette
- [ ] Confirm Partner appears in all five sports, gets a default "P" label, and can be relabeled via double-tap like Player/QB
- [ ] Save an exercise with the new elements and reload it to confirm `board_state` round-trips correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_013HK5ufTZ5TtYnuq7R9nonG)_