### PR TITLE
Repaint training equipment in real equipment colors, not UI accent

### DIFF
--- a/components/board/BoardElementNode.tsx
+++ b/components/board/BoardElementNode.tsx
@@ -144,17 +144,25 @@ function PointGlyph({
           strokeWidth={strokeWidth}
         />
       );
-    case "partner":
+    case "partner": {
+      // Same teal marker, but a dark outline (instead of the usual white
+      // ring) so it doesn't wash out against light court surfaces.
+      const partnerStroke = selected ? SELECTION_COLOR : "#111827";
       return (
         <Circle
           radius={POINT_RADIUS}
           fill="#0d9488"
-          stroke={stroke}
+          stroke={partnerStroke}
           strokeWidth={strokeWidth}
         />
       );
+    }
     case "shield": {
+      // Real contact shield colors: black fill, red outline - both read
+      // clearly against grass and against orange/brown parquet alike.
       const r = POINT_RADIUS * 0.95;
+      const shieldStroke = selected ? SELECTION_COLOR : "#dc2626";
+      const shieldStrokeWidth = selected ? 4 : 3;
       return (
         <Group>
           <Line
@@ -166,14 +174,14 @@ function PointGlyph({
               -r, r * 0.15,
             ]}
             closed
-            fill="#059669"
-            stroke={stroke}
-            strokeWidth={strokeWidth}
+            fill="#111827"
+            stroke={shieldStroke}
+            strokeWidth={shieldStrokeWidth}
             lineJoin="round"
           />
           <Line
             points={[0, -r * 0.55, 0, r * 0.55]}
-            stroke="#ffffff"
+            stroke="#f8fafc"
             strokeWidth={1.5}
             opacity={0.7}
             listening={false}
@@ -182,8 +190,12 @@ function PointGlyph({
       );
     }
     case "gate": {
+      // PVC training gate: white frame/posts with a dark outline so the
+      // white doesn't disappear against light court surfaces.
       const w = POINT_RADIUS * 1.7;
       const h = POINT_RADIUS * 1.15;
+      const gateStroke = selected ? SELECTION_COLOR : "#111827";
+      const gateStrokeWidth = selected ? 4 : 3;
       return (
         <Group>
           <Rect
@@ -192,12 +204,12 @@ function PointGlyph({
             width={w}
             height={h}
             cornerRadius={4}
-            fill="rgba(5, 150, 105, 0.15)"
-            stroke={stroke}
-            strokeWidth={strokeWidth}
+            fill="rgba(248, 250, 252, 0.35)"
+            stroke={gateStroke}
+            strokeWidth={gateStrokeWidth}
           />
-          <Circle x={-w / 2} y={h / 2} radius={3.5} fill="#059669" stroke="#ffffff" strokeWidth={1} />
-          <Circle x={w / 2} y={h / 2} radius={3.5} fill="#059669" stroke="#ffffff" strokeWidth={1} />
+          <Circle x={-w / 2} y={h / 2} radius={3.5} fill="#f8fafc" stroke="#111827" strokeWidth={1.5} />
+          <Circle x={w / 2} y={h / 2} radius={3.5} fill="#f8fafc" stroke="#111827" strokeWidth={1.5} />
         </Group>
       );
     }

--- a/components/board/PathElementNode.tsx
+++ b/components/board/PathElementNode.tsx
@@ -21,6 +21,15 @@ const HURDLE_SPACING = 42;
 const HURDLE_BAR_HALF_WIDTH = 11;
 const HURDLE_LEG_LENGTH = 7;
 
+// Equipment renders in real-world equipment colors rather than the tool's
+// UI-accent `color`, and always as a dark outline plus a distinct fill/line
+// color - a single hue can't stay legible on both green grass and the
+// orange/brown basketball parquet, but outline + color together do.
+const EQUIPMENT_OUTLINE_COLOR = "#111827";
+const LADDER_RAIL_COLOR = "#dc2626";
+const LADDER_RUNG_COLOR = "#facc15";
+const HURDLE_COLOR = "#dc2626";
+
 interface PathElementNodeProps {
   element: PathBoardElement;
   selected: boolean;
@@ -98,14 +107,12 @@ export function PathElementNode({
       {element.kind === "ladder" ? (
         <LadderShape
           points={points}
-          color={color}
           strokeWidth={strokeWidth}
           highlight={highlight}
         />
       ) : element.kind === "hurdles" ? (
         <HurdleRow
           points={points}
-          color={color}
           strokeWidth={strokeWidth}
           highlight={highlight}
         />
@@ -228,12 +235,10 @@ type ShadowHighlight = {
  */
 function LadderShape({
   points,
-  color,
   strokeWidth,
   highlight,
 }: {
   points: BoardPoint[];
-  color: string;
   strokeWidth: number;
   highlight: ShadowHighlight;
 }) {
@@ -249,40 +254,68 @@ function LadderShape({
         };
       }),
     );
+  const rail1 = railSide(1);
+  const railNeg1 = railSide(-1);
+  const rungStrokeWidth = Math.max(2, strokeWidth - 1);
 
   return (
     <Group {...highlight}>
       <Line
-        points={railSide(1)}
-        stroke={color}
-        strokeWidth={strokeWidth}
+        points={rail1}
+        stroke={EQUIPMENT_OUTLINE_COLOR}
+        strokeWidth={strokeWidth + 2.5}
         lineCap="round"
         lineJoin="round"
       />
       <Line
-        points={railSide(-1)}
-        stroke={color}
+        points={rail1}
+        stroke={LADDER_RAIL_COLOR}
         strokeWidth={strokeWidth}
         lineCap="round"
         lineJoin="round"
+        listening={false}
+      />
+      <Line
+        points={railNeg1}
+        stroke={EQUIPMENT_OUTLINE_COLOR}
+        strokeWidth={strokeWidth + 2.5}
+        lineCap="round"
+        lineJoin="round"
+      />
+      <Line
+        points={railNeg1}
+        stroke={LADDER_RAIL_COLOR}
+        strokeWidth={strokeWidth}
+        lineCap="round"
+        lineJoin="round"
+        listening={false}
       />
       {marks.map((m, i) => {
         const perp = { x: -m.dir.y, y: m.dir.x };
         const rungHalf = half + LADDER_RUNG_OVERHANG;
+        const rungPoints = [
+          m.point.x - perp.x * rungHalf,
+          m.point.y - perp.y * rungHalf,
+          m.point.x + perp.x * rungHalf,
+          m.point.y + perp.y * rungHalf,
+        ];
         return (
-          <Line
-            key={i}
-            points={[
-              m.point.x - perp.x * rungHalf,
-              m.point.y - perp.y * rungHalf,
-              m.point.x + perp.x * rungHalf,
-              m.point.y + perp.y * rungHalf,
-            ]}
-            stroke={color}
-            strokeWidth={Math.max(2, strokeWidth - 1)}
-            lineCap="round"
-            hitStrokeWidth={20}
-          />
+          <Group key={i}>
+            <Line
+              points={rungPoints}
+              stroke={EQUIPMENT_OUTLINE_COLOR}
+              strokeWidth={rungStrokeWidth + 2}
+              lineCap="round"
+              hitStrokeWidth={20}
+            />
+            <Line
+              points={rungPoints}
+              stroke={LADDER_RUNG_COLOR}
+              strokeWidth={rungStrokeWidth}
+              lineCap="round"
+              listening={false}
+            />
+          </Group>
         );
       })}
     </Group>
@@ -296,16 +329,15 @@ function LadderShape({
  */
 function HurdleRow({
   points,
-  color,
   strokeWidth,
   highlight,
 }: {
   points: BoardPoint[];
-  color: string;
   strokeWidth: number;
   highlight: ShadowHighlight;
 }) {
   const marks = markPointsAlongPolyline(points, HURDLE_SPACING);
+  const outlineWidth = strokeWidth + 2.5;
 
   return (
     <Group {...highlight}>
@@ -327,26 +359,50 @@ function HurdleRow({
           x: barB.x + m.dir.x * HURDLE_LEG_LENGTH,
           y: barB.y + m.dir.y * HURDLE_LEG_LENGTH,
         };
+        const barPoints = [barA.x, barA.y, barB.x, barB.y];
+        const legAPoints = [barA.x, barA.y, legA.x, legA.y];
+        const legBPoints = [barB.x, barB.y, legB.x, legB.y];
         return (
           <Group key={i}>
             <Line
-              points={[barA.x, barA.y, barB.x, barB.y]}
-              stroke={color}
-              strokeWidth={strokeWidth}
+              points={barPoints}
+              stroke={EQUIPMENT_OUTLINE_COLOR}
+              strokeWidth={outlineWidth}
               lineCap="round"
               hitStrokeWidth={20}
             />
             <Line
-              points={[barA.x, barA.y, legA.x, legA.y]}
-              stroke={color}
-              strokeWidth={strokeWidth}
+              points={legAPoints}
+              stroke={EQUIPMENT_OUTLINE_COLOR}
+              strokeWidth={outlineWidth}
               lineCap="round"
             />
             <Line
-              points={[barB.x, barB.y, legB.x, legB.y]}
-              stroke={color}
+              points={legBPoints}
+              stroke={EQUIPMENT_OUTLINE_COLOR}
+              strokeWidth={outlineWidth}
+              lineCap="round"
+            />
+            <Line
+              points={barPoints}
+              stroke={HURDLE_COLOR}
               strokeWidth={strokeWidth}
               lineCap="round"
+              listening={false}
+            />
+            <Line
+              points={legAPoints}
+              stroke={HURDLE_COLOR}
+              strokeWidth={strokeWidth}
+              lineCap="round"
+              listening={false}
+            />
+            <Line
+              points={legBPoints}
+              stroke={HURDLE_COLOR}
+              strokeWidth={strokeWidth}
+              lineCap="round"
+              listening={false}
             />
           </Group>
         );

--- a/components/board/icons.tsx
+++ b/components/board/icons.tsx
@@ -264,9 +264,9 @@ export function ShieldIcon() {
     <svg viewBox="0 0 24 24" className="h-6 w-6">
       <path
         d="M4 4h16v8c0 6-8 8-8 8s-8-2-8-8z"
-        fill="#059669"
-        stroke="#fff"
-        strokeWidth="1.2"
+        fill="#111827"
+        stroke="#dc2626"
+        strokeWidth="1.6"
         strokeLinejoin="round"
       />
       <line x1="12" y1="5" x2="12" y2="18" stroke="#fff" strokeWidth="1.2" opacity="0.7" />
@@ -284,11 +284,11 @@ export function GateIcon() {
         height="10"
         rx="1.5"
         fill="none"
-        stroke="#059669"
+        stroke="#111827"
         strokeWidth="2.2"
       />
-      <circle cx="4" cy="16" r="1.8" fill="#059669" />
-      <circle cx="20" cy="16" r="1.8" fill="#059669" />
+      <circle cx="4" cy="16" r="1.8" fill="#f8fafc" stroke="#111827" strokeWidth="1" />
+      <circle cx="20" cy="16" r="1.8" fill="#f8fafc" stroke="#111827" strokeWidth="1" />
     </svg>
   );
 }
@@ -296,11 +296,11 @@ export function GateIcon() {
 export function LadderIcon() {
   return (
     <svg viewBox="0 0 24 24" className="h-6 w-6">
-      <line x1="6" y1="2" x2="6" y2="22" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
-      <line x1="18" y1="2" x2="18" y2="22" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
-      <line x1="6" y1="6" x2="18" y2="6" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
-      <line x1="6" y1="12" x2="18" y2="12" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
-      <line x1="6" y1="18" x2="18" y2="18" stroke="#059669" strokeWidth="2" strokeLinecap="round" />
+      <line x1="6" y1="2" x2="6" y2="22" stroke="#dc2626" strokeWidth="2" strokeLinecap="round" />
+      <line x1="18" y1="2" x2="18" y2="22" stroke="#dc2626" strokeWidth="2" strokeLinecap="round" />
+      <line x1="6" y1="6" x2="18" y2="6" stroke="#facc15" strokeWidth="2" strokeLinecap="round" />
+      <line x1="6" y1="12" x2="18" y2="12" stroke="#facc15" strokeWidth="2" strokeLinecap="round" />
+      <line x1="6" y1="18" x2="18" y2="18" stroke="#facc15" strokeWidth="2" strokeLinecap="round" />
     </svg>
   );
 }
@@ -311,7 +311,31 @@ export function HurdlesIcon() {
       <path
         d="M4 20V14M4 14h4M8 20V14"
         fill="none"
-        stroke="#059669"
+        stroke="#111827"
+        strokeWidth="3.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11 20V14M11 14h4M15 20V14"
+        fill="none"
+        stroke="#111827"
+        strokeWidth="3.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 20V14M18 14h4M22 20V14"
+        fill="none"
+        stroke="#111827"
+        strokeWidth="3.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4 20V14M4 14h4M8 20V14"
+        fill="none"
+        stroke="#dc2626"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -319,7 +343,7 @@ export function HurdlesIcon() {
       <path
         d="M11 20V14M11 14h4M15 20V14"
         fill="none"
-        stroke="#059669"
+        stroke="#dc2626"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -327,7 +351,7 @@ export function HurdlesIcon() {
       <path
         d="M18 20V14M18 14h4M22 20V14"
         fill="none"
-        stroke="#059669"
+        stroke="#dc2626"
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/lib/board/sports/americanFootball.tsx
+++ b/lib/board/sports/americanFootball.tsx
@@ -90,7 +90,7 @@ export const americanFootballConfig: SportBoardConfig = {
       icon: <LadderIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },
@@ -100,7 +100,7 @@ export const americanFootballConfig: SportBoardConfig = {
       icon: <HurdlesIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },

--- a/lib/board/sports/basketball.tsx
+++ b/lib/board/sports/basketball.tsx
@@ -59,7 +59,7 @@ export const basketballConfig: SportBoardConfig = {
       icon: <LadderIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },
@@ -69,7 +69,7 @@ export const basketballConfig: SportBoardConfig = {
       icon: <HurdlesIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },

--- a/lib/board/sports/football.tsx
+++ b/lib/board/sports/football.tsx
@@ -57,7 +57,7 @@ export const footballConfig: SportBoardConfig = {
       icon: <LadderIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },
@@ -67,7 +67,7 @@ export const footballConfig: SportBoardConfig = {
       icon: <HurdlesIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },

--- a/lib/board/sports/handball.tsx
+++ b/lib/board/sports/handball.tsx
@@ -58,7 +58,7 @@ export const handballConfig: SportBoardConfig = {
       icon: <LadderIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },
@@ -68,7 +68,7 @@ export const handballConfig: SportBoardConfig = {
       icon: <HurdlesIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },

--- a/lib/board/sports/volleyball.tsx
+++ b/lib/board/sports/volleyball.tsx
@@ -51,7 +51,7 @@ export const volleyballConfig: SportBoardConfig = {
       icon: <LadderIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },
@@ -61,7 +61,7 @@ export const volleyballConfig: SportBoardConfig = {
       icon: <HurdlesIcon />,
       kind: {
         create: "path",
-        style: { color: "#059669", strokeWidth: 3, headStyle: "none" },
+        style: { color: "#dc2626", strokeWidth: 3, headStyle: "none" },
         maxPoints: 2,
       },
     },


### PR DESCRIPTION
## Summary

The training-equipment tools added in #26 (drabinka, tarcza, bramka, płotki, partner) were all rendered in the emerald UI accent (`#059669`/`#0d9488`). That color disappears against green pitches (American football, soccer) and against the basketball court's orange/brown parquet.

Every element is now two-tone — a dark outline plus a distinct fill/stroke color — so at least one tone stays legible no matter which field it's on:

- **Drabinka** (ladder): red rails, yellow rungs
- **Płotki** (hurdles): red bars/legs with a black outline — plain red blends into the parquet, the dark outline is what keeps it visible there
- **Tarcza** (shield, AF-only): black fill, red outline
- **Bramka** (PVC gate, AF-only): white frame/posts with a thin dark outline
- **Partner**: unchanged teal fill, dark outline instead of white (it was already reasonably distinct, but the dark ring keeps it crisp everywhere)

Toolbar icons for these five tools were updated to match, so the palette preview matches what actually gets placed on the board.

This is a pure rendering change — no mechanics touched. Placement, stretch/drag handles, and delete behavior for ladder/hurdles/shield/gate/partner are untouched (`markPointsAlongPolyline`, point-drag handlers, etc. are all unmodified).

## Verification

- `tsc --noEmit` and `eslint` pass clean on the changed files.
- Built a standalone SVG harness reproducing the exact shapes/colors against each sport's real field background color (pulled from `components/board/fields/*.tsx`) and screenshotted it to check legibility across all five sports (AF turf, soccer turf, basketball parquet, volleyball floor, handball floor) — every element reads clearly on every background.
- Couldn't exercise the live board itself in this environment (requires a Supabase-backed session), so please double check on-device as the source of truth.

## Test plan

- [ ] Open the tactics board for each sport and place a drabinka, płotki, and partner; confirm they're clearly visible against the field.
- [ ] On American football, also place a tarcza and bramka.
- [ ] Confirm stretch (drag ladder/hurdle endpoints), drag, select, and delete still work as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_018pKST7P64bXrJwkT9jNCNa)_