### PR TITLE
Landing showcase: denser scenes, seamless loop

### DIFF
--- a/components/showcase/AnimatedPath.tsx
+++ b/components/showcase/AnimatedPath.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { Arrow, Circle, Line } from "react-konva";
-import { flattenPoints } from "@/lib/board/path";
+import { endTangent, flattenPoints } from "@/lib/board/path";
 import { easeInOutCubic, easeOutCubic, timedProgress } from "@/lib/board/showcase/easing";
 import { revealPathPoints } from "@/lib/board/showcase/reveal";
 import type { ShowcasePath } from "@/lib/board/showcase/types";
+import type { BoardPoint } from "@/lib/board/types";
+import { HurdleRow, LadderShape } from "./EquipmentPath";
 
 // Same styling TacticsBoard.tsx uses for the in-progress point markers
 // while a coach is actively drawing a route on the real board (line 690) -
@@ -12,6 +14,9 @@ import type { ShowcasePath } from "@/lib/board/showcase/types";
 // does live.
 const DRAWING_TIP_COLOR = "#10b981";
 const ARROWHEAD_SETTLE_MS = 220;
+// Matches PathElementNode's BlockBar - the perpendicular end-cap the real
+// board draws for the "block" tool's headStyle: "bar".
+const BLOCK_BAR_HALF_LENGTH = 11;
 
 export function AnimatedPath({ path, elapsed }: { path: ShowcasePath; elapsed: number }) {
   const progress = timedProgress(elapsed, path.startAt, path.duration, easeInOutCubic);
@@ -19,6 +24,11 @@ export function AnimatedPath({ path, elapsed }: { path: ShowcasePath; elapsed: n
 
   const revealed = revealPathPoints(path.points, Boolean(path.curved), Boolean(path.wavy), progress);
   if (revealed.points.length < 2) return null;
+
+  if (path.kind === "ladder" || path.kind === "hurdles") {
+    const Shape = path.kind === "ladder" ? LadderShape : HurdleRow;
+    return <Shape points={revealed.points} strokeWidth={path.strokeWidth} />;
+  }
 
   const flat = flattenPoints(revealed.points);
   const arrowheadProgress = revealed.complete
@@ -53,6 +63,9 @@ export function AnimatedPath({ path, elapsed }: { path: ShowcasePath; elapsed: n
           listening={false}
         />
       )}
+      {path.headStyle === "bar" && revealed.complete && (
+        <BlockBarEnd points={revealed.points} color={path.color} strokeWidth={path.strokeWidth} />
+      )}
       {!revealed.complete && revealed.tip && (
         <Circle
           x={revealed.tip.x}
@@ -65,5 +78,29 @@ export function AnimatedPath({ path, elapsed }: { path: ShowcasePath; elapsed: n
         />
       )}
     </>
+  );
+}
+
+function BlockBarEnd({
+  points,
+  color,
+  strokeWidth,
+}: {
+  points: BoardPoint[];
+  color: string;
+  strokeWidth: number;
+}) {
+  const end = points[points.length - 1];
+  const tangent = endTangent(points);
+  const perp = { x: -tangent.y, y: tangent.x };
+  const half = BLOCK_BAR_HALF_LENGTH;
+  return (
+    <Line
+      points={[end.x - perp.x * half, end.y - perp.y * half, end.x + perp.x * half, end.y + perp.y * half]}
+      stroke={color}
+      strokeWidth={strokeWidth}
+      lineCap="round"
+      listening={false}
+    />
   );
 }

--- a/components/showcase/BoardShowcaseEngine.tsx
+++ b/components/showcase/BoardShowcaseEngine.tsx
@@ -21,6 +21,19 @@ export interface BoardShowcaseEngineProps {
   transitionMs: number;
   loop: boolean;
   showCaptions: boolean;
+  /**
+   * How long, in ms, the next scene is pre-mounted (ticking at opacity 0,
+   * behind the current one) before it becomes the visible front layer -
+   * and how far into its own timeline the very first slot starts. Default
+   * 0 reproduces the original behaviour exactly: every scene starts from a
+   * bare field, and the crossfade at loop-round happens between a fully
+   * built scene and a brand new empty one - a visible "reset" beat. A
+   * positive value means the incoming scene is already partway built by
+   * the time it's revealed, so there's no seam and no empty field on first
+   * paint either. Onboarding leaves this unset; only the landing variant
+   * sets it.
+   */
+  overlapMs?: number;
   className?: string;
 }
 
@@ -28,8 +41,9 @@ export interface BoardShowcaseEngineProps {
  * The one shared animation engine behind both the onboarding and landing
  * showcases. Owns the playback clock and the scene sequence/crossfade;
  * everything sport-specific (field, colors, choreography) comes from
- * `scenes`, and everything about pacing/looping/captions comes from props -
- * so the two call sites only differ in what they pass in here.
+ * `scenes`, and everything about pacing/looping/captions/overlap comes
+ * from props - so the two call sites only differ in what they pass in
+ * here.
  */
 export function BoardShowcaseEngine({
   scenes,
@@ -38,13 +52,14 @@ export function BoardShowcaseEngine({
   transitionMs,
   loop,
   showCaptions,
+  overlapMs = 0,
   className,
 }: BoardShowcaseEngineProps) {
   const pacedScenes = useMemo(() => scenes.map((s) => paceScene(s, pace)), [scenes, pace]);
 
   const [now, setNow] = useState(() => performance.now());
   const [slots, setSlots] = useState<Slot[]>(() => [
-    { key: 0, sceneIndex: 0, startedAt: performance.now() },
+    { key: 0, sceneIndex: 0, startedAt: performance.now() - overlapMs },
   ]);
   const [frontKey, setFrontKey] = useState(0);
   // Deliberately separate from frontKey: frontKey flips at the *start* of
@@ -56,6 +71,10 @@ export function BoardShowcaseEngine({
   const [captionSceneIndex, setCaptionSceneIndex] = useState(0);
   const nextKeyRef = useRef(1);
   const transitioningRef = useRef(false);
+  // Key of a scene already pre-mounted (behind, at opacity 0) ahead of its
+  // actual reveal - null when nothing's been pre-mounted yet, or when
+  // overlapMs is 0 and this mechanism never engages at all.
+  const pendingKeyRef = useRef<number | null>(null);
   // Only cleared by the unmount effect below - deliberately *not* tied to
   // the polling effect's own re-runs. That polling effect re-fires every
   // animation frame (it depends on `now`), and a cleanup returned from it
@@ -87,15 +106,41 @@ export function BoardShowcaseEngine({
     const scene = pacedScenes[front.sceneIndex];
     const elapsed = now - front.startedAt;
     const total = scene.scriptedDuration + holdMs;
-    if (elapsed < total) return;
-
     const atEnd = front.sceneIndex === scenes.length - 1;
-    if (atEnd && !loop) return;
+    const canAdvance = !(atEnd && !loop);
+
+    // Pre-mount the next scene, invisible, `overlapMs` before this one
+    // would otherwise hand off - so by the time it's actually revealed
+    // below it's already partway built instead of starting the crossfade
+    // from an empty field. No-op whenever overlapMs is 0.
+    if (
+      canAdvance &&
+      overlapMs > 0 &&
+      pendingKeyRef.current === null &&
+      elapsed >= total - overlapMs &&
+      elapsed < total
+    ) {
+      const nextIndex = (front.sceneIndex + 1) % scenes.length;
+      const newKey = nextKeyRef.current++;
+      pendingKeyRef.current = newKey;
+      setSlots((prev) => [...prev, { key: newKey, sceneIndex: nextIndex, startedAt: now }]);
+    }
+
+    if (elapsed < total) return;
+    if (!canAdvance) return;
 
     transitioningRef.current = true;
-    const nextIndex = (front.sceneIndex + 1) % scenes.length;
-    const newKey = nextKeyRef.current++;
-    setSlots((prev) => [...prev, { key: newKey, sceneIndex: nextIndex, startedAt: now }]);
+    let newKey: number;
+    let nextIndex: number;
+    if (pendingKeyRef.current !== null) {
+      newKey = pendingKeyRef.current;
+      pendingKeyRef.current = null;
+      nextIndex = slots.find((s) => s.key === newKey)?.sceneIndex ?? (front.sceneIndex + 1) % scenes.length;
+    } else {
+      nextIndex = (front.sceneIndex + 1) % scenes.length;
+      newKey = nextKeyRef.current++;
+      setSlots((prev) => [...prev, { key: newKey, sceneIndex: nextIndex, startedAt: now }]);
+    }
 
     // Let the new slot mount (and paint) at opacity 0 first, so flipping
     // `frontKey` a frame later is what the CSS transition actually
@@ -111,7 +156,7 @@ export function BoardShowcaseEngine({
       transitioningRef.current = false;
       pendingTimeoutRef.current = null;
     }, transitionMs + 80);
-  }, [now, frontKey, slots, pacedScenes, scenes.length, loop, holdMs, transitionMs]);
+  }, [now, frontKey, slots, pacedScenes, scenes.length, loop, holdMs, transitionMs, overlapMs]);
 
   const activeCaption = pacedScenes[captionSceneIndex]?.caption;
 

--- a/components/showcase/EquipmentPath.tsx
+++ b/components/showcase/EquipmentPath.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Group, Line } from "react-konva";
+import { flattenPoints, markPointsAlongPolyline } from "@/lib/board/path";
+import type { BoardPoint } from "@/lib/board/types";
+
+// Mirrors components/board/PathElementNode.tsx's LadderShape/HurdleRow
+// constant-for-constant (spacing, gaps, colors) - a ladder or hurdle row
+// placed in a showcase scene has to read as the exact same equipment the
+// coach drags onto the real board, not an approximation of it. Dropped:
+// the drag handles and hit-testing props, since nothing here is
+// interactive.
+const LADDER_RUNG_SPACING = 20;
+const LADDER_RAIL_GAP = 24;
+const LADDER_RUNG_OVERHANG = 5;
+const HURDLE_SPACING = 42;
+const HURDLE_BAR_HALF_WIDTH = 11;
+const HURDLE_LEG_LENGTH = 7;
+
+const EQUIPMENT_OUTLINE_COLOR = "#111827";
+const LADDER_RAIL_COLOR = "#dc2626";
+const LADDER_RUNG_COLOR = "#facc15";
+const HURDLE_COLOR = "#dc2626";
+
+export function LadderShape({
+  points,
+  strokeWidth,
+}: {
+  points: BoardPoint[];
+  strokeWidth: number;
+}) {
+  if (points.length < 2) return null;
+  const marks = markPointsAlongPolyline(points, LADDER_RUNG_SPACING);
+  const half = LADDER_RAIL_GAP / 2;
+  const railSide = (side: 1 | -1) =>
+    flattenPoints(
+      marks.map((m) => {
+        const perp = { x: -m.dir.y, y: m.dir.x };
+        return {
+          x: m.point.x + perp.x * half * side,
+          y: m.point.y + perp.y * half * side,
+        };
+      }),
+    );
+  const rail1 = railSide(1);
+  const railNeg1 = railSide(-1);
+  const rungStrokeWidth = Math.max(2, strokeWidth - 1);
+
+  return (
+    <Group listening={false}>
+      <Line points={rail1} stroke={EQUIPMENT_OUTLINE_COLOR} strokeWidth={strokeWidth + 2.5} lineCap="round" lineJoin="round" />
+      <Line points={rail1} stroke={LADDER_RAIL_COLOR} strokeWidth={strokeWidth} lineCap="round" lineJoin="round" />
+      <Line points={railNeg1} stroke={EQUIPMENT_OUTLINE_COLOR} strokeWidth={strokeWidth + 2.5} lineCap="round" lineJoin="round" />
+      <Line points={railNeg1} stroke={LADDER_RAIL_COLOR} strokeWidth={strokeWidth} lineCap="round" lineJoin="round" />
+      {marks.map((m, i) => {
+        const perp = { x: -m.dir.y, y: m.dir.x };
+        const rungHalf = half + LADDER_RUNG_OVERHANG;
+        const rungPoints = [
+          m.point.x - perp.x * rungHalf,
+          m.point.y - perp.y * rungHalf,
+          m.point.x + perp.x * rungHalf,
+          m.point.y + perp.y * rungHalf,
+        ];
+        return (
+          <Group key={i}>
+            <Line points={rungPoints} stroke={EQUIPMENT_OUTLINE_COLOR} strokeWidth={rungStrokeWidth + 2} lineCap="round" />
+            <Line points={rungPoints} stroke={LADDER_RUNG_COLOR} strokeWidth={rungStrokeWidth} lineCap="round" />
+          </Group>
+        );
+      })}
+    </Group>
+  );
+}
+
+export function HurdleRow({
+  points,
+  strokeWidth,
+}: {
+  points: BoardPoint[];
+  strokeWidth: number;
+}) {
+  if (points.length < 2) return null;
+  const marks = markPointsAlongPolyline(points, HURDLE_SPACING);
+  const outlineWidth = strokeWidth + 2.5;
+
+  return (
+    <Group listening={false}>
+      {marks.map((m, i) => {
+        const perp = { x: -m.dir.y, y: m.dir.x };
+        const barA = {
+          x: m.point.x - perp.x * HURDLE_BAR_HALF_WIDTH,
+          y: m.point.y - perp.y * HURDLE_BAR_HALF_WIDTH,
+        };
+        const barB = {
+          x: m.point.x + perp.x * HURDLE_BAR_HALF_WIDTH,
+          y: m.point.y + perp.y * HURDLE_BAR_HALF_WIDTH,
+        };
+        const legA = { x: barA.x + m.dir.x * HURDLE_LEG_LENGTH, y: barA.y + m.dir.y * HURDLE_LEG_LENGTH };
+        const legB = { x: barB.x + m.dir.x * HURDLE_LEG_LENGTH, y: barB.y + m.dir.y * HURDLE_LEG_LENGTH };
+        const barPoints = [barA.x, barA.y, barB.x, barB.y];
+        const legAPoints = [barA.x, barA.y, legA.x, legA.y];
+        const legBPoints = [barB.x, barB.y, legB.x, legB.y];
+        return (
+          <Group key={i}>
+            <Line points={barPoints} stroke={EQUIPMENT_OUTLINE_COLOR} strokeWidth={outlineWidth} lineCap="round" />
+            <Line points={legAPoints} stroke={EQUIPMENT_OUTLINE_COLOR} strokeWidth={outlineWidth} lineCap="round" />
+            <Line points={legBPoints} stroke={EQUIPMENT_OUTLINE_COLOR} strokeWidth={outlineWidth} lineCap="round" />
+            <Line points={barPoints} stroke={HURDLE_COLOR} strokeWidth={strokeWidth} lineCap="round" />
+            <Line points={legAPoints} stroke={HURDLE_COLOR} strokeWidth={strokeWidth} lineCap="round" />
+            <Line points={legBPoints} stroke={HURDLE_COLOR} strokeWidth={strokeWidth} lineCap="round" />
+          </Group>
+        );
+      })}
+    </Group>
+  );
+}

--- a/components/showcase/LandingShowcase.tsx
+++ b/components/showcase/LandingShowcase.tsx
@@ -1,20 +1,28 @@
 "use client";
 
-import { showcaseScenes } from "@/lib/board/showcase/scenes";
+import { landingShowcaseScenes } from "@/lib/board/showcase/landingScenes";
 import { BoardShowcaseEngine } from "./BoardShowcaseEngine";
 
 /**
- * Tighter, caption-free, single looping cycle meant to sit inside a landing
- * page hero - not wired into any page yet (that's a future round), but the
- * engine underneath is the exact same one the onboarding variant uses.
+ * Caption-free, single looping cycle meant to sit inside a landing page
+ * hero. Uses its own denser, busier scenes (lib/board/showcase/landingScenes.ts)
+ * instead of the onboarding ones - onboarding teaches one tool at a time,
+ * this needs to sell in a few seconds, so each scene builds a fuller
+ * picture (multiple players, more than one route/action, training
+ * equipment) with everything staggered rather than sequential.
+ *
+ * `overlapMs` pre-mounts the next scene behind the current one before it
+ * hands off, so the loop never visibly resets to an empty field - the same
+ * engine onboarding uses, just with that one extra knob turned on.
  */
 export function LandingShowcase({ className }: { className?: string }) {
   return (
     <BoardShowcaseEngine
-      scenes={showcaseScenes}
+      scenes={landingShowcaseScenes}
       pace={0.85}
       holdMs={550}
       transitionMs={500}
+      overlapMs={1000}
       loop
       showCaptions={false}
       className={className ?? "h-full w-full"}

--- a/lib/board/showcase/landingScenes.ts
+++ b/lib/board/showcase/landingScenes.ts
@@ -1,0 +1,247 @@
+import { americanFootballConfig } from "@/lib/board/sports/americanFootball";
+import { basketballConfig } from "@/lib/board/sports/basketball";
+import { footballConfig } from "@/lib/board/sports/football";
+import { toolStyle } from "./scenes";
+import type { ShowcaseScene } from "./types";
+
+// Landing-only choreography. Onboarding (scenes.ts / showcaseScenes) builds
+// one thing at a time because it's teaching a coach how each tool works -
+// this instead composes a fuller scene per sport (multiple players, more
+// than one route/action, training equipment) with everything staggered so
+// a visitor sees "this is a real tactical tool" within a couple of
+// seconds, not "this draws a line". Same real per-sport tool defs/colors
+// as the onboarding scenes - nothing invented, still pixel-identical to
+// the live board. This file is only ever imported by LandingShowcase.
+
+// ---------------------------------------------------------------------------
+// American football: a full passing-play picture - two receivers running
+// routes on either side, a defender covering one of them, a quick block
+// off the snap, pre-snap cones marking the formation width, and a shield
+// nearby, before the QB's pass connects.
+// ---------------------------------------------------------------------------
+const afRoute = toolStyle(americanFootballConfig, "route");
+const afBlock = toolStyle(americanFootballConfig, "block");
+
+const afQb = { x: 500, y: 320 };
+const afWr1Start = { x: 560, y: 96 };
+const afWr1End = { x: 900, y: 236 };
+const afWr2Start = { x: 560, y: 430 };
+const afWr2End = { x: 780, y: 378 };
+
+export const landingAmericanFootballScene: ShowcaseScene = {
+  sportSlug: "american_football",
+  fieldModeId: "full",
+  caption: "Pełny obraz akcji ofensywnej.",
+  markers: [
+    { id: "qb", kind: "qb", x: afQb.x, y: afQb.y, label: "QB", appearAt: 0 },
+    { id: "cone-a", kind: "cone", x: 500, y: 190, appearAt: 40 },
+    { id: "cone-b", kind: "cone", x: 500, y: 450, appearAt: 90 },
+    { id: "shield", kind: "shield", x: 430, y: 250, appearAt: 220 },
+    { id: "wr1", kind: "player", x: afWr1Start.x, y: afWr1Start.y, label: "WR", appearAt: 150 },
+    { id: "wr2", kind: "player", x: afWr2Start.x, y: afWr2Start.y, label: "WR", appearAt: 150 },
+    { id: "defender", kind: "opponent", x: 760, y: 410, appearAt: 480 },
+  ],
+  paths: [
+    {
+      id: "block",
+      points: [{ x: 430, y: 250 }, { x: 480, y: 258 }],
+      color: afBlock.color,
+      strokeWidth: afBlock.strokeWidth,
+      headStyle: afBlock.headStyle,
+      startAt: 350,
+      duration: 450,
+    },
+    {
+      id: "route2",
+      points: [afWr2Start, { x: 700, y: 430 }, afWr2End],
+      color: afRoute.color,
+      strokeWidth: afRoute.strokeWidth,
+      headStyle: afRoute.headStyle,
+      curved: true,
+      startAt: 550,
+      duration: 1200,
+    },
+    {
+      id: "route1",
+      points: [afWr1Start, { x: 760, y: 96 }, afWr1End],
+      color: afRoute.color,
+      strokeWidth: afRoute.strokeWidth,
+      headStyle: afRoute.headStyle,
+      curved: true,
+      startAt: 700,
+      duration: 1700,
+    },
+    {
+      id: "pass",
+      points: [afQb, afWr1End],
+      color: afRoute.color,
+      strokeWidth: afRoute.strokeWidth,
+      headStyle: afRoute.headStyle,
+      curved: true,
+      startAt: 2600,
+      duration: 1000,
+    },
+  ],
+  scriptedDuration: 3600,
+};
+
+// ---------------------------------------------------------------------------
+// Basketball: a ball handler works off an agility ladder and a dribble
+// gate, a defender steps up, then a pass to a teammate sets up the shot.
+// ---------------------------------------------------------------------------
+const bbDribble = toolStyle(basketballConfig, "dribble");
+const bbShot = toolStyle(basketballConfig, "shot");
+const bbPass = toolStyle(basketballConfig, "passLine");
+
+const bbBallStart = { x: 470, y: 270 };
+const bbDribbleEnd = { x: 790, y: 270 };
+const bbTeammate = { x: 760, y: 150 };
+const bbHoop = { x: 866, y: 270 };
+
+export const landingBasketballScene: ShowcaseScene = {
+  sportSlug: "basketball",
+  fieldModeId: "full",
+  caption: "Tak powstaje cała akcja pod koszem.",
+  markers: [
+    { id: "player", kind: "player", x: bbBallStart.x, y: bbBallStart.y, appearAt: 0 },
+    { id: "cone-a", kind: "cone", x: 520, y: 340, appearAt: 40 },
+    { id: "cone-b", kind: "cone", x: 520, y: 210, appearAt: 90 },
+    { id: "defender", kind: "opponent", x: 650, y: 220, appearAt: 400 },
+    { id: "teammate", kind: "partner", x: bbTeammate.x, y: bbTeammate.y, label: "P", appearAt: 900 },
+  ],
+  paths: [
+    {
+      id: "ladder",
+      kind: "ladder",
+      points: [{ x: 70, y: 460 }, { x: 220, y: 460 }],
+      color: "#dc2626",
+      strokeWidth: 3,
+      headStyle: "none",
+      startAt: 150,
+      duration: 550,
+    },
+    {
+      id: "dribble",
+      points: [bbBallStart, { x: 600, y: 200 }, { x: 700, y: 330 }, bbDribbleEnd],
+      color: bbDribble.color,
+      strokeWidth: bbDribble.strokeWidth,
+      headStyle: bbDribble.headStyle,
+      wavy: true,
+      startAt: 350,
+      duration: 1600,
+    },
+    {
+      id: "passLine",
+      points: [bbDribbleEnd, bbTeammate],
+      color: bbPass.color,
+      strokeWidth: bbPass.strokeWidth,
+      headStyle: bbPass.headStyle,
+      dash: bbPass.dash,
+      startAt: 1500,
+      duration: 650,
+    },
+    {
+      id: "shot",
+      points: [bbTeammate, bbHoop],
+      color: bbShot.color,
+      strokeWidth: bbShot.strokeWidth,
+      headStyle: bbShot.headStyle,
+      curved: true,
+      startAt: 2300,
+      duration: 900,
+    },
+  ],
+  scriptedDuration: 3200,
+};
+
+// ---------------------------------------------------------------------------
+// Soccer: the slalom drill runs through a full agility circuit - hurdles
+// and a ladder as stations either side of the cones - a defender is beaten,
+// and the move finishes with a pass to a teammate making the run.
+// ---------------------------------------------------------------------------
+const soccerMove = toolStyle(footballConfig, "movement");
+const soccerPass = toolStyle(footballConfig, "passLine");
+
+const slalomCones = [
+  { x: 650, y: 340 },
+  { x: 720, y: 340 },
+  { x: 790, y: 340 },
+  { x: 860, y: 340 },
+];
+const slalomStart = { x: 580, y: 340 };
+const slalomEnd = { x: 920, y: 340 };
+const soccerTeammate = { x: 980, y: 260 };
+
+export const landingSoccerScene: ShowcaseScene = {
+  sportSlug: "football",
+  fieldModeId: "full",
+  caption: "Cały tor zwinnościowy w akcji.",
+  markers: [
+    { id: "player", kind: "player", x: slalomStart.x, y: slalomStart.y, appearAt: 0 },
+    ...slalomCones.map((c, i) => ({
+      id: `cone-${i}`,
+      kind: "cone" as const,
+      x: c.x,
+      y: c.y,
+      appearAt: 60 + i * 90,
+    })),
+    { id: "defender", kind: "opponent" as const, x: 700, y: 420, appearAt: 500 },
+    { id: "teammate", kind: "partner" as const, x: soccerTeammate.x, y: soccerTeammate.y, label: "P", appearAt: 1200 },
+  ],
+  paths: [
+    {
+      id: "ladder",
+      kind: "ladder",
+      points: [{ x: 620, y: 520 }, { x: 760, y: 520 }],
+      color: "#dc2626",
+      strokeWidth: 3,
+      headStyle: "none",
+      startAt: 120,
+      duration: 550,
+    },
+    {
+      id: "hurdles",
+      kind: "hurdles",
+      points: [{ x: 620, y: 160 }, { x: 740, y: 160 }],
+      color: "#dc2626",
+      strokeWidth: 3,
+      headStyle: "none",
+      startAt: 250,
+      duration: 550,
+    },
+    {
+      id: "slalom",
+      points: [
+        slalomStart,
+        { x: slalomCones[0].x, y: 296 },
+        { x: slalomCones[1].x, y: 384 },
+        { x: slalomCones[2].x, y: 296 },
+        { x: slalomCones[3].x, y: 384 },
+        slalomEnd,
+      ],
+      color: soccerMove.color,
+      strokeWidth: soccerMove.strokeWidth,
+      headStyle: soccerMove.headStyle,
+      curved: true,
+      startAt: 550,
+      duration: 2100,
+    },
+    {
+      id: "passLine",
+      points: [slalomEnd, soccerTeammate],
+      color: soccerPass.color,
+      strokeWidth: soccerPass.strokeWidth,
+      headStyle: soccerPass.headStyle,
+      dash: soccerPass.dash,
+      startAt: 2750,
+      duration: 550,
+    },
+  ],
+  scriptedDuration: 3300,
+};
+
+export const landingShowcaseScenes: ShowcaseScene[] = [
+  landingAmericanFootballScene,
+  landingBasketballScene,
+  landingSoccerScene,
+];

--- a/lib/board/showcase/scenes.ts
+++ b/lib/board/showcase/scenes.ts
@@ -9,7 +9,7 @@ import type { ShowcaseScene } from "./types";
 // per-sport tool defs (lib/board/sports/*.tsx) - never invented - so what
 // animates here is styled identically to what the coach draws with that
 // same tool moments later on the real board.
-function toolStyle(config: SportBoardConfig, toolId: string) {
+export function toolStyle(config: SportBoardConfig, toolId: string) {
   const tool = config.tools.find((t) => t.id === toolId);
   if (!tool || tool.kind.create !== "path") {
     throw new Error(`Showcase: tool "${toolId}" not found or not a path tool`);

--- a/lib/board/showcase/types.ts
+++ b/lib/board/showcase/types.ts
@@ -26,6 +26,13 @@ export interface ShowcasePath {
   dash?: number[];
   curved?: boolean;
   wavy?: boolean;
+  /**
+   * Set for training-equipment paths (the real "ladder"/"hurdles" tools,
+   * which are 2-point strips rather than a drawn route) so they render as
+   * the actual rails/rungs or hurdle row PathElementNode draws on the live
+   * board, instead of a plain stroked line.
+   */
+  kind?: "ladder" | "hurdles";
   /** ms into the scene when drawing starts. */
   startAt: number;
   /** how long the reveal animation takes, in ms. */


### PR DESCRIPTION
## Summary

LandingShowcase and OnboardingShowcase share one engine but have different jobs: onboarding teaches one tool at a time, landing needs to sell in a few seconds. This round differentiates them without touching onboarding's behavior.

- **Denser scenes** — `lib/board/showcase/landingScenes.ts` is a new, landing-only scene set (the onboarding scenes in `scenes.ts` are untouched). Each sport now composes a fuller picture instead of one lone route on an empty field:
  - American football: QB + two receivers running routes on either side, a defender, a quick block off the snap, pre-snap cones, and a blocking shield.
  - Basketball: a ball handler working off an agility ladder and a dribble gate, a defender, a pass to a teammate, then the shot.
  - Soccer: the slalom cone drill runs through a full agility circuit (hurdles + ladder stations either side), a defender beaten, finishing with a pass to a teammate.
  - Everything is staggered/overlapping (`appearAt`/`startAt` timings interleave rather than running strictly sequentially), and cones/ladder/hurdles/shield use the real per-sport `ToolDefs` colors and geometry — same rule as before, nothing invented.
  - Ladder/hurdles paths now render as the actual rails/rungs/hurdle-row shapes the live board draws (new `EquipmentPath.tsx`, mirroring `PathElementNode.tsx`'s constants 1:1) instead of a plain line, and the AF "block" tool's bar end-cap is now supported too.

- **Seamless loop** — `BoardShowcaseEngine` gains an opt-in `overlapMs` prop. When set, the next scene is pre-mounted (ticking at opacity 0, behind the current one) `overlapMs` before the current scene would otherwise hand off, so by the time the crossfade reveals it, it's already partway built instead of starting from an empty field. The same value also offsets the very first slot's clock, so first paint isn't a bare field either. `LandingShowcase` sets `overlapMs={1000}`; pace/hold/transition are unchanged. Verified by screenshotting the dev server through a full loop cycle (including the wrap-around back to the first scene) — no empty-field frame at any transition.

- **Onboarding unchanged** — `overlapMs` defaults to `0`, which reproduces the original engine logic exactly (verified by re-reading the diff: the only behavioral branch is gated behind `overlapMs > 0`). `OnboardingShowcase.tsx` and `scenes.ts`'s `showcaseScenes` are not part of this diff at all. Manually re-verified onboarding still shows one element at a time, at its original slower pace, with captions, via a temporary local route (not part of this diff).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx eslint components/showcase lib/board/showcase` — clean
- [x] `npx vitest run` — 16/16 passing
- [x] Manual: ran the dev server, screenshotted the landing hero through a full loop (all 3 sports + wrap-around) — scenes are dense from first paint, no visible reset-to-empty beat
- [x] Manual: screenshotted `OnboardingShowcase` in isolation — single-element builds, original pace, captions all unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01ApdprnafR4fTHByf2b7eNJ)_