### PR TITLE
feat(board): add dashed pass-line tool to american football

### DIFF
--- a/lib/board/sports/americanFootball.tsx
+++ b/lib/board/sports/americanFootball.tsx
@@ -14,6 +14,7 @@ import {
   LadderIcon,
   OpponentIcon,
   PartnerIcon,
+  PassLineIcon,
   PlayerIcon,
   QbIcon,
   RunArrowIcon,
@@ -112,6 +113,20 @@ export const americanFootballConfig: SportBoardConfig = {
         create: "path",
         style: { color: "#111827", strokeWidth: 4, headStyle: "arrow" },
         curvable: true,
+      },
+    },
+    {
+      id: "passLine",
+      label: "Podanie",
+      icon: <PassLineIcon />,
+      kind: {
+        create: "path",
+        style: {
+          color: "#7c3aed",
+          strokeWidth: 4,
+          headStyle: "arrow",
+          dash: [14, 10],
+        },
       },
     },
     {


### PR DESCRIPTION
## Summary
- American football had no dedicated pass tool, so a QB's throw had to be drawn with "Trasa biegu" (run route) — making passes and runs visually identical, which is wrong in football notation (run = solid, pass = dashed).
- Adds a `passLine` tool (label "Podanie") to `americanFootballConfig.tools` in `lib/board/sports/americanFootball.tsx`, reusing the exact same mechanism already used by soccer, basketball, handball, and volleyball: a `create: "path"` `ToolKind` with `style.dash: [14, 10]`, `headStyle: "arrow"`, `color: "#7c3aed"`, rendered dashed via `PathElementNode`'s generic Konva `Arrow`/`Line` `dash` prop — no new element kind or rendering code needed.
- Uses the existing shared `PassLineIcon` (violet dashed arrow) for the toolbar icon, keeping it visually distinct from the black solid "Trasa biegu" arrow.

## Test plan
- [x] `npx tsc --noEmit` shows no new errors in the changed file (pre-existing unrelated module-resolution errors are from `node_modules` not being installed in this environment)
- [ ] Manually verify in the AF board that "Podanie" appears in the toolbar, draws a dashed violet arrow, and behaves like other path tools (drag/delete)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtD1J3xstQ84jtgBX4Acy8)_