### PR TITLE
Support universal exercises and sport positions in the library

### DIFF
--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -5,8 +5,10 @@ import { CategoryBadge } from "@/components/exercises/CategoryBadge";
 import { SportBadge } from "@/components/exercises/SportBadge";
 import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
 import { DeleteExerciseButton } from "@/components/exercises/DeleteExerciseButton";
+import { PositionPills } from "@/components/exercises/PositionPills";
 import { formatDuration } from "@/lib/exercises";
 import { createClient } from "@/lib/supabase/server";
+import type { Position } from "@/lib/supabase/types";
 
 export const dynamic = "force-dynamic";
 
@@ -49,25 +51,47 @@ export default async function ExerciseDetailPage({
     );
   }
 
-  const [{ data: category }, { data: sport }, { data: author }] =
-    await Promise.all([
+  const [
+    { data: category },
+    { data: sport },
+    { data: author },
+    { data: exercisePositions },
+  ] = await Promise.all([
       supabase
         .from("categories")
         .select("*")
         .eq("id", exercise.category_id)
         .maybeSingle(),
-      supabase
-        .from("sports")
-        .select("*")
-        .eq("id", exercise.sport_id)
-        .maybeSingle(),
+      exercise.sport_id !== null
+        ? supabase
+            .from("sports")
+            .select("*")
+            .eq("id", exercise.sport_id)
+            .maybeSingle()
+        : Promise.resolve({ data: null }),
       exercise.author_id
         ? supabase
             .rpc("list_public_profiles")
             .eq("id", exercise.author_id)
             .maybeSingle()
         : Promise.resolve({ data: null }),
+      supabase
+        .from("exercise_positions")
+        .select("position_id")
+        .eq("exercise_id", exercise.id),
     ]);
+
+  const positionIds = (exercisePositions ?? []).map(
+    (link) => link.position_id,
+  );
+  const { data: positions } =
+    positionIds.length > 0
+      ? await supabase
+          .from("positions")
+          .select("*")
+          .in("id", positionIds)
+          .order("sort_order", { ascending: true })
+      : { data: [] as Position[] };
 
   const isOwner = userData.user?.id === exercise.author_id;
   const authorsById = new Map(
@@ -108,6 +132,11 @@ export default async function ExerciseDetailPage({
               </span>
             )}
           </div>
+          {positions && positions.length > 0 && (
+            <div className="mt-2">
+              <PositionPills positions={positions} />
+            </div>
+          )}
         </div>
 
         <div className="flex shrink-0 gap-2">

--- a/components/exercises/ExerciseCard.tsx
+++ b/components/exercises/ExerciseCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type {
   Category,
   Exercise,
+  Position,
   PublicProfile,
   Sport,
 } from "@/lib/supabase/types";
@@ -9,18 +10,21 @@ import { formatDuration } from "@/lib/exercises";
 import { AuthorBadge } from "./AuthorBadge";
 import { CategoryBadge } from "./CategoryBadge";
 import { DifficultyIndicator } from "./DifficultyIndicator";
+import { PositionPills } from "./PositionPills";
 import { SportBadge } from "./SportBadge";
 
 export function ExerciseCard({
   exercise,
   category,
   sport,
+  positions,
   authorsById,
   currentUserId,
 }: {
   exercise: Exercise;
   category: Category | undefined;
   sport: Sport | undefined;
+  positions: Position[];
   authorsById: Map<string, PublicProfile>;
   currentUserId: string | null;
 }) {
@@ -46,6 +50,12 @@ export function ExerciseCard({
           authorsById={authorsById}
         />
       </div>
+
+      {positions.length > 0 && (
+        <div className="mt-2">
+          <PositionPills positions={positions} />
+        </div>
+      )}
 
       {exercise.description && (
         <p className="mt-3 line-clamp-2 text-sm text-neutral-600 dark:text-neutral-400">

--- a/components/exercises/ExercisesLibrary.tsx
+++ b/components/exercises/ExercisesLibrary.tsx
@@ -8,6 +8,8 @@ import type {
   Category,
   Difficulty,
   Exercise,
+  ExercisePosition,
+  Position,
   PublicProfile,
   Sport,
 } from "@/lib/supabase/types";
@@ -54,6 +56,11 @@ export function ExercisesLibrary({
     Difficulty | typeof ALL
   >(ALL);
   const [equipmentFilter, setEquipmentFilter] = useState<string>(ALL);
+  const [positionFilter, setPositionFilter] = useState<string>(ALL);
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [exercisePositions, setExercisePositions] = useState<
+    ExercisePosition[]
+  >([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -93,11 +100,67 @@ export function ExercisesLibrary({
     };
   }, []);
 
+  // Positions and their exercise tags are static reference/join data, fetched
+  // once and joined in memory - same approach as authors above.
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    Promise.all([
+      supabase.from("positions").select("*"),
+      supabase.from("exercise_positions").select("*"),
+    ]).then(([positionsRes, exercisePositionsRes]) => {
+      if (cancelled) return;
+      if (positionsRes.data) setPositions(positionsRes.data);
+      if (exercisePositionsRes.data)
+        setExercisePositions(exercisePositionsRes.data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const authorsById = useMemo(() => {
     const map = new Map<string, PublicProfile>();
     for (const author of authors) map.set(author.id, author);
     return map;
   }, [authors]);
+
+  const positionsById = useMemo(() => {
+    const map = new Map<string, Position>();
+    for (const position of positions) map.set(position.id, position);
+    return map;
+  }, [positions]);
+
+  const positionsByExerciseId = useMemo(() => {
+    const map = new Map<string, Position[]>();
+    for (const link of exercisePositions) {
+      const position = positionsById.get(link.position_id);
+      if (!position) continue;
+      const list = map.get(link.exercise_id) ?? [];
+      list.push(position);
+      map.set(link.exercise_id, list);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => a.sort_order - b.sort_order);
+    }
+    return map;
+  }, [exercisePositions, positionsById]);
+
+  // Options are sport-dependent so a coach never sees another sport's
+  // positions; the filter itself is hidden when there's nothing to show.
+  const positionOptions = useMemo(() => {
+    if (sportFilter === ALL) return [];
+    return positions
+      .filter((position) => position.sport_id === sportFilter)
+      .sort((a, b) => a.sort_order - b.sort_order);
+  }, [positions, sportFilter]);
+
+  useEffect(() => {
+    if (positionFilter === ALL) return;
+    if (!positionOptions.some((position) => position.id === positionFilter)) {
+      setPositionFilter(ALL);
+    }
+  }, [positionOptions, positionFilter]);
 
   const categoriesById = useMemo(() => {
     const map = new Map<number, Category>();
@@ -143,8 +206,15 @@ export function ExercisesLibrary({
       }
       if (scopeFilter === MINE && exercise.author_id !== currentUserId)
         return false;
-      if (sportFilter !== ALL && exercise.sport_id !== sportFilter)
+      // sport_id === null means the exercise is universal, so it must match
+      // every sport filter, not just "all".
+      if (
+        sportFilter !== ALL &&
+        exercise.sport_id !== sportFilter &&
+        exercise.sport_id !== null
+      ) {
         return false;
+      }
       if (categoryFilter !== ALL && exercise.category_id !== categoryFilter)
         return false;
       if (difficultyFilter !== ALL && exercise.difficulty !== difficultyFilter)
@@ -154,6 +224,12 @@ export function ExercisesLibrary({
         !exercise.equipment.includes(equipmentFilter)
       ) {
         return false;
+      }
+      if (positionFilter !== ALL) {
+        const tags = positionsByExerciseId.get(exercise.id) ?? [];
+        if (!tags.some((position) => position.id === positionFilter)) {
+          return false;
+        }
       }
       return true;
     });
@@ -166,6 +242,8 @@ export function ExercisesLibrary({
     categoryFilter,
     difficultyFilter,
     equipmentFilter,
+    positionFilter,
+    positionsByExerciseId,
   ]);
 
   function clearAll() {
@@ -175,6 +253,7 @@ export function ExercisesLibrary({
     setCategoryFilter(ALL);
     setDifficultyFilter(ALL);
     setEquipmentFilter(ALL);
+    setPositionFilter(ALL);
   }
 
   const activeFilters: Array<{ label: string; onClear: () => void }> = [];
@@ -213,6 +292,12 @@ export function ExercisesLibrary({
     activeFilters.push({
       label: `Sprzęt: ${equipmentFilter}`,
       onClear: () => setEquipmentFilter(ALL),
+    });
+  }
+  if (positionFilter !== ALL) {
+    activeFilters.push({
+      label: `Pozycja: ${positionsById.get(positionFilter)?.label ?? positionFilter}`,
+      onClear: () => setPositionFilter(ALL),
     });
   }
 
@@ -254,7 +339,7 @@ export function ExercisesLibrary({
           />
         </div>
 
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-6">
           <FilterSelect
             id="scope-filter"
             label="Zakres"
@@ -319,6 +404,21 @@ export function ExercisesLibrary({
               ...equipmentOptions.map((item) => ({ value: item, label: item })),
             ]}
           />
+          {positionOptions.length > 0 && (
+            <FilterSelect
+              id="position-filter"
+              label="Pozycja"
+              value={positionFilter}
+              onChange={setPositionFilter}
+              options={[
+                { value: ALL, label: "Wszystkie pozycje" },
+                ...positionOptions.map((position) => ({
+                  value: position.id,
+                  label: position.label,
+                })),
+              ]}
+            />
+          )}
         </div>
 
         {activeFilters.length > 0 && (
@@ -389,7 +489,12 @@ export function ExercisesLibrary({
                 key={exercise.id}
                 exercise={exercise}
                 category={categoriesById.get(exercise.category_id)}
-                sport={sportsById.get(exercise.sport_id)}
+                sport={
+                  exercise.sport_id !== null
+                    ? sportsById.get(exercise.sport_id)
+                    : undefined
+                }
+                positions={positionsByExerciseId.get(exercise.id) ?? []}
                 authorsById={authorsById}
                 currentUserId={currentUserId}
               />

--- a/components/exercises/PositionPills.tsx
+++ b/components/exercises/PositionPills.tsx
@@ -1,0 +1,21 @@
+import type { Position } from "@/lib/supabase/types";
+
+// Deliberately quieter than CategoryBadge/SportBadge - position is a
+// secondary axis, not the primary classification of an exercise. Callers
+// are expected to pass positions already sorted by sort_order.
+export function PositionPills({ positions }: { positions: Position[] }) {
+  if (positions.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {positions.map((position) => (
+        <span
+          key={position.id}
+          className="inline-flex items-center rounded-full bg-neutral-100/70 px-2 py-0.5 text-[11px] font-medium text-neutral-500 dark:bg-neutral-900/60 dark:text-neutral-500"
+        >
+          {position.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -10,6 +10,10 @@ export type Difficulty = 1 | 2 | 3 | 4 | 5;
 
 export type WorkoutSection = "warmup" | "main" | "positional" | "cooldown";
 
+// 'official' rows are the null-author backfill; 'private' is the default for
+// anything a coach creates; 'team' is reserved for future team-shared scope.
+export type ExerciseScope = "official" | "private" | "team";
+
 export interface Database {
   public: {
     Tables: {
@@ -87,7 +91,8 @@ export interface Database {
           id: string;
           author_id: string | null;
           category_id: number;
-          sport_id: number;
+          // NULL = universal exercise, belongs to every sport.
+          sport_id: number | null;
           title: string;
           description: string | null;
           steps: string[];
@@ -97,6 +102,7 @@ export interface Database {
           media_url: string | null;
           board_state: Json | null;
           is_public: boolean;
+          scope: ExerciseScope;
           created_at: string;
           updated_at: string;
         };
@@ -104,7 +110,7 @@ export interface Database {
           id?: string;
           author_id?: string | null;
           category_id: number;
-          sport_id: number;
+          sport_id?: number | null;
           title: string;
           description?: string | null;
           steps?: string[];
@@ -114,6 +120,7 @@ export interface Database {
           media_url?: string | null;
           board_state?: Json | null;
           is_public?: boolean;
+          scope?: ExerciseScope;
           created_at?: string;
           updated_at?: string;
         };
@@ -121,7 +128,7 @@ export interface Database {
           id?: string;
           author_id?: string | null;
           category_id?: number;
-          sport_id?: number;
+          sport_id?: number | null;
           title?: string;
           description?: string | null;
           steps?: string[];
@@ -131,6 +138,7 @@ export interface Database {
           media_url?: string | null;
           board_state?: Json | null;
           is_public?: boolean;
+          scope?: ExerciseScope;
           created_at?: string;
           updated_at?: string;
         };
@@ -154,6 +162,68 @@ export interface Database {
             columns: ["sport_id"];
             isOneToOne: false;
             referencedRelation: "sports";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      positions: {
+        Row: {
+          id: string;
+          sport_id: number;
+          code: string;
+          label: string;
+          sort_order: number;
+        };
+        Insert: {
+          id?: string;
+          sport_id: number;
+          code: string;
+          label: string;
+          sort_order?: number;
+        };
+        Update: {
+          id?: string;
+          sport_id?: number;
+          code?: string;
+          label?: string;
+          sort_order?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "positions_sport_id_fkey";
+            columns: ["sport_id"];
+            isOneToOne: false;
+            referencedRelation: "sports";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      exercise_positions: {
+        Row: {
+          exercise_id: string;
+          position_id: string;
+        };
+        Insert: {
+          exercise_id: string;
+          position_id: string;
+        };
+        Update: {
+          exercise_id?: string;
+          position_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "exercise_positions_exercise_id_fkey";
+            columns: ["exercise_id"];
+            isOneToOne: false;
+            referencedRelation: "exercises";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "exercise_positions_position_id_fkey";
+            columns: ["position_id"];
+            isOneToOne: false;
+            referencedRelation: "positions";
             referencedColumns: ["id"];
           },
         ];
@@ -271,6 +341,9 @@ export interface Database {
 export type Exercise = Database["public"]["Tables"]["exercises"]["Row"];
 export type Category = Database["public"]["Tables"]["categories"]["Row"];
 export type Sport = Database["public"]["Tables"]["sports"]["Row"];
+export type Position = Database["public"]["Tables"]["positions"]["Row"];
+export type ExercisePosition =
+  Database["public"]["Tables"]["exercise_positions"]["Row"];
 export type Workout = Database["public"]["Tables"]["workouts"]["Row"];
 export type WorkoutItem = Database["public"]["Tables"]["workout_items"]["Row"];
 


### PR DESCRIPTION
## Summary

The DB schema changed outside this repo (migration applied directly, not included here): `exercises.sport_id` is now nullable — `NULL` means the exercise is universal and belongs to every discipline — plus a new `scope` column, and two new tables, `positions` and `exercise_positions` (many-to-many). Both new tables are RLS-readable by any authenticated user and writable by nobody, matching the existing exercise-immutability convention.

- **Regenerated `lib/supabase/types.ts` from the live database** (via Supabase MCP introspection) rather than hand-editing it: `sport_id: number | null`, added `scope: ExerciseScope`, and added the `positions` / `exercise_positions` table shapes + exported `Position`/`ExercisePosition` types.
- **Fixed the live bug**: the library's sport filter did an exact match on `sport_id`, silently hiding all 6 universal warmup/conditioning exercises under every sport filter. Selecting "Futbol amerykański" now matches `sport_id = 5 OR sport_id IS NULL`. Verified the affected rows directly against the live DB.
- **Checked `ExercisePicker`/`WorkoutBuilder` for the same pattern** — it turns out neither filters exercises by `sport_id` at all today, so there was no equivalent bug to fix there.
- **Added a position filter** to the exercises library, modeled on the existing `FilterSelect` instances. It's sport-dependent (options come from `positions` filtered by the selected sport) and hides itself entirely when the sport filter is "all" or the selected sport has no positions defined yet (every sport except American football, currently). Follows the existing client-side approach: `positions` and `exercise_positions` are fetched once and joined in memory, same pattern as the existing `authors` fetch.
- **Position tags as pills**: exercise cards and the detail page now show each exercise's tagged positions as small, visually quiet pills (no border, muted gray, smaller text than `CategoryBadge`/`SportBadge`), ordered by `sort_order`. On the detail page they sit directly below the existing sport/category/difficulty metadata row.

### URL sync for the position filter — flagging before building it

The sport filter syncs to `?sport=` via hand-written `URLSearchParams`/`router.replace` plumbing (there's no shared hook for it). I did **not** wire the same sync for the position filter in this PR — flagging the cost first, per the ask:

- Needs its own `searchParams` read + `router.replace` write, mirroring `setSportFilter`.
- Needs validation on load: a `?position=` from a stale/shared link could reference a position that doesn't belong to the currently-selected `?sport=` (or no sport at all) — has to silently fall back rather than error.
- Position ids are UUIDs, so the URL gets noticeably uglier than the numeric `?sport=` (e.g. `?sport=5&position=3f2a1e9c-...`) — a shareable link is less readable, though still functional.
- Interacts with the "hide filter when incompatible" behavior: switching sport away from AF should probably clear `?position=` from the URL too, not just from local state.

Net: small-to-medium, mechanical, no new dependencies. My instinct agrees it's worth doing for shareability — happy to add it as a quick follow-up if you want it in.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` all pass.
- Cross-checked against the live DB: 6 universal exercises (`sport_id IS NULL`), 10 seeded AF positions with real tag counts (`exercise_positions`) — matches what the new filter/pills logic expects.
- Did not spin up the dev server against live credentials for an in-browser check (skipped by request mid-session); relied on typecheck/lint/tests plus direct DB verification instead.

## Out of scope (per instructions)

No migrations written, no RLS touched, no exercise rows seeded or deleted — all schema/data work happened outside this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_019RM93ZBWZwe6jSrVcTJ96q)_