### PR TITLE
Persist board field mode; render exercise diagrams from board_state

### DIFF
--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -6,9 +6,17 @@ import { SportBadge } from "@/components/exercises/SportBadge";
 import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
 import { DeleteExerciseButton } from "@/components/exercises/DeleteExerciseButton";
 import { PositionPills } from "@/components/exercises/PositionPills";
+import { BoardViewLoader } from "@/components/board/BoardViewLoader";
 import { formatDuration } from "@/lib/exercises";
+import type { BoardElement } from "@/lib/board/types";
 import { createClient } from "@/lib/supabase/server";
-import type { Position } from "@/lib/supabase/types";
+import type { Exercise, Position } from "@/lib/supabase/types";
+
+function boardElementsOf(exercise: Exercise): BoardElement[] | null {
+  return Array.isArray(exercise.board_state)
+    ? (exercise.board_state as unknown as BoardElement[])
+    : null;
+}
 
 export const dynamic = "force-dynamic";
 
@@ -97,6 +105,7 @@ export default async function ExerciseDetailPage({
   const authorsById = new Map(
     author ? [[author.id, author]] : [],
   );
+  const boardElements = boardElementsOf(exercise);
 
   return (
     <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
@@ -152,15 +161,25 @@ export default async function ExerciseDetailPage({
         </div>
       </div>
 
-      {exercise.media_url && (
-        <div className="mt-6 overflow-hidden rounded-2xl border border-neutral-200 dark:border-neutral-800">
-          {/* eslint-disable-next-line @next/next/no-img-element -- remote Supabase Storage URL, no next/image domain config in this env */}
-          <img
-            src={exercise.media_url}
-            alt={`Diagram ćwiczenia „${exercise.title}”`}
-            className="w-full"
+      {boardElements ? (
+        <div className="mt-6">
+          <BoardViewLoader
+            sportSlug={sport?.slug}
+            fieldModeId={exercise.board_field_mode}
+            elements={boardElements}
           />
         </div>
+      ) : (
+        exercise.media_url && (
+          <div className="mt-6 overflow-hidden rounded-2xl border border-neutral-200 dark:border-neutral-800">
+            {/* eslint-disable-next-line @next/next/no-img-element -- remote Supabase Storage URL, no next/image domain config in this env */}
+            <img
+              src={exercise.media_url}
+              alt={`Diagram ćwiczenia „${exercise.title}”`}
+              className="w-full"
+            />
+          </div>
+        )
       )}
 
       {exercise.equipment.length > 0 && (

--- a/components/board/BoardView.tsx
+++ b/components/board/BoardView.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Layer, Stage } from "react-konva";
+import { getSportConfig } from "@/lib/board/sports/registry";
+import { isPathElement, isPointElement, type BoardElement } from "@/lib/board/types";
+import { BoardElementNode } from "./BoardElementNode";
+import { PathElementNode } from "./PathElementNode";
+
+const noop = () => {};
+
+interface BoardViewProps {
+  sportSlug?: string | null;
+  /** Exercise's stored board_field_mode - null falls back to the sport's defaultFieldModeId, same as a brand-new board. */
+  fieldModeId?: string | null;
+  elements: BoardElement[];
+}
+
+/**
+ * Read-only rendering of a saved board_state diagram, reusing the exact
+ * same field + element components as the editable TacticsBoard (minus
+ * every interactive handler), so an exercise's diagram renders
+ * pixel-identical on the detail page without loading the full editor.
+ */
+export function BoardView({ sportSlug, fieldModeId, elements }: BoardViewProps) {
+  const config = getSportConfig(sportSlug);
+  const resolvedModeId = fieldModeId ?? config.defaultFieldModeId;
+  const fieldMode =
+    config.fieldModes.find((m) => m.id === resolvedModeId) ??
+    config.fieldModes[0];
+  const dims = { width: fieldMode.width, height: fieldMode.height };
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setContainerSize({ width, height });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const scale = containerSize.width > 0 ? containerSize.width / dims.width : 1;
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-full overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950"
+      style={{ aspectRatio: `${dims.width} / ${dims.height}` }}
+    >
+      {containerSize.width > 0 && (
+        <Stage
+          width={containerSize.width}
+          height={containerSize.height}
+          scaleX={scale}
+          scaleY={scale}
+          listening={false}
+        >
+          <config.FieldComponent
+            modeId={fieldMode.id}
+            width={dims.width}
+            height={dims.height}
+          />
+          <Layer listening={false}>
+            {elements.map((el) =>
+              isPointElement(el) ? (
+                <BoardElementNode
+                  key={el.id}
+                  element={el}
+                  selected={false}
+                  interactive={false}
+                  onSelect={noop}
+                  onDragEnd={noop}
+                  onEditLabel={noop}
+                />
+              ) : isPathElement(el) ? (
+                <PathElementNode
+                  key={el.id}
+                  element={el}
+                  selected={false}
+                  interactive={false}
+                  selectedPointIndex={null}
+                  onSelect={noop}
+                  onSelectPoint={noop}
+                  onTranslateEnd={noop}
+                  onPointDragEnd={noop}
+                  onInsertPoint={noop}
+                />
+              ) : null,
+            )}
+          </Layer>
+        </Stage>
+      )}
+    </div>
+  );
+}

--- a/components/board/BoardViewLoader.tsx
+++ b/components/board/BoardViewLoader.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+// Konva/react-konva touch the canvas APIs at import time, so the read-only
+// view is loaded client-only and dynamically - it must never be part of
+// the server render, same as TacticsBoardLoader.
+import dynamic from "next/dynamic";
+import type { BoardElement } from "@/lib/board/types";
+import { BoardViewSkeleton } from "./BoardViewSkeleton";
+
+const BoardView = dynamic(
+  () => import("./BoardView").then((mod) => mod.BoardView),
+  { ssr: false, loading: () => <BoardViewSkeleton /> },
+);
+
+export function BoardViewLoader({
+  sportSlug,
+  fieldModeId,
+  elements,
+}: {
+  sportSlug?: string | null;
+  fieldModeId?: string | null;
+  elements: BoardElement[];
+}) {
+  return (
+    <BoardView
+      sportSlug={sportSlug}
+      fieldModeId={fieldModeId}
+      elements={elements}
+    />
+  );
+}

--- a/components/board/BoardViewSkeleton.tsx
+++ b/components/board/BoardViewSkeleton.tsx
@@ -1,0 +1,8 @@
+export function BoardViewSkeleton() {
+  return (
+    <div
+      className="w-full animate-pulse rounded-2xl bg-neutral-200 dark:bg-neutral-800"
+      style={{ aspectRatio: "1200 / 520" }}
+    />
+  );
+}

--- a/components/board/TacticsBoard.tsx
+++ b/components/board/TacticsBoard.tsx
@@ -71,6 +71,8 @@ const EXPORT_TARGET_WIDTH = 900;
 export interface TacticsBoardHandle {
   isEmpty(): boolean;
   getElements(): BoardElement[];
+  /** Field-view mode id (FieldViewMode.id) the board is currently showing. */
+  getFieldModeId(): string;
   /** Data URL (PNG) of the current drawing, or null if the board is empty. */
   exportPng(): string | null;
 }
@@ -80,6 +82,8 @@ interface TacticsBoardProps {
   /** Controlled from outside (the exercise's "Dyscyplina" field) - null before a sport is chosen. */
   sportId?: number | null;
   initialElements?: BoardElement[];
+  /** Field mode to open in (e.g. a duplicated exercise's saved board_field_mode) - falls back to the sport's defaultFieldModeId when omitted or unrecognized, same as a brand-new board. */
+  initialFieldModeId?: string | null;
   /** Mutated (not replaced) with the latest imperative handle on every relevant change. */
   handleRef?: MutableRefObject<TacticsBoardHandle | null>;
 }
@@ -88,6 +92,7 @@ export function TacticsBoard({
   sports,
   sportId = null,
   initialElements,
+  initialFieldModeId,
   handleRef,
 }: TacticsBoardProps) {
   const [history, dispatch] = useReducer(
@@ -108,7 +113,12 @@ export function TacticsBoard({
     [activeSport],
   );
 
-  const [fieldModeId, setFieldModeId] = useState(config.defaultFieldModeId);
+  const [fieldModeId, setFieldModeId] = useState(() =>
+    initialFieldModeId &&
+    config.fieldModes.some((m) => m.id === initialFieldModeId)
+      ? initialFieldModeId
+      : config.defaultFieldModeId,
+  );
   const [activeTool, setActiveTool] = useState<ActiveTool>("select");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedPointIndex, setSelectedPointIndex] = useState<number | null>(
@@ -165,6 +175,7 @@ export function TacticsBoard({
     handleRef.current = {
       isEmpty: () => history.present.length === 0,
       getElements: () => history.present,
+      getFieldModeId: () => fieldModeId,
       exportPng: () => {
         const stage = stageRef.current;
         if (!stage || history.present.length === 0) return null;
@@ -175,7 +186,7 @@ export function TacticsBoard({
         return stage.toDataURL({ mimeType: "image/png", pixelRatio });
       },
     };
-  }, [handleRef, history.present, containerSize.width]);
+  }, [handleRef, history.present, containerSize.width, fieldModeId]);
 
   function cancelDrawingPath() {
     setDrawingPath(null);

--- a/components/board/TacticsBoardLoader.tsx
+++ b/components/board/TacticsBoardLoader.tsx
@@ -19,11 +19,13 @@ export function TacticsBoardLoader({
   sports,
   sportId,
   initialElements,
+  initialFieldModeId,
   handleRef,
 }: {
   sports: Sport[];
   sportId?: number | null;
   initialElements?: BoardElement[];
+  initialFieldModeId?: string | null;
   handleRef?: MutableRefObject<TacticsBoardHandle | null>;
 }) {
   return (
@@ -31,6 +33,7 @@ export function TacticsBoardLoader({
       sports={sports}
       sportId={sportId}
       initialElements={initialElements}
+      initialFieldModeId={initialFieldModeId}
       handleRef={handleRef}
     />
   );

--- a/components/exercises/ExerciseForm.tsx
+++ b/components/exercises/ExerciseForm.tsx
@@ -103,6 +103,8 @@ export function ExerciseForm({
 
   const boardHandleRef = useRef<TacticsBoardHandle | null>(null);
   const initialBoardElements = useRef(boardElementsOf(duplicateFrom)).current;
+  const initialFieldModeId = useRef(duplicateFrom?.board_field_mode ?? null)
+    .current;
 
   function validate(): FieldErrors {
     const errors: FieldErrors = {};
@@ -175,6 +177,8 @@ export function ExerciseForm({
     const board = boardHandleRef.current;
     const boardElements =
       board && !board.isEmpty() ? board.getElements() : null;
+    const boardFieldMode =
+      board && boardElements ? board.getFieldModeId() : null;
 
     let mediaUrl: string | null = null;
     if (board && boardElements) {
@@ -212,6 +216,7 @@ export function ExerciseForm({
       equipment,
       media_url: mediaUrl,
       board_state: boardElements as unknown as Json,
+      board_field_mode: boardFieldMode,
       is_public: !keepPrivate,
     };
 
@@ -283,6 +288,7 @@ export function ExerciseForm({
               sports={sports}
               sportId={sportId === "" ? null : sportId}
               initialElements={initialBoardElements}
+              initialFieldModeId={initialFieldModeId}
               handleRef={boardHandleRef}
             />
           </div>

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -101,6 +101,10 @@ export interface Database {
           equipment: string[];
           media_url: string | null;
           board_state: Json | null;
+          // Field-view mode (FieldViewMode.id, e.g. "full"/"redzone") the
+          // board_state diagram was authored in. NULL = fall back to the
+          // sport's defaultFieldModeId.
+          board_field_mode: string | null;
           is_public: boolean;
           scope: ExerciseScope;
           created_at: string;
@@ -119,6 +123,7 @@ export interface Database {
           equipment?: string[];
           media_url?: string | null;
           board_state?: Json | null;
+          board_field_mode?: string | null;
           is_public?: boolean;
           scope?: ExerciseScope;
           created_at?: string;
@@ -137,6 +142,7 @@ export interface Database {
           equipment?: string[];
           media_url?: string | null;
           board_state?: Json | null;
+          board_field_mode?: string | null;
           is_public?: boolean;
           scope?: ExerciseScope;
           created_at?: string;

--- a/supabase/migrations/20260728120000_exercise_board_field_mode.sql
+++ b/supabase/migrations/20260728120000_exercise_board_field_mode.sql
@@ -1,0 +1,21 @@
+-- Coach Zone — exercise board field mode
+-- Run after 20260716110000_add_onboarding_completed.sql (plus the
+-- exercise_scope_positions_and_sport_fix and seed_american_football_exercises
+-- migrations already applied directly to the database, not yet present as
+-- files in this repo's migration history).
+
+-- Persists which field-view mode (lib/board/sports/types.ts,
+-- FieldViewMode.id - e.g. American football's "full" vs "redzone") a saved
+-- board_state diagram was drawn in. Coordinates inside board_state are
+-- absolute logical pixels in that mode's own stage size (redzone is
+-- 384x520 vs full's 1200x520), so reopening a diagram under the wrong mode
+-- renders it squashed into the wrong portion of the field.
+--
+-- Kept as a sibling column rather than folded into board_state's JSON so
+-- existing rows keep working untouched: a null value here falls back to
+-- the sport's defaultFieldModeId exactly as before this column existed.
+alter table public.exercises
+  add column board_field_mode text;
+
+comment on column public.exercises.board_field_mode is
+  'Field-view mode id (FieldViewMode.id, e.g. "full" or "redzone") the board_state diagram was authored in. Null falls back to the sport''s defaultFieldModeId.';


### PR DESCRIPTION
## Summary

**1. Persist the board's field mode.** `board_state` had no board-level metadata, so a diagram reopened in the sport's `defaultFieldModeId` ("full" for American football) even if it was authored in a different mode (e.g. "redzone", 384×520). Since coordinates in `board_state` are absolute logical pixels in the *authoring* mode's space, reopening in the wrong mode rendered the diagram compressed into the wrong portion of the field — making non-default modes effectively unusable for saved exercises.

- Adds a nullable `board_field_mode text` column on `exercises` (migration included, **not applied** — the database is managed outside this repo, per instructions).
- `TacticsBoard` accepts an `initialFieldModeId` prop and initializes its field-mode state from it (falling back to the sport's default when unset or unrecognized — unchanged behavior for existing rows).
- `TacticsBoard`'s imperative handle exposes `getFieldModeId()`; `ExerciseForm` saves it alongside `board_state` in the same insert, and passes a duplicated exercise's stored mode back in as `initialFieldModeId`.

**2. Render exercise diagrams from `board_state`, not just `media_url`.** The detail page only ever rendered `exercise.media_url`, a client-generated PNG snapshot. Official library exercises are authored programmatically with `board_state` populated but `media_url` null, so they showed no diagram at all despite having complete, correct data.

- Adds `BoardView` (+ `BoardViewLoader`/`BoardViewSkeleton`), a read-only, non-interactive render of `board_state` that reuses the same field and element components as the editable board (`BoardElementNode`/`PathElementNode` with `interactive={false}`), honoring the stored `board_field_mode` from part 1.
- The detail page now renders from `board_state` when present, falling back to `media_url` only when `board_state` is null — existing rows with only a PNG keep working unchanged.

**Note on exercise list cards:** cards currently show no diagram thumbnail at all (list view never rendered `media_url` either), so there's nothing to migrate there. Mounting a read-only Konva canvas per card would add real weight to a page listing many exercises at once; happy to add it as a follow-up if wanted, but leaving cards as-is for now rather than deciding unilaterally.

## Migration (review before applying)

```sql
alter table public.exercises
  add column board_field_mode text;

comment on column public.exercises.board_field_mode is
  'Field-view mode id (FieldViewMode.id, e.g. "full" or "redzone") the board_state diagram was authored in. Null falls back to the sport''s defaultFieldModeId.';
```

Full file: `supabase/migrations/20260728120000_exercise_board_field_mode.sql`.

**Schema drift note:** two migrations already applied to the live database (`exercise_scope_positions_and_sport_fix`, `seed_american_football_exercises`) aren't present as files in this repo's `supabase/migrations/`. `lib/supabase/types.ts` was checked against `generate_typescript_types` on the live DB and already reflects the current schema correctly, so no drift fix was needed there — just noting the missing migration files for visibility.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint` on all changed/new files — clean
- [x] `vitest run` — 16/16 passing
- [x] `next build --turbopack` — succeeds, correct client/server boundaries
- [ ] Manual browser verification — not done; requires an authenticated Supabase session I don't have credentials for, and creating a test login account would mean touching the live DB, which is out of scope here
- [ ] Apply the migration, then confirm: saving a diagram in "redzone" mode and reopening it (edit/duplicate) keeps its scale; an official library exercise's diagram now renders on its detail page from `board_state`


---
_Generated by [Claude Code](https://claude.ai/code/session_014SVFPVwZAENnH2PLCa9drG)_