### PR TITLE
Reconstruct drifted migration files from live schema_migrations

### DIFF
--- a/supabase/migrations/20260727210405_exercise_scope_positions_and_sport_fix.sql
+++ b/supabase/migrations/20260727210405_exercise_scope_positions_and_sport_fix.sql
@@ -1,0 +1,109 @@
+-- Coach Zone — exercise scope, positions, and sport_id fix
+-- Run after 20260716110000_add_onboarding_completed.sql.
+-- Reconstructed from supabase_migrations.schema_migrations (version
+-- 20260727210405); applied directly to the database and not previously
+-- captured as a file in this repo's migration history.
+
+alter table exercises alter column sport_id drop not null;
+alter table exercises alter column sport_id drop default;
+
+comment on column exercises.sport_id is
+  'NULL = cwiczenie uniwersalne, widoczne dla kazdej dyscypliny. Brak defaultu celowo - insert musi ustawiac jawnie.';
+
+alter table exercises add column if not exists scope text not null default 'private';
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'exercises_scope_check') then
+    alter table exercises add constraint exercises_scope_check
+      check (scope in ('official', 'private', 'team'));
+  end if;
+end $$;
+
+update exercises set scope = 'official'
+where author_id is null and scope <> 'official';
+
+do $$
+declare
+  v_football int;
+begin
+  select id into v_football from sports where slug = 'football';
+  if v_football is null then
+    raise exception 'Nie znaleziono sportu o slugu "football".';
+  end if;
+
+  update exercises set sport_id = v_football
+  where author_id is null and title in (
+    'Rondo 4v1',
+    'Podania w parach na dwa kontakty',
+    'Prowadzenie piłki w slalomie',
+    'Uderzenia na bramkę po podaniu',
+    'Gra pozycyjna 6v6+3',
+    'Wyprowadzenie piłki spod pressingu 4v2',
+    'Gra 4v4 na cztery bramki',
+    'Gra 7v7 z warunkiem dwóch kontaktów',
+    'Przejście z obrony do ataku (tranzycja)'
+  );
+end $$;
+
+update exercises set sport_id = null
+where author_id is null and title in (
+  'Rozgrzewka dynamiczna w truchcie',
+  'Trucht wytłumiający i rozciąganie statyczne',
+  'Rolowanie i mobilizacja',
+  'Aktywacja z drabinką koordynacyjną',
+  'Interwały biegowe wysokiej intensywności',
+  'Obwód siłowy z masą własnego ciała'
+);
+
+create table if not exists positions (
+  id         uuid primary key default gen_random_uuid(),
+  sport_id   integer not null references sports(id) on delete cascade,
+  code       text not null,
+  label      text not null,
+  sort_order integer not null default 0,
+  unique (sport_id, code)
+);
+
+create table if not exists exercise_positions (
+  exercise_id uuid not null references exercises(id) on delete cascade,
+  position_id uuid not null references positions(id) on delete cascade,
+  primary key (exercise_id, position_id)
+);
+
+create index if not exists exercise_positions_position_idx
+  on exercise_positions (position_id);
+
+do $$
+declare
+  v_af int;
+begin
+  select id into v_af from sports where slug = 'american_football';
+  if v_af is null then
+    raise exception 'Nie znaleziono sportu o slugu "american_football".';
+  end if;
+
+  insert into positions (sport_id, code, label, sort_order) values
+    (v_af, 'OL',   'Linia ofensywna (OL)',   10),
+    (v_af, 'QB',   'Rozgrywający (QB)',      20),
+    (v_af, 'RB',   'Biegacz (RB)',           30),
+    (v_af, 'WR',   'Skrzydłowy (WR)',        40),
+    (v_af, 'TE',   'Tight end (TE)',         50),
+    (v_af, 'DL',   'Linia defensywna (DL)',  60),
+    (v_af, 'DE',   'Defensive end (DE)',     70),
+    (v_af, 'LB',   'Linebacker (LB)',        80),
+    (v_af, 'DB',   'Defensive back (DB)',    90),
+    (v_af, 'TEAM', 'Cała drużyna',          100)
+  on conflict (sport_id, code) do nothing;
+end $$;
+
+alter table positions enable row level security;
+alter table exercise_positions enable row level security;
+
+drop policy if exists positions_select on positions;
+create policy positions_select on positions
+  for select to authenticated using (true);
+
+drop policy if exists exercise_positions_select on exercise_positions;
+create policy exercise_positions_select on exercise_positions
+  for select to authenticated using (true);

--- a/supabase/migrations/20260727210828_seed_american_football_exercises.sql
+++ b/supabase/migrations/20260727210828_seed_american_football_exercises.sql
@@ -1,0 +1,69 @@
+-- Coach Zone — seed American football exercises
+-- Run after 20260727210405_exercise_scope_positions_and_sport_fix.sql.
+-- Reconstructed from supabase_migrations.schema_migrations (version
+-- 20260727210828); applied directly to the database and not previously
+-- captured as a file in this repo's migration history.
+
+with af as (select id from sports where slug = 'american_football'),
+data(title, description, steps, category_id, difficulty, duration_min, equipment, pos) as (values
+('Pass protection', 'Podstawowe ćwiczenie pass pro w parach. OL uczy się cierpliwości — czeka na dobry moment, zamiast rzucać się do przodu.', array['OL startuje w pozycji, partner jako "DL" nabiega na niego','"DL" ścina na wewnętrzne lub zewnętrzne ramię','OL wyczekuje momentu, atakuje rękoma i łapie za pady','Obniża biodra i zatrzymuje "DL" w miejscu','Cały czas pracuje na nogach'], 2, 2, 10, array[]::text[], array['OL']),
+('Hands replace', 'Szybkość powrotu rąk na pady. Praca nad tym, żeby zbity blok nie oznaczał końca akcji.', array['W parach, OL stoi nisko na nogach','OL kładzie ręce na klatce partnera','Partner zbija mu ręce — pojedynczo lub obie naraz','OL jak najszybciej wraca dłonią na pady'], 2, 2, 8, array[]::text[], array['OL']),
+('Push/pull', 'Utrzymanie zrównoważonej pozycji przy zmiennym nacisku. Uczy nie przenosić ciężaru za bardzo do przodu.', array['OL zaczyna w kontakcie z partnerem trzymającym tarczę, w pozycji do pass pro','Partner na zmianę pcha i ciągnie tarczę','OL utrzymuje blok i prawidłową, zrównoważoną pozycję'], 2, 2, 8, array['tarcza'], array['OL']),
+('Inside zone block', 'Standardowy blok inside zone w parach. Nacisk na mocne uderzenie i pracę nóg w kontakcie.', array['W parach, partner wchodzi w dziurę po playside','OL wykonuje blok do inside','Skupienie na mocnym uderzeniu i pracy nóg w kontakcie','Wywieźć przeciwnika, a nie stać z nim w miejscu'], 2, 2, 10, array[]::text[], array['OL']),
+('Reach block', 'Standardowy reach block przy biegach outside, w parach.', array['W parach, OL startuje w pozycji','Partner stara się utrzymać contain po playside','OL wykonuje reach block'], 2, 2, 10, array[]::text[], array['OL']),
+('Kwadrat', 'Praca nóg OL po obwodzie kwadratu — powolna, kontrolowana, nisko na nogach.', array['Ustawiamy kwadrat 5y x 5y','OL startuje z pozycji, powoli i nisko na nogach','Do przodu -> sidestep -> backpedal -> sidestep'], 1, 1, 8, array['pachołki'], array['OL']),
+('Inside run gauntlet', 'Blok na dwa poziomy — wypchnięcie DL, puszczenie i wyjście do LB.', array['OL zaczyna w pozycji','Jeden partner na jego ramieniu jako "DL", drugi z tyłu jako "LB"','Na sygnał OL rusza i wypycha "DL" 3-4y','Puszcza go, wybiega do "LB" i również wypycha go 3-4y'], 2, 3, 10, array[]::text[], array['OL']),
+('Hips roll', 'Praca bioder w kontakcie — wyciągnięcie przeciwnika w górę zamiast pchania na wprost.', array['W parach, DL łapie partnera "OL" za pady','Staje nisko, wychylony do przodu','Na sygnał pcha partnera','Równocześnie wyciąga go w górę, przybliżając do niego biodra'], 2, 2, 8, array[]::text[], array['DL','DE']),
+('Hands fight', 'Walka rąk zakończona przejściem za plecy blokującego.', array['W parach, partner "OL" stara się położyć ręce na klatce DL','DL zbija je, "OL" szybko wraca rękoma na klatkę','Po ok. 5s zbijania rąk DL uzupełnia ruch o przejście za plecy "OL"'], 2, 3, 8, array[]::text[], array['DL','DE']),
+('Forklift', 'Wypchnięcie rąk blokującego w górę i wejście za jego plecy.', array['W parach, partner "OL" kładzie wyciągnięte ręce na klatce DL','Na sygnał zaczyna go lekko pchać','DL łapie obiema rękoma przedramiona "OL" i wypycha jego ręce w górę','Następnie wchodzi za jego plecy'], 2, 3, 8, array[]::text[], array['DL','DE']),
+('Bull rush', 'Rush siłowy — przepchnięcie blokującego i zrzucenie bloku w gap.', array['DL startuje z pozycji naprzeciw partnera "OL"','Na ruch "OL" (kick step) rusza','Wchodzi z nim w kontakt obiema rękoma','Przepycha go 3y do tyłu i zrzuca blok, wskakując w gap biodrami','Kończy sprintem 5y za partnera'], 2, 3, 10, array[]::text[], array['DL','DE']),
+('Start + rip', 'Zbicie rąk blokującego i technika rip.', array['DL startuje z pozycji naprzeciw partnera "OL"','Na ruch "OL" (wyjście w stronę DL i wyciągnięcie rąk) rusza','Zbija ręce "OL" na bok swoją zewnętrzną ręką','Wewnętrzną wykonuje "rip" — ugiętą ręką schodzi nisko, po czym wyrzuca ją do góry'], 2, 3, 10, array[]::text[], array['DL','DE']),
+('Shield blunt & rip', 'Uderzenie w tarczę zewnętrzną ręką plus rip wewnętrzną.', array['DL startuje z pozycji na ramieniu partnera "OL" trzymającego tarczę','Na ruch partnera DL startuje','Zewnętrzną ręką mocno uderza tarczę','Wewnętrzną robi technikę "rip" — nisko i do góry, zrywając blok','Wbiega sprintem za "OL"'], 2, 3, 10, array['tarcza'], array['DL','DE']),
+('Start + axe', 'Zbicie tarczy od góry i wbiegnięcie za plecy blokującego.', array['DL startuje w pozycji','Na miejscu OL staje partner trzymający tarczę za koniec','DL rusza na ruch partnera','Bliższą ręką od góry zbija tarczę','Wbiega za plecy partnera, podnosząc w biegu znacznik z ziemi'], 2, 3, 10, array['tarcza','pachołki'], array['DL','DE']),
+('Stab + slam/over', 'Read reakcji OL — slam gdy kontruje, over gdy się otwiera.', array['DL zaczyna w 2 point stance, na wewnętrznym partnera','Kładzie bliższą rękę na bliższej stronie klatki partnera','Na sygnał zaczyna pchać, zachowując biodra równolegle do LOS','SLAM — jeśli OL mocno kontruje: ciągniemy go do siebie i uderzamy dalszą ręką w tył barku','OVER — jeśli OL otwiera się w stronę pchania: puszczamy rękę, dalszą zbijamy jego ręce od góry ("axe") i robimy krok w poprzek OL'], 2, 4, 10, array[]::text[], array['DL','DE']),
+('Ball drills', 'Zestaw ćwiczeń czucia piłki dla WR — do rozgrzewki lub jako uzupełnienie.', array['Podrzucanie i łapanie piłki jedną ręką trzymając ją od góry','Naprzemienne łapanie piłki za koniec','Przekładanie piłki dookoła ciała','Przekładanie piłki dookoła nogi','Przekładanie piłki pomiędzy nogami','Upuszczanie piłki z wierzchu dłoni i łapanie za koniec'], 1, 1, 8, array['piłka'], array['WR']),
+('Routes on air', 'Standardowe ścieżki "na sucho", bez DB. Praca nad czystością techniki.', array['WR ustawia się w pozycji','Biega standardowe ścieżki bez krycia','Skupienie na starcie, sprzedaniu ścieżki i dynamicznym ścięciu'], 2, 1, 10, array['piłka'], array['WR']),
+('Hitch / comeback', 'Dwie ścieżki na krótkim dystansie — nacisk na sprzedanie dalekiej ścieżki.', array['Biegamy standardowy hitch (5y) i comeback (7y)','Mocny start','Sprzedanie dalekiej ścieżki','Dynamiczne ścięcie'], 2, 2, 10, array['piłka'], array['WR']),
+('Tennis ball shuffle', 'Praca nóg plus łapanie małego obiektu — koordynacja i skupienie wzroku.', array['WR staje pomiędzy dwoma znacznikami','Partner lub coach staje naprzeciwko i rzuca piłki tenisowe raz w jedną, raz w drugą stronę','WR porusza się pomiędzy znacznikami, łapie piłki i odrzuca je'], 2, 2, 8, array['piłki tenisowe','pachołki'], array['WR']),
+('Routes + shield hit', 'Krótkie ścieżki zakończone kontaktem — łapanie pod presją uderzenia.', array['Biegamy krótkie ścieżki: slant, hitch, 5 out, 5 in','Po złapaniu piłki WR uderzany jest tarczą','Nacisk na utrzymanie piłki po kontakcie'], 2, 3, 10, array['piłka','tarcza'], array['WR']),
+('1 on 1 covered catch', 'WR i DB pracują razem: WR łapie pod kryciem, DB uczy się zbijać bez obracania się do piłki. W planach treningowych występuje też pod nazwą "fade adjustment".', array['WR ustawia się w pozycji, zaraz za nim staje DB','5-10y za nimi staje QB','Na sygnał WR i DB ruszają przed siebie','QB rzuca piłkę — może lekko na lewo lub prawo, żeby WR musiał się dostosować','DB obserwuje WR i stara się włożyć rękę między jego dłonie','DB nie może obracać się do piłki — czyta jej lot z ruchu WR'], 2, 4, 10, array['piłka'], array['WR','DB']),
+('Handoffs', 'Podstawa wymiany piłki QB-RB, z zaznaczonym punktem celowania.', array['RB pracuje z QB','Handoff do inside i outside','QB co jakiś czas wyciąga piłkę (mesh read)','Ustawić ze znaczników miejsce, w które celuje RB — wewnętrzne biodro guarda lub na zewnątrz TE'], 2, 2, 10, array['piłka','pachołki'], array['RB','QB']),
+('Pass protection (RB)', 'RB wychodzi do bloku na nadbiegającego DL.', array['RB ustawia się koło QB rzucającego ścieżki receiverom','Partner "DL" ustawia się naprzeciwko','Na sygnał QB, RB wychodzi przed niego do pass pro','Blokuje nadbiegającego DL'], 2, 3, 10, array[]::text[], array['RB']),
+('Press cover', 'Krycie w pressie — od uderzenia obiema rękoma do off hand jam.', array['DB ustawia się w pressie naprzeciwko partnera robiącego za WR','WR robi pojedynczy lub podwójny release','DB kryje press — pierwsze uderzenie obiema rękoma','Następnie przechodzi do uderzeń jedną ręką (off hand jam — uderzamy zewnętrzną ręką)','Gdy WR mija DB, ten otwiera biodra i biegnie z nim, trzymając na nim rękę'], 2, 4, 10, array[]::text[], array['DB']),
+('Fly man cover', 'Krycie man z off — read step i otwarcie bioder.', array['DB ustawia się w off man','"WR" startuje biegnąc fade lub seam — release w prawo lub w lewo, potem prosto po wybranej stronie DB','DB rusza backpedalem, robiąc read step w stronę release','Gdy "WR" zaczyna go mijać, otwiera biodra w jego stronę i biegnie z nim'], 2, 3, 10, array[]::text[], array['DB']),
+('Ball strip', 'Dwóch obrońców: pierwszy zatrzymuje, drugi wyszarpuje piłkę.', array['Ustawiamy dwa rzędy, naprzeciwko nich staje "RB" z piłką','Na sygnał "RB" rusza truchtem w stronę jednego z rzędów','Defensorzy biegną do niego','Pierwszy schodzi nisko do tackla i obejmuje "RB" — bez tackla do ziemi','Drugi dobiega i wyszarpuje piłkę'], 2, 3, 10, array['piłka'], array['DL','LB','DB']),
+('Goalline tackle', 'Tackle na krótkim dystansie z wyborem strony. Nacisk na niski kontakt.', array['Zawodnik O# ustawia się nad leżącą piłką','Zawodnik D# staje 2y od niego, pomiędzy dwoma znacznikami','Na sygnał O# podnosi piłkę i kieruje się na jeden ze znaczników','D# tackluje go','Pracować nad niskim tacklem — celujemy w biodro, a nie w barki'], 2, 4, 10, array['piłka','pachołki'], array['TEAM']),
+('Wyścigi', 'Rozgrzewkowa rywalizacja z transportem piłki — cztery warianty podania.', array['Dzielimy się na 2 rzędy, każdy rozstawia się wzdłuż boiska co 10y','Cel: przetransportować piłkę w jedną i w drugą stronę','Gdy piłka wróci do pierwszego zawodnika, cały rząd musi dobiec do niego i go dotknąć','Warianty transportu: zwykły rzut / rzut słabszą ręką / toss bokiem / long snap','Przegrana drużyna robi 10 pompek'], 1, 1, 15, array['piłka'], array['TEAM']),
+('Scrimmage', 'Gra kontrolna offense vs defense na koniec treningu.', array['Ustawiamy pełne jednostki offense i defense','Gramy akcje w warunkach zbliżonych do meczowych','Coach ustala zakres — biegi, podania lub pełny playbook'], 4, 3, 30, array['piłka'], array['TEAM']),
+('Run drill', 'Scrimmage ograniczony do biegów, bez tacklowania.', array['Scrimmage offense vs defense — gramy tylko biegi','Jeśli brakuje zawodników, ustawiać bez WR i DB','Bez tacklowania'], 4, 2, 10, array['piłka'], array['TEAM']),
+('Defensive walkthrough', 'Wolne powtórzenie odczytów defensywy przeciwko formacji z dwoma TE.', array['Offense ustawia formację z dwoma TE (jeśli brakuje zawodników — bez WR)','Gramy biegi z pullem guarda lub rzut (TE wybiegają ścieżki)','Defense ustawia linię (DT i DE) oraz Mike i Backera','M i B czytają TE i ewentualny pull guarda','Reagują na otwierający się B-gap'], 3, 3, 10, array['piłka'], array['TEAM'])
+)
+insert into exercises (author_id, sport_id, category_id, title, description, steps, difficulty, duration_min, equipment, is_public, scope)
+select null, af.id, d.category_id, d.title, d.description, d.steps, d.difficulty, d.duration_min, d.equipment, true, 'official'
+from data d cross join af
+where not exists (select 1 from exercises e where e.title = d.title and e.author_id is null);
+
+with af as (select id from sports where slug = 'american_football'),
+data(title, pos) as (values
+('Pass protection', array['OL']), ('Hands replace', array['OL']), ('Push/pull', array['OL']),
+('Inside zone block', array['OL']), ('Reach block', array['OL']), ('Kwadrat', array['OL']),
+('Inside run gauntlet', array['OL']),
+('Hips roll', array['DL','DE']), ('Hands fight', array['DL','DE']), ('Forklift', array['DL','DE']),
+('Bull rush', array['DL','DE']), ('Start + rip', array['DL','DE']), ('Shield blunt & rip', array['DL','DE']),
+('Start + axe', array['DL','DE']), ('Stab + slam/over', array['DL','DE']),
+('Ball drills', array['WR']), ('Routes on air', array['WR']), ('Hitch / comeback', array['WR']),
+('Tennis ball shuffle', array['WR']), ('Routes + shield hit', array['WR']),
+('1 on 1 covered catch', array['WR','DB']),
+('Handoffs', array['RB','QB']), ('Pass protection (RB)', array['RB']),
+('Press cover', array['DB']), ('Fly man cover', array['DB']),
+('Ball strip', array['DL','LB','DB']),
+('Goalline tackle', array['TEAM']), ('Wyścigi', array['TEAM']), ('Scrimmage', array['TEAM']),
+('Run drill', array['TEAM']), ('Defensive walkthrough', array['TEAM'])
+)
+insert into exercise_positions (exercise_id, position_id)
+select e.id, p.id
+from data d
+join exercises e on e.title = d.title and e.author_id is null
+cross join af
+join positions p on p.sport_id = af.id and p.code = any(d.pos)
+on conflict do nothing;

--- a/supabase/migrations/20260728003426_exercise_board_field_mode.sql
+++ b/supabase/migrations/20260728003426_exercise_board_field_mode.sql
@@ -1,8 +1,8 @@
 -- Coach Zone — exercise board field mode
--- Run after 20260716110000_add_onboarding_completed.sql (plus the
--- exercise_scope_positions_and_sport_fix and seed_american_football_exercises
--- migrations already applied directly to the database, not yet present as
--- files in this repo's migration history).
+-- Run after 20260727210828_seed_american_football_exercises.sql.
+-- Reconstructed from supabase_migrations.schema_migrations (version
+-- 20260728003426); applied directly to the database and not previously
+-- captured accurately as a file in this repo's migration history.
 
 -- Persists which field-view mode (lib/board/sports/types.ts,
 -- FieldViewMode.id - e.g. American football's "full" vs "redzone") a saved
@@ -15,7 +15,7 @@
 -- existing rows keep working untouched: a null value here falls back to
 -- the sport's defaultFieldModeId exactly as before this column existed.
 alter table public.exercises
-  add column board_field_mode text;
+  add column if not exists board_field_mode text;
 
 comment on column public.exercises.board_field_mode is
   'Field-view mode id (FieldViewMode.id, e.g. "full" or "redzone") the board_state diagram was authored in. Null falls back to the sport''s defaultFieldModeId.';


### PR DESCRIPTION
## Summary

- Three migrations existed in the live database's history (`supabase_migrations.schema_migrations`) but not as files in `supabase/migrations/`: `exercise_scope_positions_and_sport_fix` and `seed_american_football_exercises` were applied directly and never captured as files at all.
- `exercise_board_field_mode` *was* captured as a file, but under the wrong timestamp (`20260728120000` instead of its recorded version `20260728003426`) and with SQL that had drifted from what was actually applied (missing `if not exists` on the added column).
- Read the exact applied SQL straight from `supabase_migrations.schema_migrations` on the live project (`bagcvvcklzibunmspnix`) via the Supabase MCP tools, and wrote it out verbatim into three correctly named and ordered files:
  - `supabase/migrations/20260727210405_exercise_scope_positions_and_sport_fix.sql`
  - `supabase/migrations/20260727210828_seed_american_football_exercises.sql`
  - `supabase/migrations/20260728003426_exercise_board_field_mode.sql` (renamed + content fixed)
- Used direct table reads rather than `supabase db pull` — the CLI wasn't available in this environment. No SQL was re-applied and the database was not modified in any way; this is a file-only reconstruction to make the repo the source of truth again.

## Test plan

- [x] Confirmed no other files in the repo reference the old `20260728120000` filename
- [x] Verified `git status` is clean and the rename was tracked correctly
- [ ] Reviewer: confirm the reconstructed SQL files match expectations before merging (no migration was re-run against the database)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYVkkquSVy2YFiDyfoWb7r)_