### PR TITLE
Add team support schema (teams, team_members, team_invites)

### DIFF
--- a/app/app/team/page.tsx
+++ b/app/app/team/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { TeamManager } from "@/components/team/TeamManager";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Moja drużyna — Coach Zone",
+};
+
+export default async function TeamPage() {
+  const supabase = await createClient();
+  const { data: userData } = await supabase.auth.getUser();
+
+  // Middleware already guarantees a user for any /app/* route; this is a
+  // defensive fallback, matching the other /app pages.
+  if (!userData.user) {
+    redirect("/login");
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 pt-8 pb-20">
+      <h1 className="text-3xl font-bold tracking-tight">Moja drużyna</h1>
+      <p className="mt-2 text-neutral-600 dark:text-neutral-400">
+        Zarządzaj sztabem szkoleniowym i zapraszaj asystentów do wspólnej
+        biblioteki ćwiczeń oraz planów treningowych.
+      </p>
+      <div className="mt-8">
+        <TeamManager userId={userData.user.id} />
+      </div>
+    </main>
+  );
+}

--- a/app/join/[token]/page.tsx
+++ b/app/join/[token]/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { AuthShell } from "@/components/auth/AuthShell";
+import { JoinConfirmButton } from "@/components/team/JoinConfirmButton";
+import { createClient } from "@/lib/supabase/server";
+
+// Public route (outside /app) - deliberately not behind the auth redirect in
+// middleware.ts (isProtectedPath only matches /app and /app/*), so a
+// signed-out visitor lands here and gets prompted to log in/register first,
+// rather than being bounced to a bare /login with no memory of the invite.
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Dołącz do drużyny — Coach Zone",
+};
+
+export default async function JoinPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const returnTo = `/join/${token}`;
+
+  const supabase = await createClient();
+  const { data: userData } = await supabase.auth.getUser();
+
+  if (!userData.user) {
+    return (
+      <AuthShell
+        title="Zaproszenie do drużyny"
+        subtitle="Dołączanie wymaga konta, aby head coach wiedział dokładnie, kto dołączył. Zaloguj się lub załóż konto, aby zobaczyć szczegóły tego zaproszenia."
+      >
+        <div className="flex flex-col gap-3">
+          <Link
+            href={`/login?next=${encodeURIComponent(returnTo)}`}
+            className="w-full rounded-full bg-emerald-600 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Zaloguj się
+          </Link>
+          <Link
+            href={`/signup?next=${encodeURIComponent(returnTo)}`}
+            className="w-full rounded-full border border-neutral-300 px-4 py-2.5 text-center text-sm font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Zarejestruj się
+          </Link>
+        </div>
+      </AuthShell>
+    );
+  }
+
+  // Granted to `authenticated` only (not anon) - deliberate, so even seeing
+  // which team a token belongs to requires an identified account, same
+  // reasoning the RPC comment gives for joining itself.
+  const { data: preview, error } = await supabase.rpc("get_invite_preview", {
+    p_token: token,
+  });
+
+  if (error || !preview) {
+    return (
+      <AuthShell
+        title="Nie znaleziono zaproszenia"
+        subtitle="Ten link jest nieprawidłowy albo zaproszenie zostało usunięte."
+      >
+        <Link
+          href="/app"
+          className="block text-center text-sm font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Przejdź do aplikacji
+        </Link>
+      </AuthShell>
+    );
+  }
+
+  return (
+    <AuthShell
+      title="Zaproszenie do drużyny"
+      subtitle={
+        preview.valid
+          ? `Zostałeś zaproszony do drużyny „${preview.team_name}” (${preview.short_name}).`
+          : `Zaproszenie do drużyny „${preview.team_name}” (${preview.short_name}) jest już nieaktywne.`
+      }
+    >
+      {preview.valid ? (
+        <JoinConfirmButton token={token} />
+      ) : (
+        <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+          To zaproszenie wygasło lub zostało odwołane. Poproś head coacha o
+          nowy link.
+        </p>
+      )}
+    </AuthShell>
+  );
+}

--- a/app/join/[token]/page.tsx
+++ b/app/join/[token]/page.tsx
@@ -6,8 +6,8 @@ import { createClient } from "@/lib/supabase/server";
 
 // Public route (outside /app) - deliberately not behind the auth redirect in
 // middleware.ts (isProtectedPath only matches /app and /app/*), so a
-// signed-out visitor lands here and gets prompted to log in/register first,
-// rather than being bounced to a bare /login with no memory of the invite.
+// signed-out visitor lands here and sees which team this is for before
+// being asked to do anything.
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
@@ -23,13 +23,57 @@ export default async function JoinPage({
   const returnTo = `/join/${token}`;
 
   const supabase = await createClient();
-  const { data: userData } = await supabase.auth.getUser();
+  // get_invite_preview is granted to anon too, not just authenticated (see
+  // supabase/migrations/20260728141752_grant_invite_preview_to_anon.sql):
+  // an invited person should see which team they're being invited to
+  // *before* deciding whether to create an account - "join Husaria
+  // Szczecin's staff" is a much stronger prompt than "log in to find out
+  // what this is". Security is unchanged: the token carries ~72 bits of
+  // entropy and this returns only team_name, short_name, and a validity
+  // flag - same model as get_shared_workout(), which anon can already call.
+  const [{ data: userData }, { data: preview, error }] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.rpc("get_invite_preview", { p_token: token }),
+  ]);
+
+  if (error || !preview) {
+    return (
+      <AuthShell
+        title="Nie znaleziono zaproszenia"
+        subtitle="Ten link jest nieprawidłowy albo zaproszenie zostało usunięte."
+      >
+        <Link
+          href="/"
+          className="block text-center text-sm font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Strona główna
+        </Link>
+      </AuthShell>
+    );
+  }
+
+  const teamTitle = `${preview.team_name} (${preview.short_name})`;
+
+  // Dead regardless of who's looking at it - say so plainly rather than
+  // sending anyone off to log in or register for nothing.
+  if (!preview.valid) {
+    return (
+      <AuthShell
+        title={teamTitle}
+        subtitle="To zaproszenie do sztabu szkoleniowego wygasło lub zostało odwołane."
+      >
+        <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+          Poproś head coacha o nowy link zaproszenia.
+        </p>
+      </AuthShell>
+    );
+  }
 
   if (!userData.user) {
     return (
       <AuthShell
-        title="Zaproszenie do drużyny"
-        subtitle="Dołączanie wymaga konta, aby head coach wiedział dokładnie, kto dołączył. Zaloguj się lub załóż konto, aby zobaczyć szczegóły tego zaproszenia."
+        title={teamTitle}
+        subtitle="Zaprasza Cię do sztabu szkoleniowego. Aby dołączyć, zaloguj się lub załóż konto — dzięki temu head coach widzi dokładnie, kto dołączył."
       >
         <div className="flex flex-col gap-3">
           <Link
@@ -49,46 +93,12 @@ export default async function JoinPage({
     );
   }
 
-  // Granted to `authenticated` only (not anon) - deliberate, so even seeing
-  // which team a token belongs to requires an identified account, same
-  // reasoning the RPC comment gives for joining itself.
-  const { data: preview, error } = await supabase.rpc("get_invite_preview", {
-    p_token: token,
-  });
-
-  if (error || !preview) {
-    return (
-      <AuthShell
-        title="Nie znaleziono zaproszenia"
-        subtitle="Ten link jest nieprawidłowy albo zaproszenie zostało usunięte."
-      >
-        <Link
-          href="/app"
-          className="block text-center text-sm font-medium text-emerald-600 hover:text-emerald-500"
-        >
-          Przejdź do aplikacji
-        </Link>
-      </AuthShell>
-    );
-  }
-
   return (
     <AuthShell
-      title="Zaproszenie do drużyny"
-      subtitle={
-        preview.valid
-          ? `Zostałeś zaproszony do drużyny „${preview.team_name}” (${preview.short_name}).`
-          : `Zaproszenie do drużyny „${preview.team_name}” (${preview.short_name}) jest już nieaktywne.`
-      }
+      title={teamTitle}
+      subtitle="Zaprasza Cię do sztabu szkoleniowego."
     >
-      {preview.valid ? (
-        <JoinConfirmButton token={token} />
-      ) : (
-        <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
-          To zaproszenie wygasło lub zostało odwołane. Poproś head coacha o
-          nowy link.
-        </p>
-      )}
+      <JoinConfirmButton token={token} />
     </AuthShell>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,9 +17,9 @@ const QUERY_ERROR_MESSAGES: Record<string, string> = {
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string; next?: string }>;
 }) {
-  const { error } = await searchParams;
+  const { error, next } = await searchParams;
   const initialError = error ? QUERY_ERROR_MESSAGES[error] : undefined;
 
   return (
@@ -27,7 +27,7 @@ export default async function LoginPage({
       title="Witaj ponownie"
       subtitle="Zaloguj się, aby zaplanować kolejny trening."
     >
-      <LoginForm initialError={initialError} />
+      <LoginForm initialError={initialError} next={next} />
     </AuthShell>
   );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -8,13 +8,19 @@ export const metadata: Metadata = {
   title: "Zarejestruj się — Coach Zone",
 };
 
-export default function SignupPage() {
+export default async function SignupPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+
   return (
     <AuthShell
       title="Utwórz konto"
       subtitle="Zbuduj bibliotekę ćwiczeń i zacznij planować treningi."
     >
-      <SignupForm />
+      <SignupForm next={next} />
     </AuthShell>
   );
 }

--- a/components/auth/GoogleAuthButton.tsx
+++ b/components/auth/GoogleAuthButton.tsx
@@ -32,12 +32,14 @@ function GoogleIcon() {
   );
 }
 
-export function GoogleAuthButton() {
+export function GoogleAuthButton({ redirectTo }: { redirectTo?: string } = {}) {
   async function handleClick() {
     const supabase = createClient();
+    const callbackUrl = new URL("/auth/callback", window.location.origin);
+    if (redirectTo) callbackUrl.searchParams.set("next", redirectTo);
     await supabase.auth.signInWithOAuth({
       provider: "google",
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
+      options: { redirectTo: callbackUrl.toString() },
     });
   }
 

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -17,7 +17,14 @@ interface FieldErrors {
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export function LoginForm({ initialError }: { initialError?: string | null }) {
+export function LoginForm({
+  initialError,
+  next,
+}: {
+  initialError?: string | null;
+  /** Where to send the visitor after a successful login, e.g. back to a /join/[token] page. Defaults to /app. */
+  next?: string;
+}) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -59,7 +66,7 @@ export function LoginForm({ initialError }: { initialError?: string | null }) {
       return;
     }
 
-    router.push("/app");
+    router.push(next || "/app");
     router.refresh();
   }
 
@@ -67,7 +74,7 @@ export function LoginForm({ initialError }: { initialError?: string | null }) {
     <form onSubmit={handleSubmit} noValidate className="space-y-4">
       <FormBanner variant="error" message={formError} />
 
-      <GoogleAuthButton />
+      <GoogleAuthButton redirectTo={next} />
 
       <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-500">
         <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -23,7 +23,12 @@ interface FieldErrors {
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export function SignupForm() {
+export function SignupForm({
+  next,
+}: {
+  /** Where to send the visitor after signup, e.g. back to a /join/[token] page. Defaults to /app. Only reachable when signup grants a session immediately - see the confirmation-sent branch below for the email-confirmation case. */
+  next?: string;
+} = {}) {
   const router = useRouter();
   const [pseudonym, setPseudonym] = useState("");
   const [email, setEmail] = useState("");
@@ -108,7 +113,7 @@ export function SignupForm() {
     }
 
     if (data.session) {
-      router.push("/app");
+      router.push(next || "/app");
       router.refresh();
       return;
     }
@@ -123,12 +128,25 @@ export function SignupForm() {
           variant="success"
           message={`Wysłaliśmy link potwierdzający na adres ${confirmationSentTo}. Otwórz go, aby aktywować konto.`}
         />
-        <Link
-          href="/login"
-          className="inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
-        >
-          Powrót do logowania
-        </Link>
+        {next ? (
+          <p className="text-sm text-neutral-600 dark:text-neutral-400">
+            Po potwierdzeniu adresu e-mail zaloguj się, a następnie{" "}
+            <Link
+              href={next}
+              className="font-medium text-emerald-600 hover:text-emerald-500"
+            >
+              wróć pod ten link
+            </Link>
+            , aby dokończyć dołączanie do drużyny.
+          </p>
+        ) : (
+          <Link
+            href="/login"
+            className="inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
+          >
+            Powrót do logowania
+          </Link>
+        )}
       </div>
     );
   }
@@ -137,7 +155,7 @@ export function SignupForm() {
     <form onSubmit={handleSubmit} noValidate className="space-y-4">
       <FormBanner variant="error" message={formError} />
 
-      <GoogleAuthButton />
+      <GoogleAuthButton redirectTo={next} />
 
       <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-500">
         <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-800" />

--- a/components/team/CreateTeamForm.tsx
+++ b/components/team/CreateTeamForm.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { FormBanner } from "@/components/auth/FormBanner";
+import { FormField } from "@/components/auth/FormField";
+import { SubmitButton } from "@/components/auth/SubmitButton";
+import { createClient } from "@/lib/supabase/client";
+
+interface FieldErrors {
+  name?: string;
+  shortName?: string;
+}
+
+// Mirrors the DB check (char_length(short_name) between 2 and 6) - the DB
+// is the source of truth, this is only a fast client-side check.
+const SHORT_NAME_PATTERN = /^.{2,6}$/;
+
+export function CreateTeamForm({
+  userId,
+  onCreated,
+}: {
+  userId: string;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [shortName, setShortName] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  function validate(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (!name.trim()) errors.name = "Podaj pełną nazwę drużyny.";
+    if (!SHORT_NAME_PATTERN.test(shortName.trim())) {
+      errors.shortName = "Skrót musi mieć 2–6 znaków.";
+    }
+    return errors;
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    setSaving(true);
+    const supabase = createClient();
+    // Only teams gets an insert - a trigger (add_team_creator_as_head_coach)
+    // makes the caller the team's head coach automatically.
+    const { error } = await supabase.from("teams").insert({
+      name: name.trim(),
+      short_name: shortName.trim(),
+      created_by: userId,
+    });
+
+    setSaving(false);
+    if (error) {
+      setFormError("Nie udało się utworzyć drużyny. Spróbuj ponownie.");
+      return;
+    }
+    onCreated();
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold tracking-tight">Załóż drużynę</h2>
+      <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+        Zostaniesz automatycznie head coachem. Będziesz mógł zapraszać
+        asystentów i dzielić się z nimi biblioteką ćwiczeń oraz planami
+        treningowymi.
+      </p>
+      <form onSubmit={handleSubmit} noValidate className="mt-6 space-y-5">
+        <FormBanner variant="error" message={formError} />
+
+        <FormField
+          id="team-name"
+          label="Pełna nazwa drużyny"
+          type="text"
+          placeholder="np. Husaria Szczecin — Seniorzy"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          error={fieldErrors.name}
+        />
+
+        <div>
+          <FormField
+            id="team-short-name"
+            label="Skrót (2–6 znaków)"
+            type="text"
+            placeholder="np. HUS SR"
+            maxLength={6}
+            value={shortName}
+            onChange={(e) => setShortName(e.target.value.toUpperCase())}
+            error={fieldErrors.shortName}
+          />
+          <p className="mt-1.5 text-xs text-neutral-500 dark:text-neutral-500">
+            Skrót używany tam, gdzie nie ma miejsca na pełną nazwę — tak jak
+            transmisje skracają nazwy klubów.
+          </p>
+        </div>
+
+        <SubmitButton loading={saving} loadingText="Tworzenie…">
+          Utwórz drużynę
+        </SubmitButton>
+      </form>
+    </div>
+  );
+}

--- a/components/team/InvitesPanel.tsx
+++ b/components/team/InvitesPanel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { SITE_URL } from "@/lib/site";
+import type { TeamInvite } from "@/lib/supabase/types";
+
+function formatExpiry(value: string): string {
+  return new Date(value).toLocaleString("pl-PL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function InvitesPanel({
+  teamId,
+  invites,
+  currentUserId,
+  onChanged,
+}: {
+  teamId: string;
+  invites: TeamInvite[];
+  currentUserId: string;
+  onChanged: () => void;
+}) {
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  // Revoked invites are done, full stop - no reason to keep showing them.
+  // Expired-but-not-revoked ones still show (with a "Wygasło" flag) so a
+  // head coach can tell "never created" apart from "went stale" and still
+  // has something to explicitly revoke for tidiness.
+  const activeInvites = [...invites]
+    .filter((invite) => !invite.revoked_at)
+    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+
+  async function handleCreate() {
+    setCreating(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("team_invites")
+      .insert({ team_id: teamId, created_by: currentUserId });
+
+    setCreating(false);
+    if (error) {
+      setError("Nie udało się utworzyć zaproszenia. Spróbuj ponownie.");
+      return;
+    }
+    onChanged();
+  }
+
+  async function handleRevoke(inviteId: string) {
+    setRevokingId(inviteId);
+    setError(null);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("team_invites")
+      .update({ revoked_at: new Date().toISOString() })
+      .eq("id", inviteId);
+
+    setRevokingId(null);
+    if (error) {
+      setError("Nie udało się odwołać zaproszenia. Spróbuj ponownie.");
+      return;
+    }
+    onChanged();
+  }
+
+  async function handleCopy(token: string, inviteId: string) {
+    const url = `${SITE_URL}/join/${token}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedId(inviteId);
+      setTimeout(
+        () => setCopiedId((current) => (current === inviteId ? null : current)),
+        2000,
+      );
+    } catch {
+      // Clipboard API can be unavailable - the link is still visible and
+      // selectable in the field below.
+    }
+  }
+
+  return (
+    <div className="mt-6 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold">Zaproszenia</h3>
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={creating}
+          className="rounded-full bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {creating ? "Tworzenie…" : "+ Nowe zaproszenie"}
+        </button>
+      </div>
+
+      {error && (
+        <p className="mt-2 text-xs text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      {activeInvites.length === 0 ? (
+        <p className="mt-3 text-sm text-neutral-500 dark:text-neutral-500">
+          Brak aktywnych zaproszeń.
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {activeInvites.map((invite) => {
+            const expired = new Date(invite.expires_at).getTime() <= Date.now();
+            const url = `${SITE_URL}/join/${invite.token}`;
+            return (
+              <li
+                key={invite.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-neutral-200 p-3 text-sm dark:border-neutral-800"
+              >
+                <div className="min-w-0 flex-1">
+                  <input
+                    type="text"
+                    readOnly
+                    value={url}
+                    onFocus={(e) => e.target.select()}
+                    aria-label="Link zaproszenia"
+                    className="w-full min-w-0 truncate rounded-lg border border-neutral-300 bg-white px-2.5 py-1.5 text-xs outline-none dark:border-neutral-700 dark:bg-neutral-900"
+                  />
+                  <p
+                    className={`mt-1 text-xs ${
+                      expired
+                        ? "text-red-600 dark:text-red-400"
+                        : "text-neutral-500 dark:text-neutral-500"
+                    }`}
+                  >
+                    {expired ? "Wygasło" : "Wygasa"} {formatExpiry(invite.expires_at)}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(invite.token, invite.id)}
+                    className="rounded-full border border-neutral-300 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+                  >
+                    {copiedId === invite.id ? "Skopiowano" : "Kopiuj"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRevoke(invite.id)}
+                    disabled={revokingId === invite.id}
+                    className="rounded-full border border-red-300 px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/40"
+                  >
+                    {revokingId === invite.id ? "…" : "Odwołaj"}
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/team/JoinConfirmButton.tsx
+++ b/components/team/JoinConfirmButton.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type FormEvent } from "react";
+import { FormBanner } from "@/components/auth/FormBanner";
+import { SubmitButton } from "@/components/auth/SubmitButton";
+import { createClient } from "@/lib/supabase/client";
+import type { JoinTeamResult } from "@/lib/supabase/types";
+
+// "this link expired" and "this link never existed" mean very different
+// things to the person holding it - one message per reason, no generic
+// catch-all for the structured {ok: false, reason} responses.
+const REASON_MESSAGES: Record<
+  Extract<JoinTeamResult, { ok: false }>["reason"],
+  string
+> = {
+  not_found:
+    "Ten link zaproszenia nie istnieje. Sprawdź, czy skopiowałeś go w całości.",
+  expired: "To zaproszenie wygasło. Poproś head coacha o nowy link.",
+  revoked: "To zaproszenie zostało odwołane. Poproś head coacha o nowy link.",
+  not_authenticated:
+    "Twoja sesja wygasła. Zaloguj się ponownie i spróbuj jeszcze raz.",
+};
+
+export function JoinConfirmButton({ token }: { token: string }) {
+  const [joining, setJoining] = useState(false);
+  const [result, setResult] = useState<JoinTeamResult | null>(null);
+  // Kept separate from `result`: a transport/RPC failure isn't any of the
+  // four structured reasons join_team_with_token itself returns.
+  const [genericError, setGenericError] = useState(false);
+
+  async function handleJoin(event: FormEvent) {
+    event.preventDefault();
+    setJoining(true);
+    setGenericError(false);
+
+    const supabase = createClient();
+    const { data, error } = await supabase.rpc("join_team_with_token", {
+      p_token: token,
+    });
+
+    setJoining(false);
+    if (error || !data) {
+      setGenericError(true);
+      return;
+    }
+    setResult(data);
+  }
+
+  if (result?.ok) {
+    // Joining twice is a no-op by design (ON CONFLICT DO NOTHING) and
+    // reports ok: true either way - one success message covers both.
+    return (
+      <div className="space-y-4 text-center">
+        <FormBanner variant="success" message="Dołączyłeś do drużyny." />
+        <Link
+          href="/app/team"
+          className="inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Przejdź do drużyny
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleJoin} className="space-y-4">
+      <FormBanner
+        variant="error"
+        message={
+          genericError
+            ? "Nie udało się dołączyć do drużyny. Spróbuj ponownie."
+            : result && !result.ok
+              ? REASON_MESSAGES[result.reason]
+              : null
+        }
+      />
+      <SubmitButton loading={joining} loadingText="Dołączanie…">
+        Dołącz do drużyny
+      </SubmitButton>
+    </form>
+  );
+}

--- a/components/team/RemoveMemberButton.tsx
+++ b/components/team/RemoveMemberButton.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+// Used both for a head coach removing someone else and for a member leaving
+// on their own - same delete, RLS (team_members_delete) decides who's
+// allowed to run it: is_team_head_coach(team_id) or user_id = auth.uid().
+export function RemoveMemberButton({
+  teamId,
+  userId,
+  label,
+  confirmLabel,
+  onRemoved,
+}: {
+  teamId: string;
+  userId: string;
+  label: string;
+  confirmLabel: string;
+  onRemoved: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRemove() {
+    setRemoving(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("team_members")
+      .delete()
+      .eq("team_id", teamId)
+      .eq("user_id", userId);
+
+    if (error) {
+      setRemoving(false);
+      setError("Nie udało się wykonać tej operacji. Spróbuj ponownie.");
+      return;
+    }
+
+    onRemoved();
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-neutral-600 dark:text-neutral-400">
+          {confirmLabel}
+        </span>
+        <button
+          type="button"
+          onClick={handleRemove}
+          disabled={removing}
+          className="rounded-full bg-red-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {removing ? "…" : "Tak"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setConfirming(false)}
+          disabled={removing}
+          className="rounded-full border border-neutral-300 px-3 py-1 text-xs font-medium transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-900"
+        >
+          Anuluj
+        </button>
+        {error && (
+          <span className="text-xs text-red-600 dark:text-red-400">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setConfirming(true)}
+      className="rounded-full border border-red-300 px-3 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-950/40"
+    >
+      {label}
+    </button>
+  );
+}

--- a/components/team/TeamCard.tsx
+++ b/components/team/TeamCard.tsx
@@ -1,0 +1,102 @@
+import type { PublicProfile, Team, TeamInvite, TeamMember } from "@/lib/supabase/types";
+import { InvitesPanel } from "./InvitesPanel";
+import { RemoveMemberButton } from "./RemoveMemberButton";
+
+const ROLE_LABELS: Record<TeamMember["role"], string> = {
+  head_coach: "Head coach",
+  assistant_coach: "Assistant coach",
+};
+
+export function TeamCard({
+  team,
+  members,
+  invites,
+  authorsById,
+  currentUserId,
+  onChanged,
+}: {
+  team: Team;
+  members: TeamMember[];
+  invites: TeamInvite[];
+  authorsById: Map<string, PublicProfile>;
+  currentUserId: string;
+  onChanged: () => void;
+}) {
+  const myMembership = members.find(
+    (member) => member.user_id === currentUserId,
+  );
+  const isHeadCoach = myMembership?.role === "head_coach";
+
+  const sortedMembers = [...members].sort((a, b) =>
+    a.joined_at.localeCompare(b.joined_at),
+  );
+
+  return (
+    <div className="rounded-2xl border border-neutral-200 p-5 dark:border-neutral-800">
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight">{team.name}</h2>
+        <p className="text-sm text-neutral-500 dark:text-neutral-500">
+          {team.short_name}
+        </p>
+      </div>
+
+      {/* Not paginated and never will be - a coaching staff is a handful of people. */}
+      <ul className="mt-4 space-y-2">
+        {sortedMembers.map((member) => {
+          const isMe = member.user_id === currentUserId;
+          const displayName =
+            authorsById.get(member.user_id)?.display_name ?? "Trener";
+          return (
+            <li
+              key={member.user_id}
+              className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-neutral-200 px-3 py-2 text-sm dark:border-neutral-800"
+            >
+              <span className="flex items-center gap-2">
+                <span>
+                  {displayName}
+                  {isMe && (
+                    <span className="text-neutral-500 dark:text-neutral-500">
+                      {" "}
+                      (Ty)
+                    </span>
+                  )}
+                </span>
+                <span className="inline-flex items-center rounded-full border border-neutral-200 bg-neutral-50 px-2 py-0.5 text-xs font-medium text-neutral-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-400">
+                  {ROLE_LABELS[member.role]}
+                </span>
+              </span>
+              {isHeadCoach && !isMe && (
+                <RemoveMemberButton
+                  teamId={team.id}
+                  userId={member.user_id}
+                  label="Usuń"
+                  confirmLabel={`Usunąć ${displayName} z drużyny?`}
+                  onRemoved={onChanged}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {isHeadCoach ? (
+        <InvitesPanel
+          teamId={team.id}
+          invites={invites}
+          currentUserId={currentUserId}
+          onChanged={onChanged}
+        />
+      ) : (
+        <div className="mt-6 border-t border-neutral-200 pt-6 dark:border-neutral-800">
+          <RemoveMemberButton
+            teamId={team.id}
+            userId={currentUserId}
+            label="Opuść drużynę"
+            confirmLabel="Na pewno chcesz opuścić tę drużynę?"
+            onRemoved={onChanged}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/team/TeamManager.tsx
+++ b/components/team/TeamManager.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type {
+  PublicProfile,
+  Team,
+  TeamInvite,
+  TeamMember,
+} from "@/lib/supabase/types";
+import { CreateTeamForm } from "./CreateTeamForm";
+import { TeamCard } from "./TeamCard";
+
+export function TeamManager({ userId }: { userId: string }) {
+  const [teams, setTeams] = useState<Team[] | null>(null);
+  const [members, setMembers] = useState<TeamMember[]>([]);
+  const [invites, setInvites] = useState<TeamInvite[]>([]);
+  const [authors, setAuthors] = useState<PublicProfile[]>([]);
+  const [loadError, setLoadError] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setTeams(null);
+    setLoadError(false);
+
+    const supabase = createClient();
+    // RLS already scopes every one of these to "my" teams (is_team_member /
+    // is_team_head_coach), so no explicit team_id filter is needed here -
+    // same pattern as ExercisesLibrary relying on RLS for exercises.
+    Promise.all([
+      supabase.from("teams").select("*").order("created_at", { ascending: true }),
+      supabase.from("team_members").select("*"),
+      supabase
+        .from("team_invites")
+        .select("*")
+        .order("created_at", { ascending: false }),
+      supabase.rpc("list_public_profiles"),
+    ]).then(([teamsRes, membersRes, invitesRes, profilesRes]) => {
+      if (cancelled) return;
+      if (teamsRes.error || !teamsRes.data) {
+        setLoadError(true);
+        return;
+      }
+      setTeams(teamsRes.data);
+      setMembers(membersRes.data ?? []);
+      setInvites(invitesRes.data ?? []);
+      setAuthors(profilesRes.data ?? []);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  const authorsById = useMemo(() => {
+    const map = new Map<string, PublicProfile>();
+    for (const author of authors) map.set(author.id, author);
+    return map;
+  }, [authors]);
+
+  const membersByTeam = useMemo(() => {
+    const map = new Map<string, TeamMember[]>();
+    for (const member of members) {
+      const list = map.get(member.team_id) ?? [];
+      list.push(member);
+      map.set(member.team_id, list);
+    }
+    return map;
+  }, [members]);
+
+  const invitesByTeam = useMemo(() => {
+    const map = new Map<string, TeamInvite[]>();
+    for (const invite of invites) {
+      const list = map.get(invite.team_id) ?? [];
+      list.push(invite);
+      map.set(invite.team_id, list);
+    }
+    return map;
+  }, [invites]);
+
+  function refresh() {
+    setReloadToken((n) => n + 1);
+  }
+
+  if (loadError) {
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/50 dark:bg-red-950/40">
+        <p className="text-sm text-red-700 dark:text-red-400">
+          Nie udało się wczytać drużyny. Spróbuj ponownie.
+        </p>
+        <button
+          type="button"
+          onClick={refresh}
+          className="mt-3 rounded-full bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
+        >
+          Spróbuj ponownie
+        </button>
+      </div>
+    );
+  }
+
+  if (teams === null) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 2 }, (_, i) => (
+          <div
+            key={i}
+            className="h-32 animate-pulse rounded-2xl bg-neutral-100 dark:bg-neutral-900"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (teams.length === 0) {
+    return (
+      <div className="max-w-md">
+        <CreateTeamForm userId={userId} onCreated={refresh} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {teams.map((team) => (
+        <TeamCard
+          key={team.id}
+          team={team}
+          members={membersByTeam.get(team.id) ?? []}
+          invites={invitesByTeam.get(team.id) ?? []}
+          authorsById={authorsById}
+          currentUserId={userId}
+          onChanged={refresh}
+        />
+      ))}
+    </div>
+  );
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -10,199 +10,34 @@ export type Difficulty = 1 | 2 | 3 | 4 | 5;
 
 export type WorkoutSection = "warmup" | "main" | "positional" | "cooldown";
 
-// 'official' rows are the null-author backfill; 'private' is the default for
-// anything a coach creates; 'team' is reserved for future team-shared scope.
-export type ExerciseScope = "official" | "private" | "team";
+export type TeamRole = "head_coach" | "assistant_coach";
 
-export interface Database {
+export type Database = {
+  __InternalSupabase: {
+    PostgrestVersion: "14.5";
+  };
   public: {
     Tables: {
-      profiles: {
-        Row: {
-          id: string;
-          display_name: string;
-          club_name: string | null;
-          avatar_url: string | null;
-          onboarding_completed: boolean;
-          created_at: string;
-        };
-        Insert: {
-          id: string;
-          display_name: string;
-          club_name?: string | null;
-          avatar_url?: string | null;
-          onboarding_completed?: boolean;
-          created_at?: string;
-        };
-        Update: {
-          id?: string;
-          display_name?: string;
-          club_name?: string | null;
-          avatar_url?: string | null;
-          onboarding_completed?: boolean;
-          created_at?: string;
-        };
-        Relationships: [];
-      };
       categories: {
         Row: {
           id: number;
-          slug: string;
-          name_pl: string;
           name_en: string;
+          name_pl: string;
+          slug: string;
         };
         Insert: {
           id?: number;
-          slug: string;
-          name_pl: string;
           name_en: string;
+          name_pl: string;
+          slug: string;
         };
         Update: {
           id?: number;
-          slug?: string;
-          name_pl?: string;
           name_en?: string;
+          name_pl?: string;
+          slug?: string;
         };
         Relationships: [];
-      };
-      sports: {
-        Row: {
-          id: number;
-          slug: string;
-          name_pl: string;
-          name_en: string;
-        };
-        Insert: {
-          id?: number;
-          slug: string;
-          name_pl: string;
-          name_en: string;
-        };
-        Update: {
-          id?: number;
-          slug?: string;
-          name_pl?: string;
-          name_en?: string;
-        };
-        Relationships: [];
-      };
-      exercises: {
-        Row: {
-          id: string;
-          author_id: string | null;
-          category_id: number;
-          // NULL = universal exercise, belongs to every sport.
-          sport_id: number | null;
-          title: string;
-          description: string | null;
-          steps: string[];
-          duration_min: number | null;
-          difficulty: Difficulty | null;
-          equipment: string[];
-          media_url: string | null;
-          board_state: Json | null;
-          // Field-view mode (FieldViewMode.id, e.g. "full"/"redzone") the
-          // board_state diagram was authored in. NULL = fall back to the
-          // sport's defaultFieldModeId.
-          board_field_mode: string | null;
-          is_public: boolean;
-          scope: ExerciseScope;
-          created_at: string;
-          updated_at: string;
-        };
-        Insert: {
-          id?: string;
-          author_id?: string | null;
-          category_id: number;
-          sport_id?: number | null;
-          title: string;
-          description?: string | null;
-          steps?: string[];
-          duration_min?: number | null;
-          difficulty?: Difficulty | null;
-          equipment?: string[];
-          media_url?: string | null;
-          board_state?: Json | null;
-          board_field_mode?: string | null;
-          is_public?: boolean;
-          scope?: ExerciseScope;
-          created_at?: string;
-          updated_at?: string;
-        };
-        Update: {
-          id?: string;
-          author_id?: string | null;
-          category_id?: number;
-          sport_id?: number | null;
-          title?: string;
-          description?: string | null;
-          steps?: string[];
-          duration_min?: number | null;
-          difficulty?: Difficulty | null;
-          equipment?: string[];
-          media_url?: string | null;
-          board_state?: Json | null;
-          board_field_mode?: string | null;
-          is_public?: boolean;
-          scope?: ExerciseScope;
-          created_at?: string;
-          updated_at?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "exercises_author_id_fkey";
-            columns: ["author_id"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "exercises_category_id_fkey";
-            columns: ["category_id"];
-            isOneToOne: false;
-            referencedRelation: "categories";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "exercises_sport_id_fkey";
-            columns: ["sport_id"];
-            isOneToOne: false;
-            referencedRelation: "sports";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      positions: {
-        Row: {
-          id: string;
-          sport_id: number;
-          code: string;
-          label: string;
-          sort_order: number;
-        };
-        Insert: {
-          id?: string;
-          sport_id: number;
-          code: string;
-          label: string;
-          sort_order?: number;
-        };
-        Update: {
-          id?: string;
-          sport_id?: number;
-          code?: string;
-          label?: string;
-          sort_order?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "positions_sport_id_fkey";
-            columns: ["sport_id"];
-            isOneToOne: false;
-            referencedRelation: "sports";
-            referencedColumns: ["id"];
-          },
-        ];
       };
       exercise_positions: {
         Row: {
@@ -234,36 +69,366 @@ export interface Database {
           },
         ];
       };
-      workouts: {
+      exercises: {
         Row: {
-          id: string;
-          owner_id: string;
-          title: string;
-          team_name: string | null;
-          scheduled_for: string | null;
-          notes: string | null;
-          share_id: string;
+          author_id: string | null;
+          board_field_mode: string | null;
+          board_state: Json | null;
+          category_id: number;
           created_at: string;
+          description: string | null;
+          difficulty: Difficulty | null;
+          duration_min: number | null;
+          equipment: string[];
+          id: string;
+          is_public: boolean;
+          media_url: string | null;
+          sport_id: number | null;
+          steps: string[];
+          team_id: string | null;
+          title: string;
+          updated_at: string;
         };
         Insert: {
-          id?: string;
-          owner_id: string;
-          title: string;
-          team_name?: string | null;
-          scheduled_for?: string | null;
-          notes?: string | null;
-          share_id?: string;
+          author_id?: string | null;
+          board_field_mode?: string | null;
+          board_state?: Json | null;
+          category_id: number;
           created_at?: string;
+          description?: string | null;
+          difficulty?: Difficulty | null;
+          duration_min?: number | null;
+          equipment?: string[];
+          id?: string;
+          is_public?: boolean;
+          media_url?: string | null;
+          sport_id?: number | null;
+          steps?: string[];
+          team_id?: string | null;
+          title: string;
+          updated_at?: string;
         };
         Update: {
-          id?: string;
-          owner_id?: string;
-          title?: string;
-          team_name?: string | null;
-          scheduled_for?: string | null;
-          notes?: string | null;
-          share_id?: string;
+          author_id?: string | null;
+          board_field_mode?: string | null;
+          board_state?: Json | null;
+          category_id?: number;
           created_at?: string;
+          description?: string | null;
+          difficulty?: Difficulty | null;
+          duration_min?: number | null;
+          equipment?: string[];
+          id?: string;
+          is_public?: boolean;
+          media_url?: string | null;
+          sport_id?: number | null;
+          steps?: string[];
+          team_id?: string | null;
+          title?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "exercises_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "exercises_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "categories";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "exercises_sport_id_fkey";
+            columns: ["sport_id"];
+            isOneToOne: false;
+            referencedRelation: "sports";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "exercises_team_id_fkey";
+            columns: ["team_id"];
+            isOneToOne: false;
+            referencedRelation: "teams";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      positions: {
+        Row: {
+          code: string;
+          id: string;
+          label: string;
+          sort_order: number;
+          sport_id: number;
+        };
+        Insert: {
+          code: string;
+          id?: string;
+          label: string;
+          sort_order?: number;
+          sport_id: number;
+        };
+        Update: {
+          code?: string;
+          id?: string;
+          label?: string;
+          sort_order?: number;
+          sport_id?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "positions_sport_id_fkey";
+            columns: ["sport_id"];
+            isOneToOne: false;
+            referencedRelation: "sports";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      profiles: {
+        Row: {
+          avatar_url: string | null;
+          club_name: string | null;
+          created_at: string;
+          display_name: string;
+          id: string;
+          onboarding_completed: boolean;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          club_name?: string | null;
+          created_at?: string;
+          display_name: string;
+          id: string;
+          onboarding_completed?: boolean;
+        };
+        Update: {
+          avatar_url?: string | null;
+          club_name?: string | null;
+          created_at?: string;
+          display_name?: string;
+          id?: string;
+          onboarding_completed?: boolean;
+        };
+        Relationships: [];
+      };
+      sports: {
+        Row: {
+          id: number;
+          name_en: string;
+          name_pl: string;
+          slug: string;
+        };
+        Insert: {
+          id?: number;
+          name_en: string;
+          name_pl: string;
+          slug: string;
+        };
+        Update: {
+          id?: number;
+          name_en?: string;
+          name_pl?: string;
+          slug?: string;
+        };
+        Relationships: [];
+      };
+      team_invites: {
+        Row: {
+          created_at: string;
+          created_by: string;
+          expires_at: string;
+          id: string;
+          revoked_at: string | null;
+          team_id: string;
+          token: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_by: string;
+          expires_at?: string;
+          id?: string;
+          revoked_at?: string | null;
+          team_id: string;
+          token?: string;
+        };
+        Update: {
+          created_at?: string;
+          created_by?: string;
+          expires_at?: string;
+          id?: string;
+          revoked_at?: string | null;
+          team_id?: string;
+          token?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "team_invites_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "team_invites_team_id_fkey";
+            columns: ["team_id"];
+            isOneToOne: false;
+            referencedRelation: "teams";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      team_members: {
+        Row: {
+          joined_at: string;
+          role: TeamRole;
+          team_id: string;
+          user_id: string;
+        };
+        Insert: {
+          joined_at?: string;
+          role: TeamRole;
+          team_id: string;
+          user_id: string;
+        };
+        Update: {
+          joined_at?: string;
+          role?: TeamRole;
+          team_id?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "team_members_team_id_fkey";
+            columns: ["team_id"];
+            isOneToOne: false;
+            referencedRelation: "teams";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "team_members_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      teams: {
+        Row: {
+          created_at: string;
+          created_by: string;
+          id: string;
+          name: string;
+          short_name: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_by: string;
+          id?: string;
+          name: string;
+          short_name: string;
+        };
+        Update: {
+          created_at?: string;
+          created_by?: string;
+          id?: string;
+          name?: string;
+          short_name?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "teams_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      workout_items: {
+        Row: {
+          assigned_to: string | null;
+          duration_min: number | null;
+          exercise_id: string;
+          id: string;
+          position: number;
+          section: WorkoutSection;
+          workout_id: string;
+        };
+        Insert: {
+          assigned_to?: string | null;
+          duration_min?: number | null;
+          exercise_id: string;
+          id?: string;
+          position: number;
+          section: WorkoutSection;
+          workout_id: string;
+        };
+        Update: {
+          assigned_to?: string | null;
+          duration_min?: number | null;
+          exercise_id?: string;
+          id?: string;
+          position?: number;
+          section?: WorkoutSection;
+          workout_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "workout_items_exercise_id_fkey";
+            columns: ["exercise_id"];
+            isOneToOne: false;
+            referencedRelation: "exercises";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "workout_items_workout_id_fkey";
+            columns: ["workout_id"];
+            isOneToOne: false;
+            referencedRelation: "workouts";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      workouts: {
+        Row: {
+          created_at: string;
+          id: string;
+          notes: string | null;
+          owner_id: string;
+          scheduled_for: string | null;
+          share_id: string;
+          team_id: string | null;
+          team_name: string | null;
+          title: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          notes?: string | null;
+          owner_id: string;
+          scheduled_for?: string | null;
+          share_id?: string;
+          team_id?: string | null;
+          team_name?: string | null;
+          title: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          notes?: string | null;
+          owner_id?: string;
+          scheduled_for?: string | null;
+          share_id?: string;
+          team_id?: string | null;
+          team_name?: string | null;
+          title?: string;
         };
         Relationships: [
           {
@@ -273,76 +438,174 @@ export interface Database {
             referencedRelation: "profiles";
             referencedColumns: ["id"];
           },
-        ];
-      };
-      workout_items: {
-        Row: {
-          id: string;
-          workout_id: string;
-          exercise_id: string;
-          section: WorkoutSection;
-          position: number;
-          duration_min: number | null;
-          assigned_to: string | null;
-        };
-        Insert: {
-          id?: string;
-          workout_id: string;
-          exercise_id: string;
-          section: WorkoutSection;
-          position: number;
-          duration_min?: number | null;
-          assigned_to?: string | null;
-        };
-        Update: {
-          id?: string;
-          workout_id?: string;
-          exercise_id?: string;
-          section?: WorkoutSection;
-          position?: number;
-          duration_min?: number | null;
-          assigned_to?: string | null;
-        };
-        Relationships: [
           {
-            foreignKeyName: "workout_items_workout_id_fkey";
-            columns: ["workout_id"];
+            foreignKeyName: "workouts_team_id_fkey";
+            columns: ["team_id"];
             isOneToOne: false;
-            referencedRelation: "workouts";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "workout_items_exercise_id_fkey";
-            columns: ["exercise_id"];
-            isOneToOne: false;
-            referencedRelation: "exercises";
+            referencedRelation: "teams";
             referencedColumns: ["id"];
           },
         ];
       };
     };
-    Views: Record<string, never>;
+    Views: {
+      [_ in never]: never;
+    };
     Functions: {
-      get_shared_workout: {
-        Args: { p_share_id: string };
-        Returns: SharedWorkoutPayload | null;
-      };
       duplicate_workout: {
         Args: { p_workout_id: string };
         Returns: Database["public"]["Tables"]["workouts"]["Row"];
       };
+      generate_share_id: { Args: never; Returns: string };
+      get_invite_preview: { Args: { p_token: string }; Returns: InvitePreview | null };
+      get_shared_workout: { Args: { p_share_id: string }; Returns: SharedWorkoutPayload | null };
       is_pseudonym_available: {
         Args: { p_display_name: string };
         Returns: boolean;
       };
+      is_team_head_coach: { Args: { p_team_id: string }; Returns: boolean };
+      is_team_member: { Args: { p_team_id: string }; Returns: boolean };
+      join_team_with_token: { Args: { p_token: string }; Returns: JoinTeamResult };
       list_public_profiles: {
-        Args: Record<string, never>;
-        Returns: PublicProfile[];
+        Args: never;
+        Returns: {
+          display_name: string;
+          id: string;
+        }[];
       };
+      my_team_ids: { Args: never; Returns: string[] };
     };
-    Enums: Record<string, never>;
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
   };
+};
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
 }
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never;
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never;
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const;
 
 export type Exercise = Database["public"]["Tables"]["exercises"]["Row"];
 export type Category = Database["public"]["Tables"]["categories"]["Row"];
@@ -352,6 +615,9 @@ export type ExercisePosition =
   Database["public"]["Tables"]["exercise_positions"]["Row"];
 export type Workout = Database["public"]["Tables"]["workouts"]["Row"];
 export type WorkoutItem = Database["public"]["Tables"]["workout_items"]["Row"];
+export type Team = Database["public"]["Tables"]["teams"]["Row"];
+export type TeamMember = Database["public"]["Tables"]["team_members"]["Row"];
+export type TeamInvite = Database["public"]["Tables"]["team_invites"]["Row"];
 
 // Shape returned by the list_public_profiles() RPC - the only channel
 // through which a coach can see another coach's attribution (see
@@ -388,3 +654,24 @@ export interface SharedWorkoutPayload {
   workout: Workout;
   items: SharedWorkoutItem[];
 }
+
+// Shape returned by the get_invite_preview() RPC (see
+// supabase/migrations/20260728133850_team_support.sql). Null when the token
+// doesn't match any team_invites row; `valid` reflects revoked_at/expires_at
+// so the join page can distinguish "no such invite" from "invite exists but
+// is dead" before the visitor commits to anything.
+export interface InvitePreview {
+  team_name: string;
+  short_name: string;
+  valid: boolean;
+}
+
+// Shape returned by the join_team_with_token() RPC. Joining twice is a
+// no-op that still reports ok: true (see the migration's ON CONFLICT DO
+// NOTHING), not an error - re-running the join is always safe to call.
+export type JoinTeamResult =
+  | { ok: true; team_id: string }
+  | {
+      ok: false;
+      reason: "not_found" | "expired" | "revoked" | "not_authenticated";
+    };

--- a/supabase/migrations/20260728133850_team_support.sql
+++ b/supabase/migrations/20260728133850_team_support.sql
@@ -1,0 +1,155 @@
+-- 1. Martwa kolumna scope — usunięcie
+alter table public.exercises drop column if exists scope;
+
+-- 2. Drużyny
+create table if not exists public.teams (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  short_name  text not null check (char_length(short_name) between 2 and 6),
+  created_by  uuid not null references public.profiles(id) on delete restrict,
+  created_at  timestamptz not null default now()
+);
+
+create table if not exists public.team_members (
+  team_id   uuid not null references public.teams(id) on delete cascade,
+  user_id   uuid not null references public.profiles(id) on delete cascade,
+  role      text not null check (role in ('head_coach','assistant_coach')),
+  joined_at timestamptz not null default now(),
+  primary key (team_id, user_id)
+);
+create index if not exists team_members_user_idx on public.team_members(user_id);
+
+create table if not exists public.team_invites (
+  id         uuid primary key default gen_random_uuid(),
+  team_id    uuid not null references public.teams(id) on delete cascade,
+  token      text not null unique default public.generate_share_id(),
+  created_by uuid not null references public.profiles(id) on delete cascade,
+  expires_at timestamptz not null default now() + interval '7 days',
+  revoked_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+-- 3. Przypisanie do drużyny
+alter table public.exercises add column if not exists team_id uuid references public.teams(id) on delete set null;
+alter table public.workouts  add column if not exists team_id uuid references public.teams(id) on delete set null;
+create index if not exists exercises_team_idx on public.exercises(team_id);
+create index if not exists workouts_team_idx  on public.workouts(team_id);
+
+comment on column public.workouts.team_id is
+  'Druzyna wlasciciel. Bez zwiazku z workouts.team_name, ktore jest wolna etykieta tekstowa.';
+
+-- 4. Helpery — istnieja po to, zeby polityki na team_members nie odpytywaly team_members
+--    (RLS w Postgresie wpada wtedy w nieskonczona rekurencje).
+create or replace function public.is_team_member(p_team_id uuid)
+returns boolean language sql stable security definer set search_path = public as $$
+  select exists (select 1 from public.team_members m
+                 where m.team_id = p_team_id and m.user_id = auth.uid());
+$$;
+
+create or replace function public.is_team_head_coach(p_team_id uuid)
+returns boolean language sql stable security definer set search_path = public as $$
+  select exists (select 1 from public.team_members m
+                 where m.team_id = p_team_id and m.user_id = auth.uid()
+                   and m.role = 'head_coach');
+$$;
+
+create or replace function public.my_team_ids()
+returns setof uuid language sql stable security definer set search_path = public as $$
+  select m.team_id from public.team_members m where m.user_id = auth.uid();
+$$;
+
+grant execute on function public.is_team_member(uuid)     to authenticated;
+grant execute on function public.is_team_head_coach(uuid) to authenticated;
+grant execute on function public.my_team_ids()            to authenticated;
+
+-- 5. Tworca druzyny zostaje head coachem
+create or replace function public.add_team_creator_as_head_coach()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.team_members (team_id, user_id, role)
+  values (new.id, new.created_by, 'head_coach')
+  on conflict do nothing;
+  return new;
+end $$;
+
+drop trigger if exists teams_add_creator on public.teams;
+create trigger teams_add_creator after insert on public.teams
+  for each row execute function public.add_team_creator_as_head_coach();
+
+-- 6. RLS — jawnie, bo rls_auto_enable() nie istnieje w repo
+alter table public.teams         enable row level security;
+alter table public.team_members  enable row level security;
+alter table public.team_invites  enable row level security;
+
+drop policy if exists teams_select on public.teams;
+create policy teams_select on public.teams for select to authenticated
+  using (public.is_team_member(id));
+
+drop policy if exists teams_insert on public.teams;
+create policy teams_insert on public.teams for insert to authenticated
+  with check (created_by = auth.uid());
+
+drop policy if exists teams_update on public.teams;
+create policy teams_update on public.teams for update to authenticated
+  using (public.is_team_head_coach(id)) with check (public.is_team_head_coach(id));
+
+drop policy if exists team_members_select on public.team_members;
+create policy team_members_select on public.team_members for select to authenticated
+  using (public.is_team_member(team_id));
+
+-- brak INSERT: dolaczanie wylacznie przez join_team_with_token()
+drop policy if exists team_members_delete on public.team_members;
+create policy team_members_delete on public.team_members for delete to authenticated
+  using (public.is_team_head_coach(team_id) or user_id = auth.uid());
+
+drop policy if exists team_invites_select on public.team_invites;
+create policy team_invites_select on public.team_invites for select to authenticated
+  using (public.is_team_head_coach(team_id));
+
+drop policy if exists team_invites_insert on public.team_invites;
+create policy team_invites_insert on public.team_invites for insert to authenticated
+  with check (public.is_team_head_coach(team_id) and created_by = auth.uid());
+
+drop policy if exists team_invites_update on public.team_invites;
+create policy team_invites_update on public.team_invites for update to authenticated
+  using (public.is_team_head_coach(team_id)) with check (public.is_team_head_coach(team_id));
+
+-- 7. Widocznosc cwiczen i treningow rozszerzona o druzyne
+drop policy if exists exercises_select_own_or_public on public.exercises;
+create policy exercises_select_own_or_public on public.exercises for select to authenticated
+  using (is_public or author_id = auth.uid() or team_id in (select public.my_team_ids()));
+
+drop policy if exists workouts_select_own on public.workouts;
+create policy workouts_select_own on public.workouts for select to authenticated
+  using (owner_id = auth.uid() or team_id in (select public.my_team_ids()));
+
+-- 8. Zaproszenia: podglad i dolaczenie
+create or replace function public.get_invite_preview(p_token text)
+returns jsonb language sql stable security definer set search_path = public as $$
+  select jsonb_build_object(
+           'team_name', t.name,
+           'short_name', t.short_name,
+           'valid', i.revoked_at is null and i.expires_at > now())
+  from public.team_invites i join public.teams t on t.id = i.team_id
+  where i.token = p_token;
+$$;
+
+create or replace function public.join_team_with_token(p_token text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_inv public.team_invites; v_uid uuid := auth.uid();
+begin
+  if v_uid is null then return jsonb_build_object('ok', false, 'reason', 'not_authenticated'); end if;
+  select * into v_inv from public.team_invites where token = p_token;
+  if not found then return jsonb_build_object('ok', false, 'reason', 'not_found'); end if;
+  if v_inv.revoked_at is not null then return jsonb_build_object('ok', false, 'reason', 'revoked'); end if;
+  if v_inv.expires_at <= now() then return jsonb_build_object('ok', false, 'reason', 'expired'); end if;
+
+  insert into public.team_members (team_id, user_id, role)
+  values (v_inv.team_id, v_uid, 'assistant_coach')
+  on conflict (team_id, user_id) do nothing;
+
+  return jsonb_build_object('ok', true, 'team_id', v_inv.team_id);
+end $$;
+
+grant execute on function public.get_invite_preview(text)   to authenticated;
+grant execute on function public.join_team_with_token(text) to authenticated;

--- a/supabase/migrations/20260728141752_grant_invite_preview_to_anon.sql
+++ b/supabase/migrations/20260728141752_grant_invite_preview_to_anon.sql
@@ -1,0 +1,10 @@
+-- Grant get_invite_preview() to anon too, not just authenticated (as
+-- originally shipped in 20260728133850_team_support.sql). An invited
+-- person should see which team they're being invited to *before*
+-- deciding whether to create an account - "join Husaria Szczecin's
+-- staff" is a much stronger prompt than "log in to find out what this
+-- is". Security is unchanged: the token still carries ~72 bits of
+-- entropy (generate_share_id()) and the function still returns only
+-- team_name, short_name, and a validity flag - the same model as
+-- get_shared_workout(), which anon can already call.
+grant execute on function public.get_invite_preview(text) to anon;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,6 +1,6 @@
 -- Coach Zone — official exercise library seed
--- Run AFTER migrations. Official (library) exercises have author_id = NULL
--- and scope = 'official'. Descriptions and steps are in Polish (target
+-- Run AFTER migrations. Official (library) exercises have author_id = NULL.
+-- Descriptions and steps are in Polish (target
 -- users are Polish-speaking coaches); category and sport names are
 -- bilingual (name_pl / name_en).
 --
@@ -43,8 +43,8 @@ insert into public.categories (slug, name_pl, name_en) values
 on conflict (slug) do nothing;
 
 -- ============================================================================
--- Exercises - full official library (author_id is always null, scope is
--- always 'official'). category_slug/sport_slug below are resolved to
+-- Exercises - full official library (author_id is always null).
+-- category_slug/sport_slug below are resolved to
 -- category_id/sport_id via the joins in the insert; sport_slug null stays
 -- null through the left join (universal exercise).
 -- ============================================================================
@@ -161,10 +161,10 @@ with lib (category_slug, sport_slug, title, description, steps, duration_min,
 )
 insert into public.exercises
   (author_id, sport_id, category_id, title, description, steps, duration_min,
-   difficulty, equipment, media_url, is_public, scope, board_state, board_field_mode)
+   difficulty, equipment, media_url, is_public, board_state, board_field_mode)
 select
   null, sp.id, c.id, l.title, l.description, l.steps, l.duration_min,
-  l.difficulty, l.equipment, l.media_url, true, 'official', l.board_state, l.board_field_mode
+  l.difficulty, l.equipment, l.media_url, true, l.board_state, l.board_field_mode
 from lib l
 join public.categories c on c.slug = l.category_slug
 left join public.sports sp on sp.slug = l.sport_slug


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Team support, Round A: schema, permissions, and the bare-minimum UI to create a team and invite people. Round B (team switcher in the header, audience selector on the forms, role badges, filtering the library by team) is deliberately out of scope here.

### Stage 1 — schema (applied to production by the user, confirmed: three tables, eight policies, `scope` dropped, `team_id` on both `exercises` and `workouts`, six functions, 77 official library rows intact)

- Migration `supabase/migrations/20260728133850_team_support.sql`, committed **verbatim as provided by the user**. Adds `teams`/`team_members`/`team_invites`, drops the inert `exercises.scope` column, adds `team_id` to `exercises`/`workouts`, three security-definer RLS-recursion helpers (`is_team_member`, `is_team_head_coach`, `my_team_ids`), a creator-becomes-head-coach trigger, RLS enabled explicitly on all three new tables (since `rls_auto_enable()` only exists live, not in this repo's migration history), and the `get_invite_preview`/`join_team_with_token` RPCs.
- `supabase/seed.sql` fixed: the official-library insert no longer references the dropped `scope` column, so a fresh `supabase db reset` keeps working (same class of fix as #39).
- **On the record**: this sandbox has no Supabase CLI or reachable Docker daemon, so a local `supabase db reset` could not be run to confirm "77/10/92, second run is a no-op." Hand-verified the `seed.sql` column/value alignment (13/13) instead; the actual counts were confirmed separately by the user against production. Same situation as #39.

### Stage 2 — types + UI

- `lib/supabase/types.ts` regenerated via the Supabase MCP against the applied migration, re-layered with this file's existing hand-narrowing convention (literal unions for `section`/`difficulty`/`role`; structured `Returns` types for the three jsonb RPCs, since jsonb is opaque to introspection).
- **"Moja drużyna"** (`/app/team`): no team → create-team form (full name + 2–6 char short name; a trigger makes the creator head coach, so the form only inserts into `teams`). Has team(s) → roster with roles per team, names resolved via `list_public_profiles()`. Head coaches get an invite panel (create/copy/revoke, link from `NEXT_PUBLIC_SITE_URL`) and can remove staff; assistant coaches get a read-only roster plus leave-team. Roster is unpaginated by design.
- **`/join/[token]`** (outside `/app`): calls `get_invite_preview(token)`. Added optional `next`-param support to `/login`, `/signup`, and Google OAuth's callback so a visitor who needs to authenticate returns to the invite afterward; every new prop defaults to today's exact behavior when absent.
- Untouched, as scoped: `ExerciseForm`, `WorkoutBasicsForm`, `ExercisesLibrary`, and the app header — nothing writes `team_id` from any form yet.

### Stage 2.1 — `get_invite_preview` opened to `anon`

The user granted `execute on function get_invite_preview(text) to anon` directly on production (a gap in the original migration, not a mistake in this PR's implementation): an invited person should see *which team* before deciding whether to create an account, the same model `get_shared_workout` already uses for `anon`. This PR:
- Adds `supabase/migrations/20260728141752_grant_invite_preview_to_anon.sql` with just that grant, verified against production beforehand via `has_function_privilege` so the repo matches what's actually live.
- Rewrote `/join/[token]` to call `get_invite_preview` unconditionally (not gated behind auth), so the team name renders first for every visitor; the login/register prompt is now the next step underneath it, not the first thing. An invite that resolves but reports `valid: false` (expired/revoked) says so plainly for anyone, signed in or not, with no login/register CTA.
- The `next`-param plumbing on `/login`/`/signup`/OAuth callback from Stage 2 is unchanged and still needed — joining still requires an account.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass locally after every commit in this PR.
- [x] Grepped the full codebase + `lib/supabase/types.ts` for `scope` before writing the migration.
- [x] Hand-verified the `seed.sql` insert's column/value alignment after the `scope` removal (13/13).
- [x] User applied the schema migration to production directly and confirmed: three tables, eight policies, `scope` dropped, `team_id` on both tables, six functions, 77 official rows intact.
- [x] Verified the `anon` grant on `get_invite_preview` against production (`has_function_privilege`) before writing the follow-up migration, so the file matches live state exactly.
- [x] Diffed the `next`-param commit line-by-line to confirm a plain login, plain signup, and plain Google sign-in with no `next` param are byte-identical to pre-PR behavior (`next || "/app"` reduces to the original literal; `GoogleAuthButton`'s URL construction with no `redirectTo` reduces to the original template string, confirmed with a Node check; the signup confirmation screen's no-`next` branch is textually unchanged, just moved into a ternary).
- [ ] Not exercised end-to-end against a live team (create team → invite → join from a second account) — deliberately not attempted from this sandbox, since that means real accounts and rows on production; on-device verification is the user's/Kamil's call.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01527w1eR2ZYvS1Fk7cbG4xP
EOF
)