### PR TITLE
Round B: wire team context through the app

### DIFF
--- a/app/app/calendar/page.tsx
+++ b/app/app/calendar/page.tsx
@@ -1,10 +1,33 @@
 import type { Metadata } from "next";
 import { CalendarView } from "@/components/workouts/CalendarView";
+import { resolveActiveTeamId } from "@/lib/teams";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Kalendarz — Coach Zone",
 };
 
-export default function CalendarPage() {
-  return <CalendarView />;
+export default async function CalendarPage() {
+  const supabase = await createClient();
+  const { data: userData } = await supabase.auth.getUser();
+
+  let activeTeamId: string | null = null;
+  if (userData.user) {
+    const [{ data: profile }, { data: teams }] = await Promise.all([
+      supabase
+        .from("profiles")
+        .select("active_team_id")
+        .eq("id", userData.user.id)
+        .single(),
+      supabase.from("teams").select("id"),
+    ]);
+    activeTeamId = resolveActiveTeamId(
+      profile?.active_team_id ?? null,
+      teams ?? [],
+    );
+  }
+
+  return <CalendarView activeTeamId={activeTeamId} />;
 }

--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -134,6 +134,7 @@ export default async function ExerciseDetailPage({
               authorId={exercise.author_id}
               currentUserId={userData.user?.id}
               authorsById={authorsById}
+              teamId={exercise.team_id}
             />
             {!exercise.is_public && (
               <span className="rounded-full bg-neutral-100 px-2.5 py-0.5 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">

--- a/app/app/exercises/new/page.tsx
+++ b/app/app/exercises/new/page.tsx
@@ -30,6 +30,13 @@ export default async function NewExercisePage({
     redirect("/login");
   }
 
+  // RLS (is_team_member) already scopes this to the coach's own teams - the
+  // audience selector below only ever needs to offer teams they belong to.
+  const { data: teams } = await supabase
+    .from("teams")
+    .select("id, name")
+    .order("name", { ascending: true });
+
   // RLS (public OR own) already scopes this select - if the id doesn't
   // resolve (deleted, or not visible to this coach), duplicateFrom stays
   // null and the form just falls back to a blank create.
@@ -55,6 +62,7 @@ export default async function NewExercisePage({
         <ExerciseForm
           categories={categories ?? []}
           sports={sports ?? []}
+          teams={teams ?? []}
           userId={userData.user.id}
           duplicateFrom={duplicateFrom}
         />

--- a/app/app/exercises/page.tsx
+++ b/app/app/exercises/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { ExercisesLibrary } from "@/components/exercises/ExercisesLibrary";
+import { resolveActiveTeamId } from "@/lib/teams";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -18,12 +19,29 @@ export default async function ExercisesPage() {
       supabase.auth.getUser(),
     ]);
 
+  let activeTeamId: string | null = null;
+  if (userData.user) {
+    const [{ data: profile }, { data: teams }] = await Promise.all([
+      supabase
+        .from("profiles")
+        .select("active_team_id")
+        .eq("id", userData.user.id)
+        .single(),
+      supabase.from("teams").select("id"),
+    ]);
+    activeTeamId = resolveActiveTeamId(
+      profile?.active_team_id ?? null,
+      teams ?? [],
+    );
+  }
+
   return (
     <Suspense fallback={null}>
       <ExercisesLibrary
         categories={categories ?? []}
         sports={sports ?? []}
         currentUserId={userData.user?.id ?? null}
+        activeTeamId={activeTeamId}
       />
     </Suspense>
   );

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,24 +1,88 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { Logo } from "@/components/Logo";
+import { OnboardingOverlay } from "@/components/onboarding/OnboardingOverlay";
+import { TeamSwitcher } from "@/components/team/TeamSwitcher";
+import { createClient } from "@/lib/supabase/server";
+import type { TeamRole } from "@/lib/supabase/types";
 import { logout } from "./actions";
 
 const navItems = [
   { href: "/app/exercises", label: "Ćwiczenia" },
   { href: "/app/workouts", label: "Treningi" },
   { href: "/app/calendar", label: "Kalendarz" },
+  { href: "/app/team", label: "Drużyna" },
   { href: "/app/settings", label: "Ustawienia" },
 ];
 
-export default function AppLayout({ children }: { children: ReactNode }) {
+export default async function AppLayout({ children }: { children: ReactNode }) {
+  const supabase = await createClient();
+  const { data: userData } = await supabase.auth.getUser();
+
+  let activeTeamId: string | null = null;
+  let onboardingCompleted = true;
+  let myTeams: Array<{
+    id: string;
+    name: string;
+    short_name: string;
+    role: TeamRole;
+  }> = [];
+
+  // Middleware already guarantees a user for any /app/* route; this is a
+  // defensive fallback matching the other /app pages.
+  if (userData.user) {
+    const [{ data: profile }, { data: teams }, { data: memberships }] =
+      await Promise.all([
+        supabase
+          .from("profiles")
+          .select("active_team_id, onboarding_completed")
+          .eq("id", userData.user.id)
+          .single(),
+        supabase.from("teams").select("id, name, short_name"),
+        supabase
+          .from("team_members")
+          .select("team_id, role")
+          .eq("user_id", userData.user.id),
+      ]);
+
+    activeTeamId = profile?.active_team_id ?? null;
+    onboardingCompleted = profile?.onboarding_completed ?? true;
+
+    const teamsById = new Map((teams ?? []).map((team) => [team.id, team]));
+    myTeams = (memberships ?? []).flatMap((membership) => {
+      const team = teamsById.get(membership.team_id);
+      return team ? [{ ...team, role: membership.role }] : [];
+    });
+  }
+
   return (
     <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      {/* Fires on first entry to anything under /app, whatever route the
+          coach arrives on (e.g. straight to /app/team via an invite link) -
+          not just the home page, which they might never visit first. */}
+      {userData.user && !onboardingCompleted && <OnboardingOverlay />}
+
       <header className="border-b border-neutral-200 dark:border-neutral-800">
         <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-4 sm:px-6">
-          <div className="flex items-center gap-4 sm:gap-8">
-            <Link href="/app">
-              <Logo />
+          <div className="flex min-w-0 items-center gap-3 sm:gap-8">
+            <Link href="/app" className="shrink-0">
+              {/* The wordmark and the switcher compete for space on a narrow
+                  viewport - collapse to the mark alone below sm, keeping the
+                  switcher room, rather than shrinking/wrapping the switcher. */}
+              <span className="hidden sm:inline-flex">
+                <Logo />
+              </span>
+              <span className="sm:hidden">
+                <Logo variant="mark" />
+              </span>
             </Link>
+            {userData.user && (
+              <TeamSwitcher
+                userId={userData.user.id}
+                teams={myTeams}
+                activeTeamId={activeTeamId}
+              />
+            )}
             <nav className="flex gap-3 sm:gap-6">
               {navItems.map((item) => (
                 <Link

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { OnboardingOverlay } from "@/components/onboarding/OnboardingOverlay";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -38,7 +37,7 @@ export default async function AppHomePage() {
   const { data: profile } = user
     ? await supabase
         .from("profiles")
-        .select("display_name, onboarding_completed")
+        .select("display_name")
         .eq("id", user.id)
         .single()
     : { data: null };
@@ -51,8 +50,6 @@ export default async function AppHomePage() {
 
   return (
     <main className="mx-auto max-w-3xl px-6 pt-8 pb-20">
-      {profile && !profile.onboarding_completed && <OnboardingOverlay />}
-
       <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
         Witaj, {displayName}
       </h1>

--- a/app/app/workouts/new/page.tsx
+++ b/app/app/workouts/new/page.tsx
@@ -25,6 +25,13 @@ export default async function NewWorkoutPage({
     redirect("/login");
   }
 
+  // RLS (is_team_member) already scopes this to the coach's own teams - the
+  // audience selector below only ever needs to offer teams they belong to.
+  const { data: teams } = await supabase
+    .from("teams")
+    .select("id, name")
+    .order("name", { ascending: true });
+
   const { date } = await searchParams;
   const initialScheduledFor = date && DATE_PATTERN.test(date) ? date : undefined;
 
@@ -38,6 +45,7 @@ export default async function NewWorkoutPage({
         <WorkoutBasicsForm
           mode="create"
           userId={userData.user.id}
+          teams={teams ?? []}
           initialScheduledFor={initialScheduledFor}
         />
       </div>

--- a/components/AudienceSelector.tsx
+++ b/components/AudienceSelector.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useId } from "react";
+import { audienceEquals, type Audience } from "@/lib/audience";
+
+export function AudienceSelector({
+  legend,
+  teams,
+  value,
+  onChange,
+  permanenceNotice,
+}: {
+  legend: string;
+  teams: Array<{ id: string; name: string }>;
+  value: Audience;
+  onChange: (audience: Audience) => void;
+  /** Shown as a plain-language warning right where the choice is made - e.g. exercises are immutable, this is exercise-only. */
+  permanenceNotice?: string;
+}) {
+  const name = useId();
+
+  const options: Array<{ key: string; audience: Audience; label: string; description: string }> =
+    [
+      {
+        key: "personal",
+        audience: { kind: "personal" },
+        label: "Tylko ja",
+        description: "Widoczne tylko dla Ciebie.",
+      },
+      ...teams.map((team) => ({
+        key: `team:${team.id}`,
+        audience: { kind: "team", teamId: team.id } as Audience,
+        label: team.name,
+        description: "Widoczne dla sztabu tej drużyny.",
+      })),
+      {
+        key: "public",
+        audience: { kind: "public" },
+        label: "Biblioteka publiczna",
+        description: "Widoczne dla wszystkich trenerów w Coach Zone.",
+      },
+    ];
+
+  return (
+    <fieldset>
+      <legend className="block text-sm font-medium">{legend}</legend>
+      <div className="mt-1.5 space-y-2">
+        {options.map((option) => {
+          const selected = audienceEquals(value, option.audience);
+          return (
+            <label
+              key={option.key}
+              className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors ${
+                selected
+                  ? "border-emerald-600/50 bg-emerald-50/50 dark:bg-emerald-950/20"
+                  : "border-neutral-300 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+              }`}
+            >
+              <input
+                type="radio"
+                name={name}
+                checked={selected}
+                onChange={() => onChange(option.audience)}
+                className="mt-0.5 h-4 w-4 shrink-0 border-neutral-300 text-emerald-600 focus:ring-emerald-600/50 dark:border-neutral-700"
+              />
+              <span>
+                <span className="block text-sm font-medium">
+                  {option.label}
+                </span>
+                <span className="block text-xs text-neutral-500 dark:text-neutral-500">
+                  {option.description}
+                </span>
+              </span>
+            </label>
+          );
+        })}
+      </div>
+      {permanenceNotice && (
+        <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+          {permanenceNotice}
+        </p>
+      )}
+    </fieldset>
+  );
+}

--- a/components/AudienceSelector.tsx
+++ b/components/AudienceSelector.tsx
@@ -9,6 +9,7 @@ export function AudienceSelector({
   value,
   onChange,
   permanenceNotice,
+  showPublicOption,
 }: {
   legend: string;
   teams: Array<{ id: string; name: string }>;
@@ -16,6 +17,14 @@ export function AudienceSelector({
   onChange: (audience: Audience) => void;
   /** Shown as a plain-language warning right where the choice is made - e.g. exercises are immutable, this is exercise-only. */
   permanenceNotice?: string;
+  /**
+   * Exercises: true, always - public exercises genuinely surface in the
+   * shared library. Workouts: false - workouts.is_public exists as a
+   * column but nothing reads it yet (no SELECT RLS grant, no browsing
+   * view), so offering it would let a coach pick an option that silently
+   * does nothing.
+   */
+  showPublicOption: boolean;
 }) {
   const name = useId();
 
@@ -33,12 +42,16 @@ export function AudienceSelector({
         label: team.name,
         description: "Widoczne dla sztabu tej drużyny.",
       })),
-      {
-        key: "public",
-        audience: { kind: "public" },
-        label: "Biblioteka publiczna",
-        description: "Widoczne dla wszystkich trenerów w Coach Zone.",
-      },
+      ...(showPublicOption
+        ? [
+            {
+              key: "public",
+              audience: { kind: "public" } as Audience,
+              label: "Biblioteka publiczna",
+              description: "Widoczne dla wszystkich trenerów w Coach Zone.",
+            },
+          ]
+        : []),
     ];
 
   return (

--- a/components/exercises/AuthorBadge.tsx
+++ b/components/exercises/AuthorBadge.tsx
@@ -1,15 +1,21 @@
+import type { PublicProfile } from "@/lib/supabase/types";
+import { ROLE_LABELS } from "@/lib/teams";
+
 // Renders ONLY the coach's pseudonym - never an email or author_id. See
 // supabase/migrations/20260712100000_coach_pseudonyms.sql: other coaches'
 // attribution is only ever available via list_public_profiles(), which
-// returns id + display_name and nothing else.
+// returns id + display_name (+ team_roles) and nothing else.
 export function AuthorBadge({
   authorId,
   currentUserId,
   authorsById,
+  teamId,
 }: {
   authorId: string | null;
   currentUserId: string | null | undefined;
-  authorsById: Map<string, { display_name: string }>;
+  authorsById: Map<string, PublicProfile>;
+  /** The item's team_id, to resolve whether the author is head coach or assistant *in that team*. Omit/null for non-team-scoped items. */
+  teamId?: string | null;
 }) {
   if (authorId === null) {
     return (
@@ -27,11 +33,20 @@ export function AuthorBadge({
     );
   }
 
-  const pseudonym = authorsById.get(authorId)?.display_name ?? "Inny trener";
+  const author = authorsById.get(authorId);
+  const pseudonym = author?.display_name ?? "Inny trener";
+  const role = teamId
+    ? author?.team_roles.find((entry) => entry.team_id === teamId)?.role
+    : undefined;
 
   return (
     <span className="inline-flex items-center rounded-full border border-neutral-200 bg-neutral-50 px-2.5 py-0.5 text-xs font-medium text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300">
       {pseudonym}
+      {role && (
+        <span className="text-neutral-400 dark:text-neutral-500">
+          &nbsp;· {ROLE_LABELS[role]}
+        </span>
+      )}
     </span>
   );
 }

--- a/components/exercises/ExerciseCard.tsx
+++ b/components/exercises/ExerciseCard.tsx
@@ -48,6 +48,7 @@ export function ExerciseCard({
           authorId={exercise.author_id}
           currentUserId={currentUserId}
           authorsById={authorsById}
+          teamId={exercise.team_id}
         />
       </div>
 

--- a/components/exercises/ExerciseForm.tsx
+++ b/components/exercises/ExerciseForm.tsx
@@ -2,11 +2,13 @@
 
 import { useRouter } from "next/navigation";
 import { useRef, useState, type FormEvent, type KeyboardEvent } from "react";
+import { AudienceSelector } from "@/components/AudienceSelector";
 import { FormBanner } from "@/components/auth/FormBanner";
 import { FormField } from "@/components/auth/FormField";
 import { SubmitButton } from "@/components/auth/SubmitButton";
 import type { TacticsBoardHandle } from "@/components/board/TacticsBoard";
 import { TacticsBoardLoader } from "@/components/board/TacticsBoardLoader";
+import { audienceToFields, defaultAudience, type Audience } from "@/lib/audience";
 import { DIFFICULTY_LABELS, DIFFICULTY_OPTIONS } from "@/lib/exercises";
 import type { BoardElement } from "@/lib/board/types";
 import { createClient } from "@/lib/supabase/client";
@@ -22,6 +24,7 @@ import { SaveExerciseDialog } from "./SaveExerciseDialog";
 interface ExerciseFormProps {
   categories: Category[];
   sports: Sport[];
+  teams: Array<{ id: string; name: string }>;
   userId: string;
   /** Set when opened via "Duplikuj" on an existing exercise - prefills every field, including the board. */
   duplicateFrom?: Exercise | null;
@@ -56,6 +59,7 @@ function boardElementsOf(
 export function ExerciseForm({
   categories,
   sports,
+  teams,
   userId,
   duplicateFrom,
 }: ExerciseFormProps) {
@@ -94,7 +98,9 @@ export function ExerciseForm({
     duplicateFrom?.equipment ?? [],
   );
   const [equipmentInput, setEquipmentInput] = useState("");
-  const [keepPrivate, setKeepPrivate] = useState(false);
+  const [audience, setAudience] = useState<Audience>(() =>
+    defaultAudience(teams),
+  );
 
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [formError, setFormError] = useState<string | null>(null);
@@ -217,7 +223,7 @@ export function ExerciseForm({
       media_url: mediaUrl,
       board_state: boardElements as unknown as Json,
       board_field_mode: boardFieldMode,
-      is_public: !keepPrivate,
+      ...audienceToFields(audience),
     };
 
     const { data, error } = await supabase
@@ -450,15 +456,13 @@ export function ExerciseForm({
           )}
         </div>
 
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={keepPrivate}
-            onChange={(e) => setKeepPrivate(e.target.checked)}
-            className="h-4 w-4 rounded border-neutral-300 text-emerald-600 focus:ring-emerald-600/50 dark:border-neutral-700"
-          />
-          Zachowaj jako prywatne (nie udostępniaj innym trenerom)
-        </label>
+        <AudienceSelector
+          legend="Dla kogo jest to ćwiczenie?"
+          teams={teams}
+          value={audience}
+          onChange={setAudience}
+          permanenceNotice="Ćwiczenia są niezmienne — tej decyzji nie da się później zmienić. Żeby ją poprawić, zduplikujesz ćwiczenie i zapiszesz je jako nowe."
+        />
 
         <SubmitButton loading={saving} loadingText="Zapisywanie…">
           Dodaj ćwiczenie
@@ -467,7 +471,13 @@ export function ExerciseForm({
 
       {confirmOpen && (
         <SaveExerciseDialog
-          isPublic={!keepPrivate}
+          audience={audience}
+          teamName={
+            audience.kind === "team"
+              ? (teams.find((team) => team.id === audience.teamId)?.name ??
+                "drużyny")
+              : undefined
+          }
           saving={saving}
           onConfirm={handleConfirmSave}
           onCancel={() => setConfirmOpen(false)}

--- a/components/exercises/ExerciseForm.tsx
+++ b/components/exercises/ExerciseForm.tsx
@@ -462,6 +462,7 @@ export function ExerciseForm({
           value={audience}
           onChange={setAudience}
           permanenceNotice="Ćwiczenia są niezmienne — tej decyzji nie da się później zmienić. Żeby ją poprawić, zduplikujesz ćwiczenie i zapiszesz je jako nowe."
+          showPublicOption
         />
 
         <SubmitButton loading={saving} loadingText="Zapisywanie…">

--- a/components/exercises/ExercisesLibrary.tsx
+++ b/components/exercises/ExercisesLibrary.tsx
@@ -14,6 +14,7 @@ import type {
   Sport,
 } from "@/lib/supabase/types";
 import { DIFFICULTY_LABELS, DIFFICULTY_OPTIONS } from "@/lib/exercises";
+import { isInActiveTeamScope } from "@/lib/teams";
 import { ExerciseCard } from "./ExerciseCard";
 import { ExerciseCardSkeleton } from "./ExerciseCardSkeleton";
 
@@ -24,10 +25,12 @@ export function ExercisesLibrary({
   categories,
   sports,
   currentUserId,
+  activeTeamId,
 }: {
   categories: Category[];
   sports: Sport[];
   currentUserId: string | null;
+  activeTeamId: string | null;
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -206,6 +209,9 @@ export function ExercisesLibrary({
       }
       if (scopeFilter === MINE && exercise.author_id !== currentUserId)
         return false;
+      // Team-scoped content only shows while its team is the active one;
+      // personal/public exercises (team_id null) are never gated by this.
+      if (!isInActiveTeamScope(exercise, activeTeamId)) return false;
       // sport_id === null means the exercise is universal, so it must match
       // every sport filter, not just "all".
       if (
@@ -238,6 +244,7 @@ export function ExercisesLibrary({
     search,
     scopeFilter,
     currentUserId,
+    activeTeamId,
     sportFilter,
     categoryFilter,
     difficultyFilter,

--- a/components/exercises/SaveExerciseDialog.tsx
+++ b/components/exercises/SaveExerciseDialog.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import type { Audience } from "@/lib/audience";
+
 export function SaveExerciseDialog({
-  isPublic,
+  audience,
+  teamName,
   saving,
   onConfirm,
   onCancel,
 }: {
-  isPublic: boolean;
+  audience: Audience;
+  /** The team's display name - only read when audience.kind === "team". */
+  teamName?: string;
   saving: boolean;
   onConfirm: () => void;
   onCancel: () => void;
@@ -35,13 +40,20 @@ export function SaveExerciseDialog({
             Aby cokolwiek zmienić, będziesz musiał je zduplikować i zapisać jako
             nowe ćwiczenie.
           </li>
-          {isPublic ? (
+          {audience.kind === "public" && (
             <li>
               Ćwiczenie będzie <strong>publiczne</strong> — trafi do wspólnej
               biblioteki i zobaczą je inni trenerzy. Publicznego ćwiczenia{" "}
               <strong>nie da się usunąć</strong>.
             </li>
-          ) : (
+          )}
+          {audience.kind === "team" && (
+            <li>
+              Ćwiczenie będzie widoczne dla <strong>{teamName}</strong> —
+              zobaczy je Twój sztab szkoleniowy. Nadal będziesz mógł je usunąć.
+            </li>
+          )}
+          {audience.kind === "personal" && (
             <li>
               Ćwiczenie będzie <strong>prywatne</strong> — widoczne tylko dla
               Ciebie. Prywatne ćwiczenie można później usunąć.

--- a/components/team/TeamCard.tsx
+++ b/components/team/TeamCard.tsx
@@ -1,11 +1,7 @@
 import type { PublicProfile, Team, TeamInvite, TeamMember } from "@/lib/supabase/types";
+import { ROLE_LABELS } from "@/lib/teams";
 import { InvitesPanel } from "./InvitesPanel";
 import { RemoveMemberButton } from "./RemoveMemberButton";
-
-const ROLE_LABELS: Record<TeamMember["role"], string> = {
-  head_coach: "Główny trener",
-  assistant_coach: "Asystent",
-};
 
 export function TeamCard({
   team,

--- a/components/team/TeamSwitcher.tsx
+++ b/components/team/TeamSwitcher.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { TeamRole } from "@/lib/supabase/types";
+import { ROLE_LABELS, resolveActiveTeamId } from "@/lib/teams";
+
+interface SwitcherTeam {
+  id: string;
+  name: string;
+  short_name: string;
+  role: TeamRole;
+}
+
+const badgeClasses =
+  "inline-flex shrink-0 items-center gap-1.5 rounded-full border border-neutral-300 px-3 py-1 text-xs font-medium transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900";
+
+function ActiveDot() {
+  return (
+    <span
+      aria-hidden="true"
+      className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
+    />
+  );
+}
+
+// Lives to the right of the logo lockup in the app header. Three states:
+// no team (an affordance, not an error - the app works fine without one),
+// exactly one team (a badge with nothing to switch to, so no chevron), and
+// several (a dropdown). Writes profiles.active_team_id directly - it's
+// already owner-only via RLS, no new permission needed - and persists
+// server-side on purpose: a coach opening the app on their phone at the
+// training ground should already be in the right team's context.
+export function TeamSwitcher({
+  userId,
+  teams,
+  activeTeamId,
+}: {
+  userId: string;
+  teams: SwitcherTeam[];
+  activeTeamId: string | null;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  // Optimistic: updated immediately on click, resynced whenever the server
+  // value changes (e.g. after router.refresh()). The write still happens in
+  // the background - same "don't make the coach wait on a round trip"
+  // pattern as OnboardingOverlay's dismissal.
+  const [displayedActiveId, setDisplayedActiveId] = useState(activeTeamId);
+  const [confirmation, setConfirmation] = useState<string | null>(null);
+  const [switchError, setSwitchError] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setDisplayedActiveId(activeTeamId);
+  }, [activeTeamId]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    function handleClickOutside(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open]);
+
+  const effectiveActiveId = resolveActiveTeamId(displayedActiveId, teams);
+
+  async function handleSelect(team: SwitcherTeam) {
+    setOpen(false);
+    if (team.id === effectiveActiveId) return;
+
+    setDisplayedActiveId(team.id);
+    setSwitchError(false);
+    // Switching changes what the whole app shows, which is a large
+    // consequence for a small click - surface a brief confirmation rather
+    // than letting the content silently swap underneath the coach.
+    const message = `Przełączono na ${team.short_name}`;
+    setConfirmation(message);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("profiles")
+      .update({ active_team_id: team.id })
+      .eq("id", userId);
+
+    if (error) {
+      setDisplayedActiveId(activeTeamId);
+      setConfirmation(null);
+      setSwitchError(true);
+      return;
+    }
+
+    router.refresh();
+    setTimeout(() => {
+      setConfirmation((current) => (current === message ? null : current));
+    }, 2500);
+  }
+
+  if (teams.length === 0) {
+    return (
+      <Link
+        href="/app/team"
+        className="inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-600/40 px-3 py-1 text-xs font-medium text-emerald-600 transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950/40"
+      >
+        + Utwórz drużynę
+      </Link>
+    );
+  }
+
+  if (teams.length === 1) {
+    return (
+      <Link href="/app/team" className={badgeClasses}>
+        <ActiveDot />
+        {teams[0].short_name}
+      </Link>
+    );
+  }
+
+  const activeTeam = teams.find((team) => team.id === effectiveActiveId);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        aria-haspopup="true"
+        aria-expanded={open}
+        className={`${badgeClasses} ${open ? "bg-neutral-50 dark:bg-neutral-900" : ""}`}
+      >
+        <ActiveDot />
+        {activeTeam?.short_name ?? "Wybierz drużynę"}
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          aria-hidden="true"
+          className="shrink-0"
+        >
+          <path
+            d="M2 3.5L5 6.5L8 3.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute left-0 z-50 mt-2 w-64 rounded-xl border border-neutral-200 bg-white p-1.5 shadow-lg dark:border-neutral-800 dark:bg-neutral-900">
+          <ul className="space-y-0.5">
+            {teams.map((team) => {
+              const isActive = team.id === effectiveActiveId;
+              return (
+                <li key={team.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(team)}
+                    className={`flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-800 ${
+                      isActive ? "bg-emerald-50/60 dark:bg-emerald-950/20" : ""
+                    }`}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      {isActive && <ActiveDot />}
+                      <span className="truncate font-medium">{team.name}</span>
+                    </span>
+                    <span className="shrink-0 text-xs text-neutral-500 dark:text-neutral-500">
+                      {ROLE_LABELS[team.role]}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="mt-1 border-t border-neutral-200 pt-1 dark:border-neutral-800">
+            <Link
+              href="/app/team"
+              onClick={() => setOpen(false)}
+              className="block rounded-lg px-3 py-2 text-sm font-medium text-emerald-600 hover:bg-neutral-50 dark:hover:bg-neutral-800"
+            >
+              + Utwórz drużynę
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {confirmation && (
+        <div
+          role="status"
+          className="absolute left-0 z-50 mt-2 whitespace-nowrap rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 shadow-lg dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-400"
+        >
+          {confirmation}
+        </div>
+      )}
+      {switchError && (
+        <div
+          role="alert"
+          className="absolute left-0 z-50 mt-2 whitespace-nowrap rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-medium text-red-700 shadow-lg dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-400"
+        >
+          Nie udało się przełączyć drużyny. Spróbuj ponownie.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/workouts/CalendarView.tsx
+++ b/components/workouts/CalendarView.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { Workout } from "@/lib/supabase/types";
 import { summarizeWorkoutItems, type WorkoutStats } from "@/lib/workouts";
+import { isInActiveTeamScope } from "@/lib/teams";
 import {
   addWeeks,
   formatWeekRangeLabel,
@@ -17,7 +18,11 @@ import { CalendarDayCard } from "./CalendarDayCard";
 import { UnscheduledWorkoutCard } from "./UnscheduledWorkoutCard";
 import { WorkoutCardSkeleton } from "./WorkoutCardSkeleton";
 
-export function CalendarView() {
+export function CalendarView({
+  activeTeamId,
+}: {
+  activeTeamId: string | null;
+}) {
   const [workouts, setWorkouts] = useState<Workout[] | null>(null);
   const [stats, setStats] = useState<Record<string, WorkoutStats>>({});
   const [loadError, setLoadError] = useState(false);
@@ -72,20 +77,29 @@ export function CalendarView() {
   const today = useMemo(() => new Date(), []);
   const weekDays = useMemo(() => getWeekDays(weekStart), [weekStart]);
 
+  // Reflects the active team: with a team selected, its workouts join the
+  // coach's own; with none, only the coach's own show. RLS already returns
+  // every team the coach belongs to, not just the active one, so this
+  // narrows client-side the same way the exercise library does.
+  const visibleWorkouts = useMemo(
+    () => (workouts ?? []).filter((workout) => isInActiveTeamScope(workout, activeTeamId)),
+    [workouts, activeTeamId],
+  );
+
   const workoutsByDate = useMemo(() => {
     const map = new Map<string, Workout[]>();
-    for (const workout of workouts ?? []) {
+    for (const workout of visibleWorkouts) {
       if (!workout.scheduled_for) continue;
       const list = map.get(workout.scheduled_for) ?? [];
       list.push(workout);
       map.set(workout.scheduled_for, list);
     }
     return map;
-  }, [workouts]);
+  }, [visibleWorkouts]);
 
   const unscheduled = useMemo(
-    () => (workouts ?? []).filter((workout) => !workout.scheduled_for),
-    [workouts],
+    () => visibleWorkouts.filter((workout) => !workout.scheduled_for),
+    [visibleWorkouts],
   );
 
   function handleDateAssigned(workoutId: string, newDate: string) {

--- a/components/workouts/ExercisePicker.tsx
+++ b/components/workouts/ExercisePicker.tsx
@@ -248,6 +248,7 @@ export function ExercisePicker({
                           authorId={exercise.author_id}
                           currentUserId={currentUserId}
                           authorsById={authorsById}
+                          teamId={exercise.team_id}
                         />
                       </div>
                     </div>

--- a/components/workouts/WorkoutBasicsForm.tsx
+++ b/components/workouts/WorkoutBasicsForm.tsx
@@ -2,14 +2,21 @@
 
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
+import { AudienceSelector } from "@/components/AudienceSelector";
 import { FormBanner } from "@/components/auth/FormBanner";
 import { FormField } from "@/components/auth/FormField";
 import { SubmitButton } from "@/components/auth/SubmitButton";
+import { audienceToFields, defaultAudience, type Audience } from "@/lib/audience";
 import { createClient } from "@/lib/supabase/client";
 import type { Workout } from "@/lib/supabase/types";
 
 type WorkoutBasicsFormProps =
-  | { mode: "create"; userId: string; initialScheduledFor?: string }
+  | {
+      mode: "create";
+      userId: string;
+      teams: Array<{ id: string; name: string }>;
+      initialScheduledFor?: string;
+    }
   | {
       mode: "edit";
       workout: Workout;
@@ -38,6 +45,9 @@ export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
       (props.mode === "create" ? (props.initialScheduledFor ?? "") : ""),
   );
   const [notes, setNotes] = useState(initial?.notes ?? "");
+  const [audience, setAudience] = useState<Audience>(() =>
+    props.mode === "create" ? defaultAudience(props.teams) : { kind: "personal" },
+  );
 
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [formError, setFormError] = useState<string | null>(null);
@@ -66,7 +76,11 @@ export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
     if (props.mode === "create") {
       const { data, error } = await supabase
         .from("workouts")
-        .insert({ ...payload, owner_id: props.userId })
+        .insert({
+          ...payload,
+          owner_id: props.userId,
+          ...audienceToFields(audience),
+        })
         .select("id")
         .single();
 
@@ -138,6 +152,15 @@ export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
           className={`mt-1.5 ${fieldClasses()}`}
         />
       </div>
+
+      {props.mode === "create" && (
+        <AudienceSelector
+          legend="Dla kogo jest ten trening?"
+          teams={props.teams}
+          value={audience}
+          onChange={setAudience}
+        />
+      )}
 
       <div className="flex items-center gap-3">
         <div className="flex-1">

--- a/components/workouts/WorkoutBasicsForm.tsx
+++ b/components/workouts/WorkoutBasicsForm.tsx
@@ -159,6 +159,7 @@ export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
           teams={props.teams}
           value={audience}
           onChange={setAudience}
+          showPublicOption={false}
         />
       )}
 

--- a/lib/audience.test.ts
+++ b/lib/audience.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { audienceEquals, audienceToFields, defaultAudience } from "./audience";
+
+describe("audienceToFields", () => {
+  it("personal writes is_public false and a null team_id", () => {
+    expect(audienceToFields({ kind: "personal" })).toEqual({
+      is_public: false,
+      team_id: null,
+    });
+  });
+
+  it("team writes is_public false and that team's id", () => {
+    expect(audienceToFields({ kind: "team", teamId: "team-1" })).toEqual({
+      is_public: false,
+      team_id: "team-1",
+    });
+  });
+
+  it("public writes is_public true and a null team_id", () => {
+    expect(audienceToFields({ kind: "public" })).toEqual({
+      is_public: true,
+      team_id: null,
+    });
+  });
+});
+
+describe("defaultAudience", () => {
+  it("defaults to personal with no teams", () => {
+    expect(defaultAudience([])).toEqual({ kind: "personal" });
+  });
+
+  it("defaults to the sole team when exactly one exists", () => {
+    expect(defaultAudience([{ id: "team-1" }])).toEqual({
+      kind: "team",
+      teamId: "team-1",
+    });
+  });
+
+  it("does not guess which team when there are several", () => {
+    expect(defaultAudience([{ id: "team-1" }, { id: "team-2" }])).toEqual({
+      kind: "personal",
+    });
+  });
+});
+
+describe("audienceEquals", () => {
+  it("treats two personal values as equal", () => {
+    expect(audienceEquals({ kind: "personal" }, { kind: "personal" })).toBe(
+      true,
+    );
+  });
+
+  it("compares team audiences by teamId", () => {
+    expect(
+      audienceEquals(
+        { kind: "team", teamId: "team-1" },
+        { kind: "team", teamId: "team-1" },
+      ),
+    ).toBe(true);
+    expect(
+      audienceEquals(
+        { kind: "team", teamId: "team-1" },
+        { kind: "team", teamId: "team-2" },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats different kinds as unequal", () => {
+    expect(audienceEquals({ kind: "personal" }, { kind: "public" })).toBe(
+      false,
+    );
+  });
+});

--- a/lib/audience.ts
+++ b/lib/audience.ts
@@ -1,0 +1,39 @@
+// "Who is this for" - the mutually exclusive choice shared by ExerciseForm
+// and WorkoutBasicsForm's create mode. Both resolve to the same
+// is_public/team_id pair (see
+// supabase/migrations/20260728133850_team_support.sql and
+// supabase/migrations/20260729101005_workouts_is_public.sql), so the
+// conversion lives here once instead of in each form.
+export type Audience =
+  | { kind: "personal" }
+  | { kind: "team"; teamId: string }
+  | { kind: "public" };
+
+export function audienceToFields(audience: Audience): {
+  is_public: boolean;
+  team_id: string | null;
+} {
+  switch (audience.kind) {
+    case "public":
+      return { is_public: true, team_id: null };
+    case "team":
+      return { is_public: false, team_id: audience.teamId };
+    case "personal":
+      return { is_public: false, team_id: null };
+  }
+}
+
+export function audienceEquals(a: Audience, b: Audience): boolean {
+  if (a.kind !== b.kind) return false;
+  return a.kind === "team" && b.kind === "team" ? a.teamId === b.teamId : true;
+}
+
+// A coach in a staff shares with the staff by default, not hoarded - but
+// only when there's exactly one team to default to. With zero or several
+// teams there's no single obvious choice, so default to personal and make
+// the coach choose explicitly (this choice is permanent for exercises).
+export function defaultAudience(teams: { id: string }[]): Audience {
+  return teams.length === 1
+    ? { kind: "team", teamId: teams[0].id }
+    : { kind: "personal" };
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -12,6 +12,14 @@ export type WorkoutSection = "warmup" | "main" | "positional" | "cooldown";
 
 export type TeamRole = "head_coach" | "assistant_coach";
 
+// One entry per team the caller shares with that profile - see
+// list_public_profiles() in
+// supabase/migrations/20260729101241_list_public_profiles_team_roles.sql.
+export interface TeamRoleEntry {
+  team_id: string;
+  role: TeamRole;
+}
+
 export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.5";
@@ -192,6 +200,7 @@ export type Database = {
       };
       profiles: {
         Row: {
+          active_team_id: string | null;
           avatar_url: string | null;
           club_name: string | null;
           created_at: string;
@@ -200,6 +209,7 @@ export type Database = {
           onboarding_completed: boolean;
         };
         Insert: {
+          active_team_id?: string | null;
           avatar_url?: string | null;
           club_name?: string | null;
           created_at?: string;
@@ -208,6 +218,7 @@ export type Database = {
           onboarding_completed?: boolean;
         };
         Update: {
+          active_team_id?: string | null;
           avatar_url?: string | null;
           club_name?: string | null;
           created_at?: string;
@@ -215,7 +226,15 @@ export type Database = {
           id?: string;
           onboarding_completed?: boolean;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "profiles_active_team_id_fkey";
+            columns: ["active_team_id"];
+            isOneToOne: false;
+            referencedRelation: "teams";
+            referencedColumns: ["id"];
+          },
+        ];
       };
       sports: {
         Row: {
@@ -400,6 +419,7 @@ export type Database = {
         Row: {
           created_at: string;
           id: string;
+          is_public: boolean;
           notes: string | null;
           owner_id: string;
           scheduled_for: string | null;
@@ -411,6 +431,7 @@ export type Database = {
         Insert: {
           created_at?: string;
           id?: string;
+          is_public?: boolean;
           notes?: string | null;
           owner_id: string;
           scheduled_for?: string | null;
@@ -422,6 +443,7 @@ export type Database = {
         Update: {
           created_at?: string;
           id?: string;
+          is_public?: boolean;
           notes?: string | null;
           owner_id?: string;
           scheduled_for?: string | null;
@@ -471,6 +493,7 @@ export type Database = {
         Returns: {
           display_name: string;
           id: string;
+          team_roles: TeamRoleEntry[];
         }[];
       };
       my_team_ids: { Args: never; Returns: string[] };
@@ -622,10 +645,14 @@ export type TeamInvite = Database["public"]["Tables"]["team_invites"]["Row"];
 // Shape returned by the list_public_profiles() RPC - the only channel
 // through which a coach can see another coach's attribution (see
 // supabase/migrations/20260712100000_coach_pseudonyms.sql). Never carries
-// email, club_name, or avatar_url.
+// email, club_name, or avatar_url. team_roles only ever lists teams shared
+// with the caller (see
+// supabase/migrations/20260729101241_list_public_profiles_team_roles.sql),
+// not every team the profile belongs to.
 export interface PublicProfile {
   id: string;
   display_name: string;
+  team_roles: TeamRoleEntry[];
 }
 
 // Shape returned by the get_shared_workout() RPC (see

--- a/lib/teams.test.ts
+++ b/lib/teams.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isInActiveTeamScope, resolveActiveTeamId } from "./teams";
+
+describe("resolveActiveTeamId", () => {
+  it("returns null with no teams and no active_team_id", () => {
+    expect(resolveActiveTeamId(null, [])).toBeNull();
+  });
+
+  it("falls back to the sole team when active_team_id was never set", () => {
+    expect(resolveActiveTeamId(null, [{ id: "team-1" }])).toBe("team-1");
+  });
+
+  it("does not guess when there are several teams and none is active", () => {
+    expect(
+      resolveActiveTeamId(null, [{ id: "team-1" }, { id: "team-2" }]),
+    ).toBeNull();
+  });
+
+  it("prefers the stored active_team_id over the sole-team fallback", () => {
+    expect(resolveActiveTeamId("team-9", [{ id: "team-1" }])).toBe("team-9");
+  });
+});
+
+describe("isInActiveTeamScope", () => {
+  it("always shows a personal/public item (team_id null), active team or not", () => {
+    expect(isInActiveTeamScope({ team_id: null }, null)).toBe(true);
+    expect(isInActiveTeamScope({ team_id: null }, "team-1")).toBe(true);
+  });
+
+  it("shows a team-scoped item only while that team is active", () => {
+    expect(isInActiveTeamScope({ team_id: "team-1" }, "team-1")).toBe(true);
+    expect(isInActiveTeamScope({ team_id: "team-1" }, "team-2")).toBe(false);
+  });
+
+  it("hides a team-scoped item when no team is active - the exact-match bug the sport filter already hit once", () => {
+    expect(isInActiveTeamScope({ team_id: "team-1" }, null)).toBe(false);
+  });
+});

--- a/lib/teams.ts
+++ b/lib/teams.ts
@@ -1,0 +1,34 @@
+import type { TeamRole } from "@/lib/supabase/types";
+
+export const ROLE_LABELS: Record<TeamRole, string> = {
+  head_coach: "Główny trener",
+  assistant_coach: "Asystent",
+};
+
+// The library and calendar (and the switcher itself) all need "which team
+// is active", but active_team_id can be null even when a coach has exactly
+// one team - nothing ever prompts them to choose when there's no real
+// choice (see TeamSwitcher: a lone team gets no chevron, so there is no
+// control that would write active_team_id for it). Treat that sole team as
+// effectively active everywhere this matters, without ever writing it back.
+export function resolveActiveTeamId(
+  activeTeamId: string | null,
+  teams: { id: string }[],
+): string | null {
+  if (activeTeamId) return activeTeamId;
+  return teams.length === 1 ? teams[0].id : null;
+}
+
+// Shared by the exercise library and the workout calendar: an item scoped
+// to a team (team_id set) is only in scope while that team is active. An
+// item with no team (personal or public) is never gated by team context -
+// mirrors the existing sport filter's "sport_id === null is universal"
+// guard, so this doesn't repeat that bug (an exact-match-only comparison
+// would wrongly hide every personal/public item whenever a team is active,
+// since their team_id is null and null !== activeTeamId).
+export function isInActiveTeamScope(
+  item: { team_id: string | null },
+  activeTeamId: string | null,
+): boolean {
+  return item.team_id === null || item.team_id === activeTeamId;
+}

--- a/supabase/migrations/20260729093052_profiles_active_team.sql
+++ b/supabase/migrations/20260729093052_profiles_active_team.sql
@@ -1,0 +1,18 @@
+alter table public.profiles
+  add column if not exists active_team_id uuid references public.teams(id) on delete set null;
+
+comment on column public.profiles.active_team_id is
+  'Ostatnio wybrana druzyna. NULL = kontekst osobisty (trener bez druzyny lub swiadomie poza nia).';
+
+create or replace function public.clear_active_team_on_leave()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  update public.profiles
+     set active_team_id = null
+   where id = old.user_id and active_team_id = old.team_id;
+  return old;
+end $$;
+
+drop trigger if exists team_members_clear_active on public.team_members;
+create trigger team_members_clear_active after delete on public.team_members
+  for each row execute function public.clear_active_team_on_leave();

--- a/supabase/migrations/20260729101005_workouts_is_public.sql
+++ b/supabase/migrations/20260729101005_workouts_is_public.sql
@@ -1,0 +1,20 @@
+-- Coach Zone — workout audience selector, part 1: schema
+--
+-- Workouts have no visibility concept today, only owner_id and the public
+-- share link (share_id). WorkoutBasicsForm is getting the same "who is this
+-- for" control as ExerciseForm (personal / team / public library), so it
+-- needs somewhere to write the "public" choice - team_id already exists
+-- (added for exercises and workouts together in 20260728133850_team_support.sql).
+--
+-- Select RLS is deliberately left unchanged (owner_id = auth.uid() OR
+-- team_id in my_team_ids()): there is no page yet that browses public
+-- workouts across coaches, so broadening it now would just leak other
+-- coaches' public workouts into "Twoje treningi" and the calendar, both of
+-- which trust RLS alone to scope their unfiltered `select("*")` queries to
+-- "mine". Wiring that up is future work, same as team_id was schema-only
+-- until this round.
+alter table public.workouts
+  add column if not exists is_public boolean not null default false;
+
+comment on column public.workouts.is_public is
+  'Analogicznie do exercises.is_public - pisane przez audience selector w WorkoutBasicsForm. Select RLS pozostaje owner/team: nie ma jeszcze widoku przegladania publicznych treningow innych trenerow.';

--- a/supabase/migrations/20260729101241_list_public_profiles_team_roles.sql
+++ b/supabase/migrations/20260729101241_list_public_profiles_team_roles.sql
@@ -1,0 +1,43 @@
+-- Coach Zone — teammate attribution, part 1: list_public_profiles()
+--
+-- AuthorBadge needs to show whether a teammate's exercise came from the
+-- head coach or an assistant. list_public_profiles() is the only channel
+-- through which one coach can see another's attribution (see
+-- 20260712100000_coach_pseudonyms.sql), so it gains a team_roles column
+-- rather than a second RPC.
+--
+-- team_roles is scoped to teams the caller shares with that profile (via
+-- my_team_ids()), not every team the profile belongs to - the function
+-- already exposes id + display_name for every profile globally, but their
+-- full team membership graph is not this feature's business to expose.
+-- One row per profile is kept (team_roles is a jsonb array) so existing
+-- `authorsById.set(author.id, author)` map-building call sites keep working
+-- unchanged.
+--
+-- Postgres cannot CREATE OR REPLACE a function while changing its
+-- RETURNS TABLE column set, so the old signature must be dropped first.
+drop function if exists public.list_public_profiles();
+
+create function public.list_public_profiles()
+returns table (id uuid, display_name text, team_roles jsonb)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select
+    p.id,
+    p.display_name,
+    coalesce(
+      jsonb_agg(jsonb_build_object('team_id', tm.team_id, 'role', tm.role))
+        filter (where tm.team_id is not null),
+      '[]'::jsonb
+    ) as team_roles
+  from public.profiles p
+  left join public.team_members tm
+    on tm.user_id = p.id
+   and tm.team_id in (select public.my_team_ids())
+  group by p.id, p.display_name;
+$$;
+
+grant execute on function public.list_public_profiles() to authenticated;


### PR DESCRIPTION
## Summary

Round A built the team schema, permissions, invites, and the team page, but nothing wrote `team_id` yet — every exercise and workout was still personal. This wires the team context through the rest of the app.

- **Migration, committed verbatim**: `profiles.active_team_id` + the clear-on-leave trigger, already applied to production (`20260729093052_profiles_active_team.sql`). Types regenerated from the live database via the Supabase MCP rather than hand-edited.
- **Two more migrations this round adds**: `workouts.is_public` (workouts had no visibility concept at all before — only `owner_id` and the share link), and `list_public_profiles()` extended with `team_roles` (scoped to teams shared with the caller) so attribution can show head coach vs. assistant.
- **Team switcher**, header, right of the logo. Three states: no team → `+ Utwórz drużynę` affordance; exactly one team → short name badge, no chevron; several → short name + chevron opening a dropdown of full name + role per team, with `+ Utwórz drużynę` at the foot. An emerald-500 dot marks the active context. Writes `profiles.active_team_id` (owner-only RLS already covers it), shows a brief confirmation before refreshing rather than silently swapping the app's content underneath the coach. Wordmark collapses to the mark alone below `sm` so the switcher has room.
- **Audience selector**, shared component: "Tylko ja" / one option per team / "Biblioteka publiczna", replacing `ExerciseForm`'s old private-only checkbox. Defaults to the sole team when there's exactly one (share with the staff by default), personal otherwise — no guessing among several. `SaveExerciseDialog` now explains all three outcomes, since the choice is permanent for exercises (no UPDATE policy). `WorkoutBasicsForm`'s create mode gets the same control, but with the public option withheld (see scope note below).
- **Filtering**: the exercise library and the workout calendar now narrow to the active team client-side (RLS already returns every team a coach belongs to, not just the active one). Reuses the same "team_id null passes through untouched" guard shape as the sport filter's existing bug fix, rather than repeating an exact-match mistake.
- **Attribution**: `AuthorBadge` now takes the item's `team_id` and shows the teammate's role in that team (e.g. "Jan · Główny trener"), fed by the two-part `list_public_profiles()` + `AuthorBadge` change, same fetch-once/build-map/pass-down plumbing as before.
- **Two fixes**: added the missing `/app/team` nav link, and moved the onboarding-overlay check from the home page into the app layout so it fires on first entry to anything under `/app` (an invited assistant landing on `/app/team` no longer skips it).

## Scope notes for review

- **Public workouts are deferred.** `workouts.is_public` exists as a column (the audience selector's underlying model needs a way to represent "public" distinctly from "personal"), but `WorkoutBasicsForm`'s selector only offers "Tylko ja" and the team choices — the public option is deliberately withheld via `AudienceSelector`'s `showPublicOption={false}`. SELECT RLS on `workouts` is still owner-or-team only, and there's no view that browses other coaches' public workouts, so offering "Biblioteka publiczna" there would let a coach pick an option that silently does nothing. `ExerciseForm` keeps all three options (`showPublicOption={true}`), since public exercises genuinely surface in the shared library today. Broadening workout visibility and building a browsing view is future work, same as `team_id` was schema-only until this round.
- Team-based filtering is applied to the exercise library and the calendar, matching the task's explicit scope (and where the sport-filter bug it's asked to avoid repeating actually lives). `WorkoutsList` and `ExercisePicker` are left as-is.
- The audience selector's default-to-sole-team rule is literally "exactly one team", not "the active team" — with 2+ teams the choice is always explicit, since guessing wrong on an exercise can't be undone.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (45 tests, including new coverage for `lib/audience.ts` and `lib/teams.ts`), `pnpm build` all pass
- [x] Verified via Playwright that the public pages (`/`, `/login`, `/signup`) render with no console errors
- [ ] Could not exercise the logged-in flows (switcher states, audience selector, filtering) in a live browser in this sandbox — outbound HTTPS to the Supabase project host is blocked by this session's egress policy (confirmed via the proxy's own failure log, a 403 policy denial), so only the pre-authorized Supabase MCP channel could reach it. Would appreciate a manual click-through before merge.
