### PR TITLE
Fix team-creation dead end; enable team co-editing of workouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/app/app/team/new/loading.tsx
+++ b/app/app/team/new/loading.tsx
@@ -1,0 +1,18 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <div className="h-8 w-48 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+
+      <div className="mt-8 max-w-md space-y-5">
+        <div className="h-6 w-40 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        <div className="h-4 w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+        {Array.from({ length: 2 }, (_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="h-3.5 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-10 w-full animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/app/team/new/page.tsx
+++ b/app/app/team/new/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { CreateTeamForm } from "@/components/team/CreateTeamForm";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Nowa drużyna — Coach Zone",
+};
+
+export default async function NewTeamPage() {
+  const supabase = await createClient();
+  const { data: userData } = await supabase.auth.getUser();
+
+  // Middleware already guarantees a user for any /app/* route; this is a
+  // defensive fallback since userId below is required for the insert.
+  if (!userData.user) {
+    redirect("/login");
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 pt-8 pb-20">
+      <h1 className="text-3xl font-bold tracking-tight">Nowa drużyna</h1>
+      <div className="mt-8 max-w-md">
+        <CreateTeamForm userId={userData.user.id} />
+      </div>
+    </main>
+  );
+}

--- a/app/app/workouts/[id]/page.tsx
+++ b/app/app/workouts/[id]/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { WorkoutBuilder } from "@/components/workouts/WorkoutBuilder";
 import type { Exercise } from "@/lib/supabase/types";
+import { canDeleteWorkout } from "@/lib/workouts";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -17,6 +19,16 @@ export default async function WorkoutBuilderPage({
 }) {
   const { id } = await params;
   const supabase = await createClient();
+
+  const { data: userData } = await supabase.auth.getUser();
+
+  // Middleware already guarantees a user for any /app/* route; this is a
+  // defensive fallback, matching the other /app pages. currentUserId below
+  // has to be a real id - it's written as last_edited_by on every save.
+  if (!userData.user) {
+    redirect("/login");
+  }
+  const currentUserId = userData.user.id;
 
   const [
     { data: workout, error: workoutError },
@@ -56,14 +68,33 @@ export default async function WorkoutBuilderPage({
   const exerciseIds = Array.from(
     new Set((items ?? []).map((item) => item.exercise_id)),
   );
-  const { data: exercises } =
+  // RLS (is_team_member) already scopes this to a team the caller belongs
+  // to - only reachable at all when workout.team_id is set, since that's
+  // the only case canDeleteWorkout below needs a role for.
+  const [{ data: exercises }, { data: membership }] = await Promise.all([
     exerciseIds.length > 0
-      ? await supabase.from("exercises").select("*").in("id", exerciseIds)
-      : { data: [] as Exercise[] };
+      ? supabase.from("exercises").select("*").in("id", exerciseIds)
+      : Promise.resolve({ data: [] as Exercise[] }),
+    workout.team_id
+      ? supabase
+          .from("team_members")
+          .select("role")
+          .eq("team_id", workout.team_id)
+          .eq("user_id", currentUserId)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+  ]);
 
   const exercisesById = Object.fromEntries(
     (exercises ?? []).map((exercise) => [exercise.id, exercise]),
   );
+
+  const canDelete = canDeleteWorkout({
+    ownerId: workout.owner_id,
+    teamId: workout.team_id,
+    currentUserId,
+    isHeadCoach: membership?.role === "head_coach",
+  });
 
   return (
     <WorkoutBuilder
@@ -71,6 +102,8 @@ export default async function WorkoutBuilderPage({
       initialItems={items ?? []}
       initialExercisesById={exercisesById}
       categories={categories ?? []}
+      currentUserId={currentUserId}
+      canDelete={canDelete}
     />
   );
 }

--- a/components/team/CreateTeamForm.tsx
+++ b/components/team/CreateTeamForm.tsx
@@ -16,13 +16,7 @@ interface FieldErrors {
 // is the source of truth, this is only a fast client-side check.
 const SHORT_NAME_PATTERN = /^.{2,6}$/;
 
-export function CreateTeamForm({
-  userId,
-  onCreated,
-}: {
-  userId: string;
-  onCreated: () => void;
-}) {
+export function CreateTeamForm({ userId }: { userId: string }) {
   const router = useRouter();
   const [name, setName] = useState("");
   const [shortName, setShortName] = useState("");
@@ -79,11 +73,11 @@ export function CreateTeamForm({
       .eq("id", userId);
 
     setSaving(false);
-    // onCreated() below only refetches this client component's own state -
-    // the header reads profile/team data through the server-rendered
-    // layout, which router.refresh() is what actually invalidates.
+    // /app/team re-fetches its own team list on navigation; router.refresh()
+    // is what invalidates the server-rendered header/switcher so it picks
+    // up the new active_team_id instead of showing the pre-creation state.
+    router.push("/app/team");
     router.refresh();
-    onCreated();
   }
 
   return (

--- a/components/team/TeamManager.tsx
+++ b/components/team/TeamManager.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type {
@@ -8,7 +9,6 @@ import type {
   TeamInvite,
   TeamMember,
 } from "@/lib/supabase/types";
-import { CreateTeamForm } from "./CreateTeamForm";
 import { TeamCard } from "./TeamCard";
 
 export function TeamManager({ userId }: { userId: string }) {
@@ -115,14 +115,30 @@ export function TeamManager({ userId }: { userId: string }) {
 
   if (teams.length === 0) {
     return (
-      <div className="max-w-md">
-        <CreateTeamForm userId={userId} onCreated={refresh} />
+      <div className="max-w-md rounded-2xl border border-neutral-200 p-8 text-center dark:border-neutral-800">
+        <p className="text-neutral-600 dark:text-neutral-400">
+          Nie masz jeszcze żadnej drużyny — załóż pierwszą.
+        </p>
+        <Link
+          href="/app/team/new"
+          className="mt-3 inline-block text-sm font-medium text-emerald-600 hover:text-emerald-500"
+        >
+          Załóż pierwszą drużynę →
+        </Link>
       </div>
     );
   }
 
   return (
     <div className="space-y-6">
+      <div className="flex justify-end">
+        <Link
+          href="/app/team/new"
+          className="rounded-full bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          + Nowa drużyna
+        </Link>
+      </div>
       {teams.map((team) => (
         <TeamCard
           key={team.id}

--- a/components/team/TeamSwitcher.tsx
+++ b/components/team/TeamSwitcher.tsx
@@ -151,7 +151,7 @@ export function TeamSwitcher({
   if (teams.length === 0) {
     return (
       <Link
-        href="/app/team"
+        href="/app/team/new"
         aria-label="Utwórz drużynę"
         className="inline-flex shrink-0 items-center gap-2 rounded-xl border-2 border-dashed border-neutral-300 p-1 text-sm font-medium text-neutral-500 transition-colors hover:border-emerald-500/60 hover:text-emerald-600 sm:pr-3 dark:border-neutral-700 dark:text-neutral-400 dark:hover:border-emerald-500/50 dark:hover:text-emerald-500"
       >
@@ -221,8 +221,11 @@ export function TeamSwitcher({
             })}
           </ul>
           <div className="mt-1 border-t border-neutral-200 pt-1 dark:border-neutral-800">
+            {/* /app/team/new, not /app/team: this is reachable from a coach
+                who already has teams, and /app/team shows their roster, not
+                a create form. */}
             <Link
-              href="/app/team"
+              href="/app/team/new"
               onClick={() => setOpen(false)}
               className="block rounded-lg px-3 py-2 text-sm font-medium text-emerald-600 hover:bg-neutral-50 dark:hover:bg-neutral-800"
             >

--- a/components/workouts/WorkoutBasicsForm.tsx
+++ b/components/workouts/WorkoutBasicsForm.tsx
@@ -20,7 +20,11 @@ type WorkoutBasicsFormProps =
   | {
       mode: "edit";
       workout: Workout;
+      currentUserId: string;
       onSaved: (workout: Workout) => void;
+      /** The plan changed under this coach since the form opened - the write
+       *  was refused rather than risk overwriting it. */
+      onConflict: () => void;
       onCancel: () => void;
     };
 
@@ -79,6 +83,7 @@ export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
         .insert({
           ...payload,
           owner_id: props.userId,
+          last_edited_by: props.userId,
           ...audienceToFields(audience),
         })
         .select("id")
@@ -94,16 +99,26 @@ export function WorkoutBasicsForm(props: WorkoutBasicsFormProps) {
       return;
     }
 
+    // Guarded by the same updated_at this form was opened with: a coach
+    // co-editing this plan may have changed something (here or in the
+    // builder) since then, and this write must not land on top of that
+    // unseen change. 0 rows back (no error) means exactly that - the row
+    // is still there, its updated_at just moved on.
     const { data, error } = await supabase
       .from("workouts")
-      .update(payload)
+      .update({ ...payload, last_edited_by: props.currentUserId })
       .eq("id", props.workout.id)
+      .eq("updated_at", props.workout.updated_at)
       .select("*")
-      .single();
+      .maybeSingle();
 
     setLoading(false);
-    if (error || !data) {
+    if (error) {
       setFormError("Nie udało się zapisać zmian. Spróbuj ponownie.");
+      return;
+    }
+    if (!data) {
+      props.onConflict();
       return;
     }
     props.onSaved(data);

--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -34,11 +34,18 @@ export function WorkoutBuilder({
   initialItems,
   initialExercisesById,
   categories,
+  currentUserId,
+  canDelete,
 }: {
   initialWorkout: Workout;
   initialItems: WorkoutItem[];
   initialExercisesById: Record<string, Exercise>;
   categories: Category[];
+  currentUserId: string;
+  /** Owner or team head coach only - narrower than who can edit, so it's
+   *  computed server-side (see app/app/workouts/[id]/page.tsx) rather than
+   *  guessed here from role data this component doesn't otherwise need. */
+  canDelete: boolean;
 }) {
   const router = useRouter();
 
@@ -50,13 +57,16 @@ export function WorkoutBuilder({
   const [pickerSection, setPickerSection] = useState<WorkoutSection | null>(
     null,
   );
+  // Once a save is refused for being stale, stop offering more local edits
+  // to react to - every subsequent attempt would just refuse again, and the
+  // coach's only real way forward is to see what actually changed.
+  const [conflict, setConflict] = useState(false);
 
   const [libraryExercises, setLibraryExercises] = useState<Exercise[] | null>(
     null,
   );
   const [libraryError, setLibraryError] = useState(false);
   const [authors, setAuthors] = useState<PublicProfile[]>([]);
-  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
   const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
@@ -93,9 +103,6 @@ export function WorkoutBuilder({
   useEffect(() => {
     let cancelled = false;
     const supabase = createClient();
-    supabase.auth.getUser().then(({ data }) => {
-      if (!cancelled) setCurrentUserId(data.user?.id ?? null);
-    });
     supabase.rpc("list_public_profiles").then(({ data }) => {
       if (!cancelled && data) setAuthors(data);
     });
@@ -150,14 +157,65 @@ export function WorkoutBuilder({
     [items, exercisesById],
   );
 
-  // Optimistic-update helper shared by every mutation: apply the new items
-  // array immediately, persist in the background, and roll back to the
-  // pre-mutation snapshot if the write fails so the UI never shows state
-  // that isn't actually saved.
+  // workouts.updated_at is a version marker for the whole plan, not just its
+  // own row - a trigger bumps it on every workout_items insert/update/delete
+  // too (see supabase/migrations/20260730100952_workout_items_touch_parent.sql).
+  // Checked immediately before every write: two coaches editing the same
+  // session autosave optimistically, so without this the second write would
+  // silently clobber the first rather than the coach ever finding out.
+  async function isWorkoutStillCurrent(
+    supabase: ReturnType<typeof createClient>,
+  ): Promise<boolean> {
+    const { data } = await supabase
+      .from("workouts")
+      .select("updated_at")
+      .eq("id", workout.id)
+      .single();
+    if (!data || data.updated_at !== workout.updated_at) {
+      setConflict(true);
+      return false;
+    }
+    return true;
+  }
+
+  // Runs after a workout_items write that already succeeded - attribution
+  // only, never a reason to roll back the mutation that just landed. Falls
+  // back to a plain read so the local updated_at baseline still advances
+  // even if this write fails; otherwise our own successful edit would make
+  // the coach's very next save look "stale" against no one's changes but
+  // their own.
+  async function afterSuccessfulItemWrite(
+    supabase: ReturnType<typeof createClient>,
+  ) {
+    const { data, error } = await supabase
+      .from("workouts")
+      .update({ last_edited_by: currentUserId })
+      .eq("id", workout.id)
+      .select("updated_at, last_edited_by")
+      .single();
+    if (!error && data) {
+      setWorkout((prev) => ({ ...prev, ...data }));
+      return;
+    }
+    const { data: fresh } = await supabase
+      .from("workouts")
+      .select("updated_at")
+      .eq("id", workout.id)
+      .single();
+    if (fresh) setWorkout((prev) => ({ ...prev, updated_at: fresh.updated_at }));
+  }
+
+  // Optimistic-update helper shared by every item mutation: apply the new
+  // items array immediately, persist in the background, and roll back to
+  // the pre-mutation snapshot if the write fails so the UI never shows
+  // state that isn't actually saved.
   async function applyMutation(
     nextItems: WorkoutItem[],
     persist: () => Promise<{ error: unknown }>,
   ) {
+    const supabase = createClient();
+    if (!(await isWorkoutStillCurrent(supabase))) return;
+
     const previousItems = items;
     setItems(nextItems);
     setSaveState("saving");
@@ -167,6 +225,7 @@ export function WorkoutBuilder({
       setSaveState("error");
       return;
     }
+    await afterSuccessfulItemWrite(supabase);
     setSaveState("saved");
   }
 
@@ -276,13 +335,20 @@ export function WorkoutBuilder({
     if (existing) clearTimeout(existing);
 
     const timer = setTimeout(async () => {
-      setSaveState("saving");
       const supabase = createClient();
+      if (!(await isWorkoutStillCurrent(supabase))) return;
+
+      setSaveState("saving");
       const { error } = await supabase
         .from("workout_items")
         .update(patch)
         .eq("id", itemId);
-      setSaveState(error ? "error" : "saved");
+      if (error) {
+        setSaveState("error");
+        return;
+      }
+      await afterSuccessfulItemWrite(supabase);
+      setSaveState("saved");
     }, 500);
     debounceTimers.current.set(key, timer);
   }
@@ -330,6 +396,23 @@ export function WorkoutBuilder({
     router.refresh();
   }
 
+  // A hard reload, not router.refresh(): this component's own state (items,
+  // workout) was seeded once from server props and never re-syncs itself
+  // from a refetch, so a refresh would pull fresh data the page never
+  // actually shows. The whole point here is showing the coach what's
+  // actually there now.
+  function handleReload() {
+    window.location.reload();
+  }
+
+  const lastEditedByName =
+    workout.last_edited_by === null
+      ? null
+      : workout.last_edited_by === currentUserId
+        ? "Ty"
+        : (authorsById.get(workout.last_edited_by)?.display_name ??
+          "Inny trener");
+
   return (
     <main className="mx-auto max-w-5xl px-6 pt-8 pb-24">
       <Link
@@ -339,6 +422,25 @@ export function WorkoutBuilder({
         ← Wszystkie treningi
       </Link>
 
+      {conflict && (
+        <div
+          role="alert"
+          className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-400"
+        >
+          <span>
+            Ktoś inny zmienił ten plan w międzyczasie — Twoja ostatnia zmiana
+            nie została zapisana, żeby jej nie nadpisać.
+          </span>
+          <button
+            type="button"
+            onClick={handleReload}
+            className="shrink-0 rounded-full bg-amber-600 px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-amber-500"
+          >
+            Odśwież
+          </button>
+        </div>
+      )}
+
       <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           {editingBasics ? (
@@ -346,7 +448,12 @@ export function WorkoutBuilder({
               <WorkoutBasicsForm
                 mode="edit"
                 workout={workout}
+                currentUserId={currentUserId}
                 onSaved={handleBasicsSaved}
+                onConflict={() => {
+                  setEditingBasics(false);
+                  setConflict(true);
+                }}
                 onCancel={() => setEditingBasics(false)}
               />
             </div>
@@ -358,6 +465,9 @@ export function WorkoutBuilder({
               <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-neutral-600 dark:text-neutral-400">
                 {workout.team_name && <span>{workout.team_name}</span>}
                 <span>{formatScheduledDate(workout.scheduled_for)}</span>
+                {lastEditedByName && (
+                  <span>Ostatnio zmienił: {lastEditedByName}</span>
+                )}
               </div>
               {workout.notes && (
                 <p className="mt-3 max-w-2xl whitespace-pre-line text-sm text-neutral-600 dark:text-neutral-400">
@@ -380,10 +490,12 @@ export function WorkoutBuilder({
           <div className="flex flex-wrap items-start justify-end gap-2">
             <DownloadPdfButton workout={workout} items={pdfItems} />
             <ShareWorkoutButton shareId={workout.share_id} />
-            <DeleteWorkoutButton
-              workoutId={workout.id}
-              onDeleted={handleWorkoutDeleted}
-            />
+            {canDelete && (
+              <DeleteWorkoutButton
+                workoutId={workout.id}
+                onDeleted={handleWorkoutDeleted}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/components/workouts/WorkoutCard.tsx
+++ b/components/workouts/WorkoutCard.tsx
@@ -7,10 +7,12 @@ import { DuplicateWorkoutButton } from "./DuplicateWorkoutButton";
 export function WorkoutCard({
   workout,
   itemCount,
+  canDelete,
   onDeleted,
 }: {
   workout: Workout;
   itemCount: number;
+  canDelete: boolean;
   onDeleted: () => void;
 }) {
   return (
@@ -34,7 +36,9 @@ export function WorkoutCard({
 
       <div className="mt-4 flex flex-wrap justify-end gap-2">
         <DuplicateWorkoutButton workoutId={workout.id} />
-        <DeleteWorkoutButton workoutId={workout.id} onDeleted={onDeleted} />
+        {canDelete && (
+          <DeleteWorkoutButton workoutId={workout.id} onDeleted={onDeleted} />
+        )}
       </div>
     </div>
   );

--- a/components/workouts/WorkoutsList.tsx
+++ b/components/workouts/WorkoutsList.tsx
@@ -4,12 +4,17 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { Workout } from "@/lib/supabase/types";
+import { canDeleteWorkout } from "@/lib/workouts";
 import { WorkoutCard } from "./WorkoutCard";
 import { WorkoutCardSkeleton } from "./WorkoutCardSkeleton";
 
 export function WorkoutsList() {
   const [workouts, setWorkouts] = useState<Workout[] | null>(null);
   const [itemCounts, setItemCounts] = useState<Record<string, number>>({});
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [headCoachTeamIds, setHeadCoachTeamIds] = useState<Set<string>>(
+    new Set(),
+  );
   const [loadError, setLoadError] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
 
@@ -21,25 +26,41 @@ export function WorkoutsList() {
     const supabase = createClient();
 
     async function load() {
-      const { data: workoutsData, error: workoutsError } = await supabase
-        .from("workouts")
-        .select("*")
-        .order("created_at", { ascending: false });
+      const [{ data: userData }, { data: workoutsData, error: workoutsError }] =
+        await Promise.all([
+          supabase.auth.getUser(),
+          supabase
+            .from("workouts")
+            .select("*")
+            .order("created_at", { ascending: false }),
+        ]);
 
       if (cancelled) return;
       if (workoutsError || !workoutsData) {
         setLoadError(true);
         return;
       }
+      setCurrentUserId(userData.user?.id ?? null);
 
       const ids = workoutsData.map((workout) => workout.id);
-      const { data: itemsData, error: itemsError } =
-        ids.length > 0
-          ? await supabase
-              .from("workout_items")
-              .select("workout_id")
-              .in("workout_id", ids)
-          : { data: [], error: null };
+      const [{ data: itemsData, error: itemsError }, { data: membershipsData }] =
+        await Promise.all([
+          ids.length > 0
+            ? supabase
+                .from("workout_items")
+                .select("workout_id")
+                .in("workout_id", ids)
+            : Promise.resolve({ data: [], error: null }),
+          // RLS (is_team_member) already scopes this to teams the caller
+          // belongs to - filtered to their own row so this is "which of my
+          // teams am I head coach of", not a full roster fetch.
+          userData.user
+            ? supabase
+                .from("team_members")
+                .select("team_id, role")
+                .eq("user_id", userData.user.id)
+            : Promise.resolve({ data: [] }),
+        ]);
 
       if (cancelled) return;
       if (itemsError) {
@@ -53,6 +74,13 @@ export function WorkoutsList() {
       }
 
       setItemCounts(counts);
+      setHeadCoachTeamIds(
+        new Set(
+          (membershipsData ?? [])
+            .filter((m) => m.role === "head_coach")
+            .map((m) => m.team_id),
+        ),
+      );
       setWorkouts(workoutsData);
     }
 
@@ -131,6 +159,14 @@ export function WorkoutsList() {
                 key={workout.id}
                 workout={workout}
                 itemCount={itemCounts[workout.id] ?? 0}
+                canDelete={canDeleteWorkout({
+                  ownerId: workout.owner_id,
+                  teamId: workout.team_id,
+                  currentUserId,
+                  isHeadCoach:
+                    workout.team_id !== null &&
+                    headCoachTeamIds.has(workout.team_id),
+                })}
                 onDeleted={() => handleDeleted(workout.id)}
               />
             ))}

--- a/e2e/team-creation.spec.ts
+++ b/e2e/team-creation.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Walks the real "+ Utwórz drużynę" flow end to end against a real dev
+// server and a real Supabase backend - no route mocking. This exists
+// because the previous verification pass screenshotted the switcher's
+// component states (dropdown open, dashed affordance, etc.) without ever
+// clicking through to see where the link actually landed, which is exactly
+// how #44 shipped a "+ Utwórz drużynę" that dead-ended on a coach's own
+// roster. Every assertion here is about where a click lands or what the
+// header shows afterward, not just what renders in isolation.
+//
+// Requires E2E_TEST_EMAIL / E2E_TEST_PASSWORD for a confirmed account that
+// owns zero teams when this spec starts - the first step depends on the
+// real "no team" empty state, so it can't be faked with a throwaway name.
+// The account owns two teams ("E2E Team One" / "E2E Team Two") by the end
+// of a successful run; there is no delete-team affordance in the product
+// to reset it, so re-runs need a fresh account (or a manual DB cleanup).
+//
+// Start the app first (`E2E_START_SERVER=1 pnpm exec playwright test`, or
+// run `pnpm dev` yourself and point E2E_BASE_URL/E2E_PORT at it).
+
+const EMAIL = process.env.E2E_TEST_EMAIL;
+const PASSWORD = process.env.E2E_TEST_PASSWORD;
+
+test.skip(
+  !EMAIL || !PASSWORD,
+  "E2E_TEST_EMAIL / E2E_TEST_PASSWORD not set - see file header for the account this spec expects.",
+);
+
+const TEAM_ONE = { name: "E2E Team One", shortName: "E2E1" };
+const TEAM_TWO = { name: "E2E Team Two", shortName: "E2E2" };
+
+async function login(page: Page) {
+  await page.goto("/login");
+  await page.getByLabel("Adres e-mail").fill(EMAIL!);
+  await page.getByLabel("Hasło").fill(PASSWORD!);
+  await page.getByRole("button", { name: "Zaloguj się" }).click();
+  await page.waitForURL(/\/app(\/.*)?$/);
+
+  // Fresh accounts get a full-screen first-login overlay that would
+  // otherwise sit on top of the header and swallow every click below.
+  const skipOnboarding = page.getByRole("button", { name: "Pomiń" });
+  if (await skipOnboarding.isVisible().catch(() => false)) {
+    await skipOnboarding.click();
+  }
+}
+
+// The switcher's toggle button carries a state-dependent aria-label
+// ("Wybierz drużynę" vs "Aktywna drużyna: X"), so target it by the
+// attribute that doesn't change instead.
+function switcherToggle(page: Page) {
+  return page.locator('button[aria-haspopup="true"]');
+}
+
+async function fillCreateForm(
+  page: Page,
+  team: { name: string; shortName: string },
+) {
+  await expect(page).toHaveURL(/\/app\/team\/new$/);
+  await page.getByLabel("Pełna nazwa drużyny").fill(team.name);
+  await page.getByLabel(/Skrót/).fill(team.shortName);
+  await page.getByRole("button", { name: "Utwórz drużynę" }).click();
+}
+
+test.describe.serial("team creation is reachable and functional from every switcher state", () => {
+  test("zero teams → one team → two teams, all via the switcher", async ({
+    page,
+  }) => {
+    await login(page);
+
+    await test.step("/app/team on its own offers a create affordance at zero teams", async () => {
+      await page.goto("/app/team");
+      await expect(
+        page.getByText("Nie masz jeszcze żadnej drużyny"),
+      ).toBeVisible();
+      const link = page.getByRole("link", { name: /Załóż pierwszą drużynę/ });
+      await expect(link).toHaveAttribute("href", "/app/team/new");
+    });
+
+    await test.step("dropdown's create affordance at zero teams reaches the create form", async () => {
+      await page.goto("/app");
+      await page.getByRole("link", { name: "Utwórz drużynę" }).click();
+      await expect(page).toHaveURL(/\/app\/team\/new$/);
+    });
+
+    await test.step("completing the form activates the team and lands on /app/team", async () => {
+      await fillCreateForm(page, TEAM_ONE);
+      await expect(page).toHaveURL(/\/app\/team$/);
+      await expect(switcherToggle(page)).toHaveAttribute(
+        "aria-label",
+        `Aktywna drużyna: ${TEAM_ONE.name}`,
+      );
+      await expect(switcherToggle(page)).toContainText(TEAM_ONE.shortName);
+    });
+
+    await test.step("reopening the dropdown lists the one team just created", async () => {
+      await switcherToggle(page).click();
+      await expect(
+        page.getByRole("button", { name: new RegExp(TEAM_ONE.name) }),
+      ).toBeVisible();
+      // This is the exact bug from #44: with >=1 team the switcher renders
+      // a dropdown instead of the dashed affordance, and its own
+      // "+ Utwórz drużynę" item pointed at /app/team, which for a coach who
+      // already has a team shows the roster, not a create form.
+      const dropdownCreateLink = page.getByRole("link", {
+        name: "+ Utwórz drużynę",
+      });
+      await expect(dropdownCreateLink).toHaveAttribute(
+        "href",
+        "/app/team/new",
+      );
+    });
+
+    await test.step("/app/team also offers a create affordance once a team exists", async () => {
+      await page.goto("/app/team");
+      await expect(page.getByText(TEAM_ONE.name)).toBeVisible();
+      const link = page.getByRole("link", { name: "+ Nowa drużyna" });
+      await expect(link).toHaveAttribute("href", "/app/team/new");
+    });
+
+    await test.step("clicking create from the dropdown with one team reaches the create form, not the roster", async () => {
+      await switcherToggle(page).click();
+      await page.getByRole("link", { name: "+ Utwórz drużynę" }).click();
+      await expect(page).toHaveURL(/\/app\/team\/new$/);
+    });
+
+    await test.step("completing the form again activates the second team", async () => {
+      await fillCreateForm(page, TEAM_TWO);
+      await expect(page).toHaveURL(/\/app\/team$/);
+      await expect(switcherToggle(page)).toHaveAttribute(
+        "aria-label",
+        `Aktywna drużyna: ${TEAM_TWO.name}`,
+      );
+      await expect(switcherToggle(page)).toContainText(TEAM_TWO.shortName);
+    });
+
+    await test.step("reopening the dropdown lists both teams and switching between them works", async () => {
+      await switcherToggle(page).click();
+      const rowOne = page.getByRole("button", {
+        name: new RegExp(TEAM_ONE.name),
+      });
+      const rowTwo = page.getByRole("button", {
+        name: new RegExp(TEAM_TWO.name),
+      });
+      await expect(rowOne).toBeVisible();
+      await expect(rowTwo).toBeVisible();
+
+      await rowOne.click();
+      await expect(page.getByRole("status")).toContainText(
+        `Przełączono na ${TEAM_ONE.shortName}`,
+      );
+      await expect(switcherToggle(page)).toHaveAttribute(
+        "aria-label",
+        `Aktywna drużyna: ${TEAM_ONE.name}`,
+      );
+    });
+  });
+});

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -420,6 +420,7 @@ export type Database = {
           created_at: string;
           id: string;
           is_public: boolean;
+          last_edited_by: string | null;
           notes: string | null;
           owner_id: string;
           scheduled_for: string | null;
@@ -427,11 +428,13 @@ export type Database = {
           team_id: string | null;
           team_name: string | null;
           title: string;
+          updated_at: string;
         };
         Insert: {
           created_at?: string;
           id?: string;
           is_public?: boolean;
+          last_edited_by?: string | null;
           notes?: string | null;
           owner_id: string;
           scheduled_for?: string | null;
@@ -439,11 +442,13 @@ export type Database = {
           team_id?: string | null;
           team_name?: string | null;
           title: string;
+          updated_at?: string;
         };
         Update: {
           created_at?: string;
           id?: string;
           is_public?: boolean;
+          last_edited_by?: string | null;
           notes?: string | null;
           owner_id?: string;
           scheduled_for?: string | null;
@@ -451,8 +456,16 @@ export type Database = {
           team_id?: string | null;
           team_name?: string | null;
           title?: string;
+          updated_at?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "workouts_last_edited_by_fkey";
+            columns: ["last_edited_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "workouts_owner_id_fkey";
             columns: ["owner_id"];

--- a/lib/workouts.test.ts
+++ b/lib/workouts.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { canDeleteWorkout } from "./workouts";
+
+describe("canDeleteWorkout", () => {
+  it("lets the owner delete regardless of team or role", () => {
+    expect(
+      canDeleteWorkout({
+        ownerId: "coach-1",
+        teamId: null,
+        currentUserId: "coach-1",
+        isHeadCoach: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("lets a team's head coach delete a team-scoped workout they don't own", () => {
+    expect(
+      canDeleteWorkout({
+        ownerId: "coach-1",
+        teamId: "team-1",
+        currentUserId: "coach-2",
+        isHeadCoach: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("refuses an assistant coach who doesn't own the workout", () => {
+    expect(
+      canDeleteWorkout({
+        ownerId: "coach-1",
+        teamId: "team-1",
+        currentUserId: "coach-2",
+        isHeadCoach: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("refuses a head coach on a personal (non-team) workout they don't own", () => {
+    expect(
+      canDeleteWorkout({
+        ownerId: "coach-1",
+        teamId: null,
+        currentUserId: "coach-2",
+        isHeadCoach: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("refuses when there is no signed-in user", () => {
+    expect(
+      canDeleteWorkout({
+        ownerId: "coach-1",
+        teamId: "team-1",
+        currentUserId: null,
+        isHeadCoach: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/lib/workouts.ts
+++ b/lib/workouts.ts
@@ -27,6 +27,22 @@ export const SECTION_HINTS: Record<WorkoutSection, string> = {
 // Used when adding an exercise with no duration_min of its own set.
 export const DEFAULT_ITEM_DURATION_MIN = 10;
 
+// Mirrors workouts_delete_own (supabase/migrations/20260730100932_team_workout_coediting.sql):
+// owner, or the team's head coach - narrower than the update/select policies
+// on purpose, since deleting a shared plan is irreversible in a way editing
+// isn't. Kept here and tested so a future RLS change that isn't mirrored
+// here fails loudly instead of quietly showing (or hiding) the wrong button.
+export function canDeleteWorkout(params: {
+  ownerId: string;
+  teamId: string | null;
+  currentUserId: string | null;
+  isHeadCoach: boolean;
+}): boolean {
+  if (params.currentUserId === null) return false;
+  if (params.ownerId === params.currentUserId) return true;
+  return params.teamId !== null && params.isHeadCoach;
+}
+
 // Positions are scoped per section and kept as small non-negative integers,
 // but not assumed contiguous (deleting an item leaves a gap on purpose, to
 // avoid renumbering the rest of the section on every removal). Basing the

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.62.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Real flows against a real dev server + real Supabase backend - no
+// network mocking. See e2e/team-creation.spec.ts for the account
+// precondition this suite expects.
+const PORT = process.env.E2E_PORT ?? "3100";
+const baseURL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        // This container ships a pre-fetched Chromium build outside
+        // Playwright's usual cache location (PLAYWRIGHT_BROWSERS_PATH
+        // points at it) - pin the binary explicitly so a version mismatch
+        // between that build and the installed @playwright/test can't
+        // send it looking for a download that network policy would block.
+        launchOptions: {
+          executablePath:
+            process.env.PLAYWRIGHT_CHROMIUM_PATH ?? "/opt/pw-browsers/chromium",
+        },
+      },
+    },
+  ],
+  // Not started automatically: these flows need NEXT_PUBLIC_SUPABASE_URL/
+  // NEXT_PUBLIC_SUPABASE_ANON_KEY pointed at a real project, which is
+  // environment-specific. Start `pnpm dev -p $E2E_PORT` yourself first.
+  webServer: process.env.E2E_START_SERVER
+    ? {
+        command: `pnpm dev -p ${PORT}`,
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000,
+      }
+    : undefined,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 10.3.0
       next:
         specifier: 15.5.20
-        version: 15.5.20(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.20(@playwright/test@1.62.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -44,7 +44,10 @@ importers:
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
-        version: 3.3.5
+        version: 3.3.5(supports-color@7.2.0)
+      '@playwright/test':
+        specifier: ^1.62.0
+        version: 1.62.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.2
@@ -59,13 +62,13 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       eslint:
         specifier: ^9
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       eslint-config-next:
         specifier: 15.5.20
-        version: 15.5.20(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 15.5.20(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
@@ -449,6 +452,11 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@react-pdf/fns@3.1.3':
     resolution: {integrity: sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==}
@@ -1458,6 +1466,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2004,6 +2017,16 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   png-js@2.0.0:
     resolution: {integrity: sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==}
 
@@ -2540,17 +2563,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))':
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -2563,10 +2586,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@7.2.0)':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -2781,6 +2804,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.139.0': {}
+
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
 
   '@react-pdf/fns@3.1.3': {}
 
@@ -3091,15 +3118,15 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/type-utils': 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -3107,23 +3134,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.63.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.63.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3137,13 +3164,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3151,13 +3178,13 @@ snapshots:
 
   '@typescript-eslint/types@8.63.0': {}
 
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.63.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -3166,13 +3193,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3508,13 +3535,17 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   deep-is@0.1.4: {}
 
@@ -3668,19 +3699,19 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.5.20(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@15.5.20(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 15.5.20
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.10(supports-color@7.2.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3688,56 +3719,56 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
 
-  eslint-import-resolver-node@0.3.10:
+  eslint-import-resolver-node@0.3.10(supports-color@7.2.0):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@7.2.0)
       is-core-module: 2.16.2
       resolve: 2.0.0-next.7
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@7.2.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.10(supports-color@7.2.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@7.2.0)
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.10(supports-color@7.2.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -3749,13 +3780,13 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -3765,7 +3796,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -3774,11 +3805,11 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
 
-  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -3786,7 +3817,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.3
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
@@ -3811,14 +3842,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4(jiti@2.7.0):
+  eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@7.2.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@7.2.0)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -3828,7 +3859,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -3937,6 +3968,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4340,7 +4374,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.20(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.5.20(@playwright/test@1.62.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.5.20
       '@swc/helpers': 0.5.15
@@ -4358,6 +4392,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.20
       '@next/swc-win32-arm64-msvc': 15.5.20
       '@next/swc-win32-x64-msvc': 15.5.20
+      '@playwright/test': 1.62.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4464,6 +4499,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   png-js@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  sharp: true
+  unrs-resolver: true

--- a/supabase/migrations/20260730095000_duplicate_workout_preserve_audience.sql
+++ b/supabase/migrations/20260730095000_duplicate_workout_preserve_audience.sql
@@ -1,0 +1,36 @@
+-- Coach Zone — duplicate_workout: preserve team_id and is_public
+--
+-- duplicate_workout() predates team support and the audience selector
+-- (20260710100100_duplicate_workout.sql, before team_id/is_public existed
+-- on workouts). It already copies team_name verbatim; team_id and
+-- is_public were simply never added to that column list, so "Duplikuj" on
+-- a team-scoped or public workout silently drops both and the copy becomes
+-- private to the duplicator - not a choice the coach made, and one they
+-- can't undo since WorkoutBasicsForm's edit mode has nowhere to change
+-- audience after creation.
+create or replace function public.duplicate_workout(p_workout_id uuid)
+returns public.workouts
+language plpgsql
+as $$
+declare
+  new_workout public.workouts;
+begin
+  insert into public.workouts (owner_id, title, team_name, scheduled_for, notes, team_id, is_public)
+  select auth.uid(), w.title || ' (kopia)', w.team_name, null, w.notes, w.team_id, w.is_public
+  from public.workouts w
+  where w.id = p_workout_id
+  returning * into new_workout;
+
+  if new_workout.id is null then
+    raise exception 'Workout % not found or not owned by the caller', p_workout_id;
+  end if;
+
+  insert into public.workout_items
+    (workout_id, exercise_id, section, position, duration_min, assigned_to)
+  select new_workout.id, wi.exercise_id, wi.section, wi.position, wi.duration_min, wi.assigned_to
+  from public.workout_items wi
+  where wi.workout_id = p_workout_id;
+
+  return new_workout;
+end;
+$$;

--- a/supabase/migrations/20260730100932_team_workout_coediting.sql
+++ b/supabase/migrations/20260730100932_team_workout_coediting.sql
@@ -1,0 +1,38 @@
+alter table public.workouts
+  add column if not exists updated_at timestamptz not null default now(),
+  add column if not exists last_edited_by uuid references public.profiles(id) on delete set null;
+
+drop trigger if exists workouts_set_updated_at on public.workouts;
+create trigger workouts_set_updated_at before update on public.workouts
+  for each row execute function public.set_updated_at();
+
+drop policy if exists workouts_update_own on public.workouts;
+create policy workouts_update_own on public.workouts for update to authenticated
+  using (owner_id = auth.uid() or (team_id is not null and team_id in (select public.my_team_ids())))
+  with check (owner_id = auth.uid() or (team_id is not null and team_id in (select public.my_team_ids())));
+
+drop policy if exists workouts_delete_own on public.workouts;
+create policy workouts_delete_own on public.workouts for delete to authenticated
+  using (owner_id = auth.uid() or (team_id is not null and public.is_team_head_coach(team_id)));
+
+drop policy if exists workout_items_select_own on public.workout_items;
+create policy workout_items_select_own on public.workout_items for select to authenticated
+  using (exists (select 1 from public.workouts w where w.id = workout_items.workout_id
+                 and (w.owner_id = auth.uid() or w.team_id in (select public.my_team_ids()))));
+
+drop policy if exists workout_items_insert_own on public.workout_items;
+create policy workout_items_insert_own on public.workout_items for insert to authenticated
+  with check (exists (select 1 from public.workouts w where w.id = workout_items.workout_id
+                      and (w.owner_id = auth.uid() or w.team_id in (select public.my_team_ids()))));
+
+drop policy if exists workout_items_update_own on public.workout_items;
+create policy workout_items_update_own on public.workout_items for update to authenticated
+  using (exists (select 1 from public.workouts w where w.id = workout_items.workout_id
+                 and (w.owner_id = auth.uid() or w.team_id in (select public.my_team_ids()))))
+  with check (exists (select 1 from public.workouts w where w.id = workout_items.workout_id
+                      and (w.owner_id = auth.uid() or w.team_id in (select public.my_team_ids()))));
+
+drop policy if exists workout_items_delete_own on public.workout_items;
+create policy workout_items_delete_own on public.workout_items for delete to authenticated
+  using (exists (select 1 from public.workouts w where w.id = workout_items.workout_id
+                 and (w.owner_id = auth.uid() or w.team_id in (select public.my_team_ids()))));

--- a/supabase/migrations/20260730100952_workout_items_touch_parent.sql
+++ b/supabase/migrations/20260730100952_workout_items_touch_parent.sql
@@ -1,0 +1,12 @@
+create or replace function public.touch_parent_workout()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  update public.workouts set updated_at = now()
+   where id = coalesce(new.workout_id, old.workout_id);
+  return coalesce(new, old);
+end $$;
+
+drop trigger if exists workout_items_touch_parent on public.workout_items;
+create trigger workout_items_touch_parent
+  after insert or update or delete on public.workout_items
+  for each row execute function public.touch_parent_workout();

--- a/supabase/migrations/20260731120759_workout_ownership_guard.sql
+++ b/supabase/migrations/20260731120759_workout_ownership_guard.sql
@@ -1,0 +1,17 @@
+create or replace function public.guard_workout_ownership()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if new.owner_id is distinct from old.owner_id
+     or new.team_id is distinct from old.team_id then
+    if not (old.owner_id = auth.uid()
+            or (old.team_id is not null and public.is_team_head_coach(old.team_id))) then
+      new.owner_id := old.owner_id;
+      new.team_id  := old.team_id;
+    end if;
+  end if;
+  return new;
+end $$;
+
+drop trigger if exists workouts_guard_ownership on public.workouts;
+create trigger workouts_guard_ownership before update on public.workouts
+  for each row execute function public.guard_workout_ownership();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,18 @@
 import path from "node:path";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "."),
     },
+  },
+  test: {
+    // e2e/**/*.spec.ts matches Vitest's default *.spec.ts glob, but those
+    // files use @playwright/test's own `test`/`expect` and only run under
+    // the Playwright runner (`pnpm test:e2e`) - Vitest picking them up too
+    // fails immediately since Playwright's test.skip() etc. need Playwright's
+    // own runner context.
+    exclude: [...configDefaults.exclude, "e2e/**"],
   },
 });


### PR DESCRIPTION
## Summary

- Fixes the functional bug from #44: clicking "+ Utwórz drużynę" in the switcher dropdown sent a coach who already has a team to `/app/team`, which shows their roster, not a create form. The link was a dead end.
- Root cause: the create form only ever rendered inline on `/app/team`, and only when the coach had zero teams. That was correct when nothing else linked to it, but PR #44 made the dropdown offer creation as an action from *any* state without updating the destination to match.
- Adds a real, flow-walking Playwright spec instead of more component-state screenshots, per the explicit ask on this round.
- Fixes one more instance of the same bug class found while auditing for it, in workout duplication.
- **Follow-up round**: the auditing above surfaced a bigger issue - `WorkoutBuilder` showed full edit/delete UI to any team member who could view a workout, but the underlying RLS was still owner-only, so every mutation from a non-owner silently no-opped. That got a product decision (full co-editing) and is fixed below.
- **Second follow-up**: a gap in the co-editing policy itself - `WITH CHECK (owner_id = auth.uid() OR ...)` is satisfied by the row *after* the write, so an assistant could set themselves as owner and null out `team_id` in the same update, taking a team workout out of the team. Closed with an ownership guard trigger, verified below.

## The team-creation fix

- New `/app/team/new` route carrying the create form, matching the existing `/app/exercises/new` / `/app/workouts/new` pattern.
- Both of the switcher's "+ Utwórz drużynę" affordances (the zero-team dashed link and the dropdown's menu item) now point there instead of at `/app/team`.
- `/app/team` itself now offers a create link in **both** states - "Załóż pierwszą drużynę" when empty, "+ Nowa drużyna" once populated - so it's never the one place that can't do the thing it's about. `TeamManager` no longer inlines `CreateTeamForm`; it links out, same as the exercises/workouts list pages already do for their own empty states.
- `CreateTeamForm` now redirects to `/app/team` on success (`router.push` + `router.refresh`) instead of taking an `onCreated` callback, matching how `ExerciseForm`/`WorkoutBasicsForm` already behave. Team activation on create was already correct from #44 and is unchanged.

## Audit: same class of problem elsewhere

- **Audience selector** - clean. Already handles 0/1/N teams correctly from both entry points and is correctly hidden in edit mode.
- **Invites panel** - clean. Always gated behind "head coach of a team that exists," scoped per `TeamCard`.
- **`duplicate_workout()`** - same bug shape, different feature. Predates team support and the audience selector entirely, so it copied `team_name` verbatim but never `team_id`/`is_public` - "Duplikuj" on a team-scoped or public workout silently turned the copy private. Fixed with a migration, applied and verified live against a throwaway account, cleaned up after.
- **`WorkoutBuilder` ownership gap** - the bigger one, addressed below.

## Team co-editing of workouts

Product decision: an assistant coach exists to support the head coach, not to watch, so anyone on the staff can edit a team workout.

- `workouts_update_own` / `workout_items_*_own` RLS widened from owner-only to owner-or-team-member. `workouts_delete_own` stays narrower - owner or head coach only, since deleting a shared plan is irreversible in a way editing isn't.
- Fixed a real bug this surfaced: `workout_items_select_own` was still owner-only even though `workouts_select_own` already included team members from an earlier migration - a teammate could see a team workout in a list and open it, but its items were invisible. Verified fixed end to end, not assumed.
- Edit/reorder/add controls needed no new gating - they already rendered unconditionally, and are now correctly backed by matching RLS (select and update are symmetric, so anyone who can open the page can legitimately use them). Delete is narrower, so it's computed server-side (`canDeleteWorkout()`, extracted to `lib/workouts.ts` and unit tested) and **hidden**, not shown-then-refused, on both the builder and the workouts list.
- Added `workouts.updated_at` (a trigger bumps it on any `workout_items` change too) and `last_edited_by`, both applied live and committed as migrations. Every mutation path in the builder - item add/remove/reorder/move, debounced field edits, and the basics-edit form - checks `updated_at` immediately before writing and refuses if it's moved, rather than silently overwriting a teammate's concurrent edit. The basics form does this atomically via a conditional update; item mutations via check-then-write, since their version marker lives on the parent table. A refusal shows a banner and offers a hard reload. Every mutation also stamps `last_edited_by`, surfaced as "Ostatnio zmienił: X".
- **Ownership guard**: the `WITH CHECK` above is satisfied whenever `owner_id = auth.uid()` in the *new* row, independent of what else changes - so an assistant could claim a team workout as their own and simultaneously null `team_id` out from under the team. A `BEFORE UPDATE` trigger now silently restores `owner_id`/`team_id` to their prior values unless the caller is the original owner or the original team's head coach, rather than rejecting the whole write - so a normal edit that happens to round-trip those columns still saves everything else. The owner or head coach can still legitimately move a workout between teams.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (50 unit tests, including new `canDeleteWorkout` coverage), and `pnpm build` all pass.
- New Playwright spec (`e2e/team-creation.spec.ts`) drives the team-creation flow end to end - see the file header for what it covers and the account precondition it needs.
- **Couldn't get a live browser run in this sandbox**: outbound access to this project's Supabase host (and to the Vercel-hosted deployment, checked as a fallback) is denied by the environment's egress policy. Confirmed the Playwright harness itself is sound short of that - it launches, navigates, and fills forms correctly, then fails cleanly at the network boundary.
- For the RLS/concurrency/ownership work, where a live browser wasn't an option, verified against the real database instead - and explicitly confirmed the connection wasn't silently bypassing RLS (`postgres`/`service_role` both have `BYPASSRLS`; switched to `SET LOCAL ROLE authenticated` + a simulated JWT claim so policies were genuinely enforced) before trusting any result. Built a throwaway head-coach/assistant-coach pair for each check, fully cleaned up after every run:
  - Assistant can see and edit a team workout's items but cannot delete it; head coach can delete a teammate's workout.
  - A stale conditional update is refused with 0 rows affected; the identical write with the current version succeeds.
  - The `workout_items` touch trigger correctly bumps the parent's `updated_at`.
  - An assistant's attempt to hijack ownership and pull a workout out of its team lands (1 row affected, not rejected) but `owner_id`/`team_id` come back unchanged while a title change in the same statement still applies; the head coach then successfully moves the same workout between two teams they head-coach.
- The button-hiding and banner rendering in React are verified by code review, not a live click-through, for the same sandbox reason as the Playwright spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)