### PR TITLE
Make item-mutation saves genuinely atomic; carry next through the login/signup toggle

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -118,7 +118,7 @@ export function LoginForm({
       <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
         Nie masz konta?{" "}
         <Link
-          href="/signup"
+          href={next ? `/signup?next=${encodeURIComponent(next)}` : "/signup"}
           className="font-medium text-emerald-600 hover:text-emerald-500"
         >
           Zarejestruj się

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -220,7 +220,7 @@ export function SignupForm({
       <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
         Masz już konto?{" "}
         <Link
-          href="/login"
+          href={next ? `/login?next=${encodeURIComponent(next)}` : "/login"}
           className="font-medium text-emerald-600 hover:text-emerald-500"
         >
           Zaloguj się

--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -160,49 +160,52 @@ export function WorkoutBuilder({
   // workouts.updated_at is a version marker for the whole plan, not just its
   // own row - a trigger bumps it on every workout_items insert/update/delete
   // too (see supabase/migrations/20260730100952_workout_items_touch_parent.sql).
-  // Checked immediately before every write: two coaches editing the same
-  // session autosave optimistically, so without this the second write would
-  // silently clobber the first rather than the coach ever finding out.
-  async function isWorkoutStillCurrent(
+  // Claimed atomically immediately before every item write, the same way
+  // WorkoutBasicsForm claims it for a basics edit: a conditional update
+  // (.eq("updated_at", known)) rather than a separate read-then-compare.
+  // A plain read-then-compare leaves a gap between "checked" and "wrote"
+  // that a second tab's save can land in - two coaches autosaving close
+  // together could each pass the check before either write lands, which is
+  // exactly the silent-clobber the versioning migration exists to prevent.
+  // Folding the check into the write itself closes that gap: at most one
+  // concurrent claim can match a given updated_at, because Postgres
+  // serializes concurrent updates to the same row. 0 rows back (no error)
+  // means someone else's edit already moved the version on. Also stamps
+  // last_edited_by, since claiming the version and attributing the change
+  // are naturally the same write.
+  async function claimWorkoutVersion(
     supabase: ReturnType<typeof createClient>,
   ): Promise<boolean> {
+    const { data, error } = await supabase
+      .from("workouts")
+      .update({ last_edited_by: currentUserId })
+      .eq("id", workout.id)
+      .eq("updated_at", workout.updated_at)
+      .select("updated_at, last_edited_by")
+      .maybeSingle();
+    if (error || !data) {
+      setConflict(true);
+      return false;
+    }
+    setWorkout((prev) => ({ ...prev, ...data }));
+    return true;
+  }
+
+  // Runs after a workout_items write that already succeeded - the same
+  // touch_parent_workout trigger fires on that write too, so the version
+  // claimWorkoutVersion just staked is already behind again by the time it
+  // lands. Resyncs the local baseline so the coach's own very next save
+  // doesn't look stale against no one's changes but their own; never a
+  // reason to roll back the mutation that already landed.
+  async function resyncWorkoutVersion(
+    supabase: ReturnType<typeof createClient>,
+  ) {
     const { data } = await supabase
       .from("workouts")
       .select("updated_at")
       .eq("id", workout.id)
       .single();
-    if (!data || data.updated_at !== workout.updated_at) {
-      setConflict(true);
-      return false;
-    }
-    return true;
-  }
-
-  // Runs after a workout_items write that already succeeded - attribution
-  // only, never a reason to roll back the mutation that just landed. Falls
-  // back to a plain read so the local updated_at baseline still advances
-  // even if this write fails; otherwise our own successful edit would make
-  // the coach's very next save look "stale" against no one's changes but
-  // their own.
-  async function afterSuccessfulItemWrite(
-    supabase: ReturnType<typeof createClient>,
-  ) {
-    const { data, error } = await supabase
-      .from("workouts")
-      .update({ last_edited_by: currentUserId })
-      .eq("id", workout.id)
-      .select("updated_at, last_edited_by")
-      .single();
-    if (!error && data) {
-      setWorkout((prev) => ({ ...prev, ...data }));
-      return;
-    }
-    const { data: fresh } = await supabase
-      .from("workouts")
-      .select("updated_at")
-      .eq("id", workout.id)
-      .single();
-    if (fresh) setWorkout((prev) => ({ ...prev, updated_at: fresh.updated_at }));
+    if (data) setWorkout((prev) => ({ ...prev, updated_at: data.updated_at }));
   }
 
   // Optimistic-update helper shared by every item mutation: apply the new
@@ -214,7 +217,7 @@ export function WorkoutBuilder({
     persist: () => Promise<{ error: unknown }>,
   ) {
     const supabase = createClient();
-    if (!(await isWorkoutStillCurrent(supabase))) return;
+    if (!(await claimWorkoutVersion(supabase))) return;
 
     const previousItems = items;
     setItems(nextItems);
@@ -225,7 +228,7 @@ export function WorkoutBuilder({
       setSaveState("error");
       return;
     }
-    await afterSuccessfulItemWrite(supabase);
+    await resyncWorkoutVersion(supabase);
     setSaveState("saved");
   }
 
@@ -336,7 +339,7 @@ export function WorkoutBuilder({
 
     const timer = setTimeout(async () => {
       const supabase = createClient();
-      if (!(await isWorkoutStillCurrent(supabase))) return;
+      if (!(await claimWorkoutVersion(supabase))) return;
 
       setSaveState("saving");
       const { error } = await supabase
@@ -347,7 +350,7 @@ export function WorkoutBuilder({
         setSaveState("error");
         return;
       }
-      await afterSuccessfulItemWrite(supabase);
+      await resyncWorkoutVersion(supabase);
       setSaveState("saved");
     }, 500);
     debounceTimers.current.set(key, timer);


### PR DESCRIPTION
## Summary

**Bug 1 — concurrent-edit guard didn't block in the browser.** `WorkoutBasicsForm` already claims `workouts.updated_at` atomically via a conditional update (`.eq("updated_at", known)`) and correctly refuses a stale save. Item mutations (add/remove/reorder/move-section, debounced duration/assigned_to edits) didn't: `isWorkoutStillCurrent` ran a plain `SELECT` and compared client-side, then the actual `insert`/`update`/`delete` on `workout_items` went through with **no version condition at all**. The check and the write were two separate operations, so a save landing in the gap between them went through unguarded — this is hypothesis (b) from the report: `updated_at` was captured and compared, just never sent as the guard condition on the write itself.

Fix: replaced `isWorkoutStillCurrent` (read) + the post-write `afterSuccessfulItemWrite` stamp with `claimWorkoutVersion` (the conditional update itself, done *before* the item write, doubling as the `last_edited_by` stamp) + `resyncWorkoutVersion` (a plain post-write read, since `touch_parent_workout` bumps the version again once the item write lands). Postgres serializes concurrent updates to one row, so at most one concurrent claim can match a given `updated_at` — this closes the gap rather than narrowing it.

**I could not live-test this one.** This sandbox's egress policy denies both the Supabase project host and the Vercel deployment (confirmed directly — a prior PR in this repo's history hit the identical wall). Verified via `tsc`/`eslint`/`vitest` (all clean) and by reusing the exact conditional-update mechanism `WorkoutBasicsForm` already uses and that the DB-level check already confirmed refuses stale writes. **This needs a real two-tab confirm on your end before you trust it.**

**Bug 2 — invited person loses the invite via signup.** `/join/[token]`'s own "Zaloguj się"/"Zarejestruj się" links already carried `next` correctly. The drop was one hop later: `LoginForm`'s in-form "Zarejestruj się" link and `SignupForm`'s in-form "Zaloguj się" link both hardcoded their `href`, losing `next` on the switch between them. Both now forward it, so toggling either direction and completing auth still lands back on `/join/[token]`. Signup's own post-registration redirect and `emailRedirectTo` already handled `next` correctly once it reached the form — unchanged.

Verified live: real browser against a real local dev server (no Supabase access needed for this part, since it's client-side routing) — both toggle directions, checking the rendered `href` and the post-click URL, with `next` and without. All 6 assertions passed.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` all pass
- [x] Bug 2: real-browser Playwright run against a local dev server confirms both toggle directions preserve `next`, and plain login/signup (no `next`) stays clean
- [ ] Bug 1: **needs a live two-tab confirm against the real deployed app** — this sandbox cannot reach the Supabase project or the Vercel deployment to run that test itself. Repro: open the same team workout in two tabs, edit + save in tab A, then edit + save in tab B (stale) — tab B should now show the reload banner and its write should not land.
- [ ] Bug 2 end-to-end with a real account: click "Zaloguj się" from a `/join/[token]` link, switch to "Zarejestruj się", register, confirm you land back on the invite (both directly and after email confirmation for the no-immediate-session case)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtNmSCq853vXeZ16bV6TCK)_