### PR TITLE
Detect foreign edits on resync, not just at claim time

### DIFF
--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -233,16 +233,37 @@ export function WorkoutBuilder({
   // lands. Resyncs the local baseline so the coach's own very next save
   // doesn't look stale against no one's changes but their own; never a
   // reason to roll back the mutation that already landed.
+  //
+  // This SELECT isn't atomic with the write that provoked it, so it can
+  // land after a foreign session's own claim+write has slipped into the
+  // gap in between - and updated_at alone can't tell "moved because of my
+  // write" from "moved because of my write, then someone else's too".
+  // last_edited_by can: only a claim ever sets it, every claim stamps the
+  // claimant, and nothing else touches it in that gap. If it's not still
+  // us, a foreign claim landed here first. Adopt the name for display, but
+  // deliberately leave the baseline (workoutRef.current.updated_at) at
+  // whatever claimWorkoutVersion last staked - the same shape a rejected
+  // claim already leaves it in - so this session's next claim attempt
+  // keeps failing until a reload brings `items` back in sync with the row,
+  // instead of quietly re-arming on a version we never actually saw.
   async function resyncWorkoutVersion(
     supabase: ReturnType<typeof createClient>,
   ) {
     const { data } = await supabase
       .from("workouts")
-      .select("updated_at")
+      .select("updated_at, last_edited_by")
       .eq("id", workoutRef.current.id)
       .single();
-    if (data)
-      updateWorkout((prev) => ({ ...prev, updated_at: data.updated_at }));
+    if (!data) return;
+    if (data.last_edited_by !== currentUserId) {
+      updateWorkout((prev) => ({
+        ...prev,
+        last_edited_by: data.last_edited_by,
+      }));
+      setConflict(true);
+      return;
+    }
+    updateWorkout((prev) => ({ ...prev, updated_at: data.updated_at }));
   }
 
   // Optimistic-update helper shared by every item mutation: apply the new


### PR DESCRIPTION
## Summary

Follow-up to #47. On-device two-account testing found that cross-session conflict detection is now silently broken: two separate accounts editing the same team workout concurrently (both adding exercises) never see the conflict banner, and both writes land unwarned.

**Confirmed mechanism** (checked against the live schema — triggers on `workouts`/`workout_items` match the migrations exactly, no drift) — narrower than "two sessions just take turns bumping `updated_at`":

- `claimWorkoutVersion`'s conditional update (`.eq("updated_at", baseline)`) is genuinely atomic — one UPDATE statement, and Postgres serializes two sessions racing a claim from the *same* baseline so only one can win. That part already worked correctly.
- The real hole is `resyncWorkoutVersion`: a *third*, separate round trip after claim and after the item write, doing an unconditional `select updated_at` and blindly adopting whatever it reads as the new trusted baseline. It can't tell "this value reflects only my write" from "my write, then also a foreign session's claim+write that landed in the gap before this SELECT ran." Once that happens, the local baseline is — correctly — back in sync with the row version, so every later claim from that session legitimately succeeds, even though `items` was never refreshed to include the foreign row.

This is why it reproduces reliably with two coaches both clicking through the exercise picker for a while (many chances to land in that gap) and is self-reinforcing once it happens once — and why the DB wasn't corrupted this time: pure inserts don't collide at the row level. A same-item edit (duration change, remove, reorder) racing through the same gap would silently lose one side's change.

## Fix

`last_edited_by` is only ever set by a claim, and every claim stamps its own claimant — nothing else touches it in that gap. `resyncWorkoutVersion` now reads it alongside `updated_at`:
- Still us → adopt the new `updated_at` as before (unchanged behavior).
- Not us → a foreign claim landed here first. Adopt the name for display (same "Ostatnio zmienił" path already confirmed working live), but deliberately leave `workoutRef.current.updated_at` at whatever `claimWorkoutVersion` last staked — the same shape a rejected claim already leaves it in — and set `conflict`. Every subsequent mutation in this session then keeps failing its own claim until a reload, instead of quietly re-arming on a version this session never actually saw.

Left `claimWorkoutVersion` and the mutation queue from #47 untouched — both already do what their comments say. Left `WorkoutBasicsForm` alone too: its claim+write+return is one atomic statement with no separate resync round trip, so it was never exposed to this gap.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] `npx vitest run` — 52/52 passing
- [x] Verified live trigger/function definitions on the Supabase project match the migrations exactly (no drift) before relying on their behavior
- [ ] **Needs an on-device two-account browser test** (two genuinely separate sessions, not two tabs of one login): both sessions add exercises to the same team workout around the same time — the one who saves second into an already-moved version should see the banner and stop being able to save further until reload
- [ ] Regression check: a single session adding several exercises fast still produces no banner

Did not add an automated test for the new branch — it's coupled to Supabase's row/trigger semantics in a way that would need a heavily mocked two-client harness to exercise meaningfully, and the real verification is the two-session browser test above, which a mock can't stand in for.

---

https://claude.ai/code/session_01AhJrCJoQQxEzYg8e2MbyUA


---
_Generated by [Claude Code](https://claude.ai/code/session_01AhJrCJoQQxEzYg8e2MbyUA)_