### PR TITLE
Expandable inline preview in the exercise picker

### DIFF
--- a/app/app/exercises/[id]/page.tsx
+++ b/app/app/exercises/[id]/page.tsx
@@ -7,16 +7,9 @@ import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator"
 import { DeleteExerciseButton } from "@/components/exercises/DeleteExerciseButton";
 import { PositionPills } from "@/components/exercises/PositionPills";
 import { BoardViewLoader } from "@/components/board/BoardViewLoader";
-import { formatDuration } from "@/lib/exercises";
-import type { BoardElement } from "@/lib/board/types";
+import { boardElementsOf, formatDuration } from "@/lib/exercises";
 import { createClient } from "@/lib/supabase/server";
-import type { Exercise, Position } from "@/lib/supabase/types";
-
-function boardElementsOf(exercise: Exercise): BoardElement[] | null {
-  return Array.isArray(exercise.board_state)
-    ? (exercise.board_state as unknown as BoardElement[])
-    : null;
-}
+import type { Position } from "@/lib/supabase/types";
 
 export const dynamic = "force-dynamic";
 

--- a/components/exercises/ExercisePreview.tsx
+++ b/components/exercises/ExercisePreview.tsx
@@ -1,0 +1,69 @@
+import { BoardViewLoader } from "@/components/board/BoardViewLoader";
+import { boardElementsOf } from "@/lib/exercises";
+import type { Exercise } from "@/lib/supabase/types";
+
+// board_state is null for much of the library, so every section below is independently optional.
+export function ExercisePreview({
+  exercise,
+  sportSlug,
+}: {
+  exercise: Exercise;
+  sportSlug?: string | null;
+}) {
+  const boardElements = boardElementsOf(exercise);
+  const hasBoard = boardElements !== null && boardElements.length > 0;
+  const hasEquipment = exercise.equipment.length > 0;
+  const hasSteps = exercise.steps.length > 0;
+
+  if (!hasBoard && !hasEquipment && !exercise.description && !hasSteps) {
+    return (
+      <p className="text-sm text-neutral-500 dark:text-neutral-500">
+        Brak dodatkowych informacji.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {boardElements && boardElements.length > 0 && (
+        <BoardViewLoader
+          sportSlug={sportSlug}
+          fieldModeId={exercise.board_field_mode}
+          elements={boardElements}
+        />
+      )}
+
+      {hasEquipment && (
+        <div className="flex flex-wrap gap-1.5">
+          {exercise.equipment.map((item) => (
+            <span
+              key={item}
+              className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {exercise.description && (
+        <p className="whitespace-pre-line text-sm text-neutral-700 dark:text-neutral-300">
+          {exercise.description}
+        </p>
+      )}
+
+      {hasSteps && (
+        <div>
+          <p className="text-xs font-semibold text-neutral-500 dark:text-neutral-500">
+            Przebieg ćwiczenia
+          </p>
+          <ol className="mt-1.5 list-decimal space-y-1 pl-5 text-sm text-neutral-700 dark:text-neutral-300">
+            {exercise.steps.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/workouts/ExercisePicker.tsx
+++ b/components/workouts/ExercisePicker.tsx
@@ -4,17 +4,20 @@ import { useEffect, useMemo, useState } from "react";
 import { AuthorBadge } from "@/components/exercises/AuthorBadge";
 import { CategoryBadge } from "@/components/exercises/CategoryBadge";
 import { DifficultyIndicator } from "@/components/exercises/DifficultyIndicator";
+import { ExercisePreview } from "@/components/exercises/ExercisePreview";
 import {
   DIFFICULTY_LABELS,
   DIFFICULTY_OPTIONS,
   formatDuration,
 } from "@/lib/exercises";
+import { createClient } from "@/lib/supabase/client";
 import { SECTION_LABELS } from "@/lib/workouts";
 import type {
   Category,
   Difficulty,
   Exercise,
   PublicProfile,
+  Sport,
   WorkoutSection,
 } from "@/lib/supabase/types";
 
@@ -48,6 +51,8 @@ export function ExercisePicker({
   >(ALL);
   const [equipmentFilter, setEquipmentFilter] = useState<string>(ALL);
   const [justAddedId, setJustAddedId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [sports, setSports] = useState<Sport[]>([]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -57,11 +62,32 @@ export function ExercisePicker({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
+  // Only needed to resolve each exercise's sport slug for the expanded preview's board.
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    supabase
+      .from("sports")
+      .select("*")
+      .then(({ data }) => {
+        if (!cancelled && data) setSports(data);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const categoriesById = useMemo(() => {
     const map = new Map<number, Category>();
     for (const category of categories) map.set(category.id, category);
     return map;
   }, [categories]);
+
+  const sportsById = useMemo(() => {
+    const map = new Map<number, Sport>();
+    for (const sport of sports) map.set(sport.id, sport);
+    return map;
+  }, [sports]);
 
   const equipmentOptions = useMemo(() => {
     const values = new Set<string>();
@@ -99,6 +125,10 @@ export function ExercisePicker({
     setTimeout(() => {
       setJustAddedId((current) => (current === exercise.id ? null : current));
     }, 1200);
+  }
+
+  function toggleExpanded(exerciseId: string) {
+    setExpandedId((current) => (current === exerciseId ? null : exerciseId));
   }
 
   return (
@@ -224,41 +254,71 @@ export function ExercisePicker({
             <ul className="space-y-2">
               {filtered.map((exercise) => {
                 const category = categoriesById.get(exercise.category_id);
+                const isExpanded = expandedId === exercise.id;
+                const previewId = `exercise-preview-${exercise.id}`;
                 return (
                   <li
                     key={exercise.id}
-                    className="flex items-center justify-between gap-3 rounded-xl border border-neutral-200 p-3 dark:border-neutral-800"
+                    className="rounded-xl border border-neutral-200 dark:border-neutral-800"
                   >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold">
-                        {exercise.title}
-                      </p>
-                      <div className="mt-1 flex flex-wrap items-center gap-2">
-                        {category && (
-                          <CategoryBadge
-                            name={category.name_pl}
-                            slug={category.slug}
-                          />
-                        )}
-                        <DifficultyIndicator difficulty={exercise.difficulty} />
-                        <span className="text-xs text-neutral-500 dark:text-neutral-500">
-                          {formatDuration(exercise.duration_min)}
+                    <div className="flex items-center justify-between gap-3 p-3">
+                      <button
+                        type="button"
+                        onClick={() => toggleExpanded(exercise.id)}
+                        aria-expanded={isExpanded}
+                        aria-controls={previewId}
+                        className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                      >
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-semibold">
+                            {exercise.title}
+                          </span>
+                          <span className="mt-1 flex flex-wrap items-center gap-2">
+                            {category && (
+                              <CategoryBadge
+                                name={category.name_pl}
+                                slug={category.slug}
+                              />
+                            )}
+                            <DifficultyIndicator
+                              difficulty={exercise.difficulty}
+                            />
+                            <span className="text-xs text-neutral-500 dark:text-neutral-500">
+                              {formatDuration(exercise.duration_min)}
+                            </span>
+                            <AuthorBadge
+                              authorId={exercise.author_id}
+                              currentUserId={currentUserId}
+                              authorsById={authorsById}
+                              teamId={exercise.team_id}
+                            />
+                          </span>
                         </span>
-                        <AuthorBadge
-                          authorId={exercise.author_id}
-                          currentUserId={currentUserId}
-                          authorsById={authorsById}
-                          teamId={exercise.team_id}
+                        <ChevronIcon expanded={isExpanded} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleAdd(exercise)}
+                        className="shrink-0 rounded-full bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
+                      >
+                        {justAddedId === exercise.id ? "Dodano ✓" : "Dodaj"}
+                      </button>
+                    </div>
+                    {isExpanded && (
+                      <div
+                        id={previewId}
+                        className="border-t border-neutral-200 p-3 dark:border-neutral-800"
+                      >
+                        <ExercisePreview
+                          exercise={exercise}
+                          sportSlug={
+                            exercise.sport_id !== null
+                              ? sportsById.get(exercise.sport_id)?.slug
+                              : undefined
+                          }
                         />
                       </div>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handleAdd(exercise)}
-                      className="shrink-0 rounded-full bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
-                    >
-                      {justAddedId === exercise.id ? "Dodano ✓" : "Dodaj"}
-                    </button>
+                    )}
                   </li>
                 );
               })}
@@ -267,5 +327,26 @@ export function ExercisePicker({
         </div>
       </div>
     </div>
+  );
+}
+
+function ChevronIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 10 10"
+      fill="none"
+      aria-hidden="true"
+      className={`shrink-0 text-neutral-400 transition-transform ${expanded ? "rotate-180" : ""}`}
+    >
+      <path
+        d="M2 3.5L5 6.5L8 3.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -1,4 +1,5 @@
-import type { Difficulty } from "@/lib/supabase/types";
+import type { BoardElement } from "@/lib/board/types";
+import type { Difficulty, Exercise } from "@/lib/supabase/types";
 
 export const DIFFICULTY_LABELS: Record<Difficulty, string> = {
   1: "Bardzo łatwy",
@@ -34,4 +35,10 @@ export function categoryBadgeClasses(slug: string): string {
 
 export function formatDuration(minutes: number | null): string {
   return minutes ? `${minutes} min` : "—";
+}
+
+export function boardElementsOf(exercise: Exercise): BoardElement[] | null {
+  return Array.isArray(exercise.board_state)
+    ? (exercise.board_state as unknown as BoardElement[])
+    : null;
 }


### PR DESCRIPTION
## Summary

In "Dodaj ćwiczenie", a row only showed title/category/difficulty/duration/scope — no way to see an exercise's description, steps, equipment, or diagram before adding it blind. This adds an in-place expandable preview:

- Clicking a row (title/badges area, not the **Dodaj** button) expands it inline to show description, numbered steps, equipment, and the board diagram when one exists — no modal navigation, no scroll reset.
- Clicking again collapses it; opening a different row collapses whichever was open (accordion, one open at a time — keeps a long list from turning into a wall of open diagrams on a phone).
- **Dodaj** stays a separate click target and still adds without forcing an expand.
- The diagram reuses `BoardView` (via `BoardViewLoader`) exactly as the exercise detail page does — same read-only, non-interactive rendering, honouring `board_field_mode`. `boardElementsOf` moved from the detail page into `lib/exercises.ts` so both places share one definition instead of two copies drifting apart.
- Exercises with `board_state === null` (e.g. "1 on 1 covered catch", a reading drill with nothing to draw) render as plain text — no board section, no empty frame, no reserved space.
- The picker didn't have a sport slug available per exercise (only `sport_id`), which the board renderer needs to draw the right field. Rather than threading that through `WorkoutBuilder` (out of scope per the task), `ExercisePicker` fetches the small `sports` table itself, the same way it already self-contains category/author lookups.

Nothing in the expanded content is interactive beyond scrolling, and nothing about add-to-section or `WorkoutBuilder` itself changed.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build` all pass.
- Traced every acceptance point against the code: toggle target vs. Dodaj target, null-board rendering, no reserved diagram space, non-interactive board, no width overflow at narrow viewports (the board container has no fixed widths and scales via `BoardView`'s existing `ResizeObserver`).
- Confirmed via the seed migration that "1 on 1 covered catch" has `board_state = null`, and that some exercises carry non-`american_football` `sport_id`s (a few `football`/soccer rows, some universal/`null`), which is why the sport-slug resolution matters for correct field rendering, not just AF.
- **Not done**: an actual click-through in a browser. This environment has no Supabase project wired up (no env vars, no Docker for a local stack), and the picker sits behind auth + a real workout/team, so I couldn't open it and click an exercise end-to-end. Worth a manual pass before merging.

## Test plan

- [ ] Open the picker, expand an exercise that has a diagram — confirm it renders correctly (right field, right field mode).
- [ ] Expand "1 on 1 covered catch" — confirm clean text with no empty diagram frame.
- [ ] Confirm **Dodaj** still adds without expanding the row.
- [ ] On a narrow viewport (~380px), confirm the diagram scales down instead of overflowing the modal.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cuFCQE4rVi5EDJKyyoEg7

---
_Generated by [Claude Code](https://claude.ai/code/session_018cuFCQE4rVi5EDJKyyoEg7)_