### PR TITLE
Rework exercise preview: text-first, diagram as a small thumbnail

### DIFF
--- a/components/board/BoardView.tsx
+++ b/components/board/BoardView.tsx
@@ -14,6 +14,14 @@ interface BoardViewProps {
   /** Exercise's stored board_field_mode - null falls back to the sport's defaultFieldModeId, same as a brand-new board. */
   fieldModeId?: string | null;
   elements: BoardElement[];
+  /**
+   * Renders at a fixed size instead of filling the container's width -
+   * the board is scaled down to fit inside both bounds (whichever is
+   * tighter) while keeping the field's aspect ratio. Meant for compact
+   * thumbnails; omit both for the normal responsive full-width behavior.
+   */
+  maxWidth?: number;
+  maxHeight?: number;
 }
 
 /**
@@ -22,18 +30,26 @@ interface BoardViewProps {
  * every interactive handler), so an exercise's diagram renders
  * pixel-identical on the detail page without loading the full editor.
  */
-export function BoardView({ sportSlug, fieldModeId, elements }: BoardViewProps) {
+export function BoardView({
+  sportSlug,
+  fieldModeId,
+  elements,
+  maxWidth,
+  maxHeight,
+}: BoardViewProps) {
   const config = getSportConfig(sportSlug);
   const resolvedModeId = fieldModeId ?? config.defaultFieldModeId;
   const fieldMode =
     config.fieldModes.find((m) => m.id === resolvedModeId) ??
     config.fieldModes[0];
   const dims = { width: fieldMode.width, height: fieldMode.height };
+  const fixedSize = maxWidth !== undefined || maxHeight !== undefined;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
+    if (fixedSize) return;
     const el = containerRef.current;
     if (!el) return;
     const observer = new ResizeObserver((entries) => {
@@ -44,20 +60,44 @@ export function BoardView({ sportSlug, fieldModeId, elements }: BoardViewProps) 
     });
     observer.observe(el);
     return () => observer.disconnect();
-  }, []);
+  }, [fixedSize]);
 
-  const scale = containerSize.width > 0 ? containerSize.width / dims.width : 1;
+  const fixedScale = fixedSize
+    ? Math.min(
+        maxWidth !== undefined ? maxWidth / dims.width : Infinity,
+        maxHeight !== undefined ? maxHeight / dims.height : Infinity,
+      )
+    : 1;
+  const fixedWidth = dims.width * fixedScale;
+  const fixedHeight = dims.height * fixedScale;
+
+  const scale = fixedSize
+    ? fixedScale
+    : containerSize.width > 0
+      ? containerSize.width / dims.width
+      : 1;
+  const stageWidth = fixedSize ? fixedWidth : containerSize.width;
+  const stageHeight = fixedSize ? fixedHeight : containerSize.height;
+  const ready = fixedSize || containerSize.width > 0;
 
   return (
     <div
       ref={containerRef}
-      className="w-full overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950"
-      style={{ aspectRatio: `${dims.width} / ${dims.height}` }}
+      className={
+        fixedSize
+          ? "shrink-0 overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950"
+          : "w-full overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-950"
+      }
+      style={
+        fixedSize
+          ? { width: fixedWidth, height: fixedHeight }
+          : { aspectRatio: `${dims.width} / ${dims.height}` }
+      }
     >
-      {containerSize.width > 0 && (
+      {ready && (
         <Stage
-          width={containerSize.width}
-          height={containerSize.height}
+          width={stageWidth}
+          height={stageHeight}
           scaleX={scale}
           scaleY={scale}
           listening={false}

--- a/components/board/BoardViewLoader.tsx
+++ b/components/board/BoardViewLoader.tsx
@@ -16,16 +16,22 @@ export function BoardViewLoader({
   sportSlug,
   fieldModeId,
   elements,
+  maxWidth,
+  maxHeight,
 }: {
   sportSlug?: string | null;
   fieldModeId?: string | null;
   elements: BoardElement[];
+  maxWidth?: number;
+  maxHeight?: number;
 }) {
   return (
     <BoardView
       sportSlug={sportSlug}
       fieldModeId={fieldModeId}
       elements={elements}
+      maxWidth={maxWidth}
+      maxHeight={maxHeight}
     />
   );
 }

--- a/components/exercises/ExercisePreview.tsx
+++ b/components/exercises/ExercisePreview.tsx
@@ -1,6 +1,15 @@
+"use client";
+
+import { useState } from "react";
 import { BoardViewLoader } from "@/components/board/BoardViewLoader";
 import { boardElementsOf } from "@/lib/exercises";
 import type { Exercise } from "@/lib/supabase/types";
+
+// Collapsed-thumbnail bounding box. Both bounds matter - a wide field (e.g.
+// American football's full 1200x520 board) would blow past a phone's width
+// if it were only capped by height.
+const THUMBNAIL_MAX_HEIGHT = 200;
+const THUMBNAIL_MAX_WIDTH = 260;
 
 // board_state is null for much of the library, so every section below is independently optional.
 export function ExercisePreview({
@@ -10,6 +19,7 @@ export function ExercisePreview({
   exercise: Exercise;
   sportSlug?: string | null;
 }) {
+  const [boardExpanded, setBoardExpanded] = useState(false);
   const boardElements = boardElementsOf(exercise);
   const hasBoard = boardElements !== null && boardElements.length > 0;
   const hasEquipment = exercise.equipment.length > 0;
@@ -23,29 +33,11 @@ export function ExercisePreview({
     );
   }
 
-  return (
-    <div className="space-y-3">
-      {boardElements && boardElements.length > 0 && (
-        <BoardViewLoader
-          sportSlug={sportSlug}
-          fieldModeId={exercise.board_field_mode}
-          elements={boardElements}
-        />
-      )}
-
-      {hasEquipment && (
-        <div className="flex flex-wrap gap-1.5">
-          {exercise.equipment.map((item) => (
-            <span
-              key={item}
-              className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-            >
-              {item}
-            </span>
-          ))}
-        </div>
-      )}
-
+  // Text is what answers "what is this and how do I run it" - it always
+  // leads, with the diagram as supporting illustration rather than the
+  // main event.
+  const text = (
+    <div className="min-w-0 flex-1 space-y-3">
       {exercise.description && (
         <p className="whitespace-pre-line text-sm text-neutral-700 dark:text-neutral-300">
           {exercise.description}
@@ -64,6 +56,79 @@ export function ExercisePreview({
           </ol>
         </div>
       )}
+
+      {hasEquipment && (
+        <div className="flex flex-wrap gap-1.5">
+          {exercise.equipment.map((item) => (
+            <span
+              key={item}
+              className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
+  );
+
+  if (!boardElements || boardElements.length === 0) {
+    return text;
+  }
+
+  return (
+    <div
+      className={
+        boardExpanded
+          ? "space-y-3"
+          : "flex flex-col gap-3 sm:flex-row sm:items-start"
+      }
+    >
+      {text}
+      <button
+        type="button"
+        onClick={() => setBoardExpanded((expanded) => !expanded)}
+        aria-expanded={boardExpanded}
+        aria-label={boardExpanded ? "Zwiń diagram" : "Powiększ diagram"}
+        className={
+          boardExpanded
+            ? "block w-full cursor-zoom-out rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/50"
+            : "group relative shrink-0 cursor-zoom-in self-start rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/50"
+        }
+      >
+        <BoardViewLoader
+          sportSlug={sportSlug}
+          fieldModeId={exercise.board_field_mode}
+          elements={boardElements}
+          maxWidth={boardExpanded ? undefined : THUMBNAIL_MAX_WIDTH}
+          maxHeight={boardExpanded ? undefined : THUMBNAIL_MAX_HEIGHT}
+        />
+        {!boardExpanded && (
+          <span className="pointer-events-none absolute bottom-1.5 right-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-black/50 text-white transition-colors group-hover:bg-black/70">
+            <ExpandIcon />
+          </span>
+        )}
+      </button>
+    </div>
+  );
+}
+
+function ExpandIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M1 5V1h4M11 7v4H7M1 1l4 4M11 11l-4-4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #49's exercise picker preview, addressing on-device feedback that the proportions were wrong:

- **Content order inverted**: the preview now reads description → steps → equipment, with the diagram last as supporting illustration, instead of diagram → equipment → description → steps.
- **Diagram was full board height** (aspect-ratio locked to the field, up to ~1000px), dominating the modal and pushing the description/steps below the fold. It's now a small thumbnail (`BoardView` scaled to fit inside a 200×260px box) placed after the text — stacked below on narrow viewports, beside it from `sm:` up.
- **Flat/wide boards** (e.g. American football's full 1200×520 field for "Agility z płotkami") no longer force a tall thumbnail full of empty turf — the box is capped on *both* axes, so a wide field shrinks in width first rather than blowing past a phone's screen at a fixed height.
- Tapping the thumbnail expands it in place to full size; tapping again collapses it back. No lightbox/second modal, so it never fights the picker dialog for width or z-index.
- Diagram-less exercises (e.g. "1 on 1 covered catch", `board_state` null) are unaffected: text only, no thumbnail, no placeholder frame.

`BoardView` gained optional `maxWidth`/`maxHeight` props for this fixed-size thumbnail mode; omitting both keeps its existing responsive (fill-container-width) behavior, which the exercise detail page and the expanded/full-size state both still use unchanged.

Add-to-section (`Dodaj`) and the tactics board builder are untouched.

## Test plan

Verified with a temporary local harness (mock exercises, no backend calls) driven by Playwright at both a narrow (390px) and wide (900px) viewport, then removed before committing:

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass
- [x] Narrow viewport: expanding "Agility z płotkami" shows text on top, small thumbnail below (~113×260px for this field's 2.3:1 ratio, well under the 200px height cap)
- [x] Tapping the thumbnail expands it to full size in place without exceeding the dialog's width; tapping again collapses it back
- [x] Wide viewport: thumbnail sits beside the text, top-aligned, instead of below it
- [x] Expanding "1 on 1 covered catch" (`board_state` null) shows description/steps only — no thumbnail, no empty board frame
- [x] `Dodaj` on a collapsed row adds the exercise without expanding its preview
- [x] No horizontal overflow at any point (checked via `document.documentElement.scrollWidth`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhN4HCoRYcLzTqM6vVCkoe)_