### PR TITLE
Show a collapse icon on the expanded exercise diagram

### DIFF
--- a/components/exercises/ExercisePreview.tsx
+++ b/components/exercises/ExercisePreview.tsx
@@ -92,7 +92,7 @@ export function ExercisePreview({
         aria-label={boardExpanded ? "Zwiń diagram" : "Powiększ diagram"}
         className={
           boardExpanded
-            ? "block w-full cursor-zoom-out rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/50"
+            ? "group relative block w-full cursor-zoom-out rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/50"
             : "group relative shrink-0 cursor-zoom-in self-start rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600/50"
         }
       >
@@ -103,11 +103,9 @@ export function ExercisePreview({
           maxWidth={boardExpanded ? undefined : THUMBNAIL_MAX_WIDTH}
           maxHeight={boardExpanded ? undefined : THUMBNAIL_MAX_HEIGHT}
         />
-        {!boardExpanded && (
-          <span className="pointer-events-none absolute bottom-1.5 right-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-black/50 text-white transition-colors group-hover:bg-black/70">
-            <ExpandIcon />
-          </span>
-        )}
+        <span className="pointer-events-none absolute bottom-1.5 right-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-black/50 text-white transition-colors group-hover:bg-black/70">
+          {boardExpanded ? <CollapseIcon /> : <ExpandIcon />}
+        </span>
       </button>
     </div>
   );
@@ -124,6 +122,26 @@ function ExpandIcon() {
     >
       <path
         d="M1 5V1h4M11 7v4H7M1 1l4 4M11 11l-4-4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CollapseIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M5 1V5H1M11 7H7v4M1 1l4 4M11 11l-4-4"
         stroke="currentColor"
         strokeWidth="1.4"
         strokeLinecap="round"


### PR DESCRIPTION
## Summary

Follow-up polish on the exercise preview thumbnail from #50.

- When the diagram is collapsed, the corner badge already showed outward arrows as a clear "click to enlarge" cue.
- When expanded, the only affordance to shrink it back was the cursor changing to a magnifying glass (`cursor-zoom-out`) — invisible on touch, easy to miss on desktop.
- The corner badge is now stateful: outward arrows (`ExpandIcon`) when collapsed, inward arrows (new `CollapseIcon`) when expanded, so both directions have the same visible, tappable cue. The inward icon mirrors the outward one's construction (same diagonal shafts, corner brackets relocated to the inner points) so the two read as a consistent pair.
- Nothing else about the preview's behavior or layout changes.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Verified the exact markup/SVGs render correctly in headless Chromium (outward arrows for collapsed, inward arrows for expanded) — screenshot comparison confirmed both icons point the intended direction and share the same badge styling/position
- [ ] Manual check in a running app against a real exercise with board data

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea4h7b2mHrU1J3ZAo99w3E)_