### PR TITLE
Add training mode: phone-first live workout view

### DIFF
--- a/app/app/workouts/[id]/train/loading.tsx
+++ b/app/app/workouts/[id]/train/loading.tsx
@@ -1,0 +1,10 @@
+export default function Loading() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-950">
+      <div
+        aria-hidden="true"
+        className="h-12 w-12 animate-spin rounded-full border-4 border-white/20 border-t-white"
+      />
+    </div>
+  );
+}

--- a/app/app/workouts/[id]/train/page.tsx
+++ b/app/app/workouts/[id]/train/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { TrainingMode } from "@/components/training/TrainingMode";
+import { buildTrainingPlan } from "@/lib/trainingMode";
+import type { Exercise, Position } from "@/lib/supabase/types";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Tryb treningu — Coach Zone",
+};
+
+export default async function TrainingModePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: userData } = await supabase.auth.getUser();
+
+  // Middleware already guarantees a user for any /app/* route; this is a
+  // defensive fallback, matching the other /app pages.
+  if (!userData.user) {
+    redirect("/login");
+  }
+
+  const [{ data: workout, error: workoutError }, { data: items }] =
+    await Promise.all([
+      supabase.from("workouts").select("*").eq("id", id).maybeSingle(),
+      supabase
+        .from("workout_items")
+        .select("*")
+        .eq("workout_id", id)
+        .order("position", { ascending: true }),
+    ]);
+
+  if (!workout) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 pt-8 pb-20 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {workoutError ? "Wystąpił błąd" : "Nie znaleziono treningu"}
+        </h1>
+        <p className="mt-3 text-neutral-600 dark:text-neutral-400">
+          {workoutError
+            ? "Nie udało się wczytać treningu. Spróbuj ponownie."
+            : "Ten trening nie istnieje albo nie masz do niego dostępu."}
+        </p>
+        <Link
+          href={workoutError ? `/app/workouts/${id}/train` : "/app/workouts"}
+          className="mt-6 inline-block rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          {workoutError ? "Spróbuj ponownie" : "Powrót do listy"}
+        </Link>
+      </main>
+    );
+  }
+
+  const exerciseIds = Array.from(
+    new Set((items ?? []).map((item) => item.exercise_id)),
+  );
+
+  // RLS already scopes `exercises` to what this coach can see (same query
+  // WorkoutBuilderPage runs); positions/exercise_positions/sports are
+  // readable by any authenticated user (see
+  // supabase/migrations/20260727210405_exercise_scope_positions_and_sport_fix.sql
+  // and 20260710100000_sports_and_exercise_sport_id.sql), so no team scoping
+  // is needed for those three.
+  const [{ data: exercises }, { data: exercisePositions }, { data: sports }] =
+    await Promise.all([
+      exerciseIds.length > 0
+        ? supabase.from("exercises").select("*").in("id", exerciseIds)
+        : Promise.resolve({ data: [] as Exercise[] }),
+      exerciseIds.length > 0
+        ? supabase
+            .from("exercise_positions")
+            .select("exercise_id, position_id")
+            .in("exercise_id", exerciseIds)
+        : Promise.resolve({
+            data: [] as { exercise_id: string; position_id: string }[],
+          }),
+      supabase.from("sports").select("*"),
+    ]);
+
+  const positionIds = Array.from(
+    new Set((exercisePositions ?? []).map((link) => link.position_id)),
+  );
+  const { data: positions } =
+    positionIds.length > 0
+      ? await supabase.from("positions").select("*").in("id", positionIds)
+      : { data: [] as Position[] };
+
+  const exercisesById = Object.fromEntries(
+    (exercises ?? []).map((exercise) => [exercise.id, exercise]),
+  );
+
+  const positionsById = new Map(
+    (positions ?? []).map((position) => [position.id, position]),
+  );
+  const positionsByExerciseId: Record<string, Position[]> = {};
+  for (const link of exercisePositions ?? []) {
+    const position = positionsById.get(link.position_id);
+    if (!position) continue;
+    (positionsByExerciseId[link.exercise_id] ??= []).push(position);
+  }
+
+  const sportSlugById = Object.fromEntries(
+    (sports ?? []).map((sport) => [sport.id, sport.slug]),
+  );
+
+  const plan = buildTrainingPlan({
+    items: items ?? [],
+    exercisesById,
+    positionsByExerciseId,
+    sportSlugById,
+  });
+
+  return (
+    <TrainingMode
+      workoutId={workout.id}
+      workoutTitle={workout.title}
+      plan={plan}
+    />
+  );
+}

--- a/components/training/PositionPill.tsx
+++ b/components/training/PositionPill.tsx
@@ -1,0 +1,24 @@
+const TEAM_LABEL = "Cała drużyna";
+
+// Training mode's own high-contrast take on PositionPills - dark background
+// throughout regardless of system theme (see TrainingMode.tsx), so it can't
+// reuse the light/dark-aware component from components/exercises.
+export function PositionPill({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full bg-emerald-500/20 px-2.5 py-1 text-xs font-bold tracking-wide text-emerald-300 uppercase">
+      {label}
+    </span>
+  );
+}
+
+export function PositionPillRow({ codes }: { codes: string[] }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {codes.length === 0 ? (
+        <PositionPill label={TEAM_LABEL} />
+      ) : (
+        codes.map((code) => <PositionPill key={code} label={code} />)
+      )}
+    </div>
+  );
+}

--- a/components/training/TrainingCompleteScreen.tsx
+++ b/components/training/TrainingCompleteScreen.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export function TrainingCompleteScreen({
+  workoutId,
+  workoutTitle,
+}: {
+  workoutId: string;
+  workoutTitle: string;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-neutral-950 px-6 text-center text-white">
+      <p className="text-sm font-semibold tracking-wide text-emerald-400 uppercase">
+        Trening zakończony
+      </p>
+      <h1 className="text-2xl font-bold tracking-tight text-balance">
+        {workoutTitle}
+      </h1>
+      <p className="text-neutral-400">Wszystkie sekcje zostały przećwiczone.</p>
+      <Link
+        href={`/app/workouts/${workoutId}`}
+        className="mt-4 rounded-full bg-emerald-500 px-6 py-3 text-lg font-bold text-neutral-950 transition-colors active:bg-emerald-400"
+      >
+        Powrót do treningu
+      </Link>
+    </div>
+  );
+}

--- a/components/training/TrainingGroupCard.tsx
+++ b/components/training/TrainingGroupCard.tsx
@@ -1,0 +1,55 @@
+import type { TrainingGroup } from "@/lib/trainingMode";
+import { PositionPillRow } from "./PositionPill";
+
+export function TrainingGroupCard({
+  group,
+  onOpen,
+}: {
+  group: TrainingGroup;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-center justify-between gap-3 rounded-2xl border border-white/15 bg-white/5 px-4 py-4 text-left transition-colors active:bg-white/10"
+    >
+      <span className="min-w-0">
+        <PositionPillRow
+          codes={group.positions.map((position) => position.code)}
+        />
+        <span className="mt-1.5 block truncate text-lg font-semibold text-white">
+          {group.exercise.title}
+        </span>
+      </span>
+      <span className="flex shrink-0 items-center gap-2 text-neutral-400">
+        {group.durationMin !== null && (
+          <span className="text-sm font-medium tabular-nums">
+            {group.durationMin} min
+          </span>
+        )}
+        <ChevronIcon />
+      </span>
+    </button>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M7.5 4.5L13 10l-5.5 5.5"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/training/TrainingGroupDetailScreen.tsx
+++ b/components/training/TrainingGroupDetailScreen.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { BoardViewLoader } from "@/components/board/BoardViewLoader";
+import type { TrainingGroup } from "@/lib/trainingMode";
+import { PositionPillRow } from "./PositionPill";
+
+// Matches ExercisePreview's collapsed-thumbnail bounds, so tap-to-expand
+// looks and behaves the same everywhere it shows up in the app.
+const THUMBNAIL_MAX_HEIGHT = 200;
+const THUMBNAIL_MAX_WIDTH = 260;
+
+// Screen 2: how to set the drill out. No timer here on purpose - the block's
+// countdown lives on the overview screen and keeps running underneath.
+export function TrainingGroupDetailScreen({
+  group,
+  onBack,
+}: {
+  group: TrainingGroup;
+  onBack: () => void;
+}) {
+  const [boardExpanded, setBoardExpanded] = useState(false);
+  const { exercise } = group;
+  const hasBoard =
+    exercise.boardElements !== null && exercise.boardElements.length > 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col overflow-y-auto bg-neutral-950 text-white">
+      <header className="flex items-center gap-3 px-5 pt-[max(1.25rem,env(safe-area-inset-top))] pb-2">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Powrót do przeglądu bloku"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-2xl text-neutral-300 hover:bg-white/10 hover:text-white active:bg-white/10"
+        >
+          ←
+        </button>
+        <PositionPillRow
+          codes={group.positions.map((position) => position.code)}
+        />
+      </header>
+
+      <div className="flex-1 space-y-6 px-5 pt-3 pb-10">
+        <h1 className="text-3xl font-bold tracking-tight text-balance">
+          {exercise.title}
+        </h1>
+
+        {hasBoard && (
+          <button
+            type="button"
+            onClick={() => setBoardExpanded((expanded) => !expanded)}
+            aria-expanded={boardExpanded}
+            aria-label={boardExpanded ? "Zwiń diagram" : "Powiększ diagram"}
+            className={
+              boardExpanded
+                ? "group relative block w-full cursor-zoom-out rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                : "group relative inline-block cursor-zoom-in rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+            }
+          >
+            <BoardViewLoader
+              sportSlug={exercise.sportSlug}
+              fieldModeId={exercise.boardFieldMode}
+              elements={exercise.boardElements!}
+              maxWidth={boardExpanded ? undefined : THUMBNAIL_MAX_WIDTH}
+              maxHeight={boardExpanded ? undefined : THUMBNAIL_MAX_HEIGHT}
+            />
+            <span className="pointer-events-none absolute right-2 bottom-2 flex h-8 w-8 items-center justify-center rounded-full bg-black/60 text-white transition-colors group-hover:bg-black/80">
+              {boardExpanded ? <CollapseIcon /> : <ExpandIcon />}
+            </span>
+          </button>
+        )}
+
+        {exercise.description && (
+          <p className="whitespace-pre-line text-lg leading-relaxed text-neutral-200">
+            {exercise.description}
+          </p>
+        )}
+
+        {exercise.steps.length > 0 && (
+          <div>
+            <h2 className="text-sm font-semibold tracking-wide text-neutral-400 uppercase">
+              Przebieg ćwiczenia
+            </h2>
+            <ol className="mt-3 list-decimal space-y-2 pl-5 text-lg leading-relaxed text-neutral-200">
+              {exercise.steps.map((step, i) => (
+                <li key={i}>{step}</li>
+              ))}
+            </ol>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ExpandIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M1 5V1h4M11 7v4H7M1 1l4 4M11 11l-4-4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CollapseIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M5 1V5H1M11 7H7v4M1 1l4 4M11 11l-4-4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/training/TrainingMode.tsx
+++ b/components/training/TrainingMode.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { TrainingPlan } from "@/lib/trainingMode";
+import { TrainingCompleteScreen } from "./TrainingCompleteScreen";
+import { TrainingGroupDetailScreen } from "./TrainingGroupDetailScreen";
+import { TrainingOverviewScreen } from "./TrainingOverviewScreen";
+
+// Read-only playback shell for running a workout on the field - it walks
+// `plan` (built server-side by buildTrainingPlan) in order and never writes
+// anything back. Single-coach, single-phone: no realtime, no persistence,
+// no shared state - closing the tab just means starting over from section 1.
+export function TrainingMode({
+  workoutId,
+  workoutTitle,
+  plan,
+}: {
+  workoutId: string;
+  workoutTitle: string;
+  plan: TrainingPlan;
+}) {
+  const [sectionIndex, setSectionIndex] = useState(0);
+  const [blockIndex, setBlockIndex] = useState(0);
+  const [openGroupKey, setOpenGroupKey] = useState<string | null>(null);
+  const [finished, setFinished] = useState(false);
+
+  if (plan.length === 0) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-neutral-950 px-6 text-center text-white">
+        <h1 className="text-2xl font-bold tracking-tight text-balance">
+          {workoutTitle}
+        </h1>
+        <p className="text-neutral-400">
+          Ten trening nie ma jeszcze żadnych ćwiczeń do przećwiczenia.
+        </p>
+        <Link
+          href={`/app/workouts/${workoutId}`}
+          className="mt-2 rounded-full bg-emerald-500 px-6 py-3 text-lg font-bold text-neutral-950 transition-colors active:bg-emerald-400"
+        >
+          Powrót do treningu
+        </Link>
+      </div>
+    );
+  }
+
+  if (finished) {
+    return (
+      <TrainingCompleteScreen
+        workoutId={workoutId}
+        workoutTitle={workoutTitle}
+      />
+    );
+  }
+
+  const section = plan[sectionIndex];
+  const block = section.blocks[blockIndex];
+  const openGroup =
+    block.groups.find((group) => group.key === openGroupKey) ?? null;
+
+  function handleNext() {
+    setOpenGroupKey(null);
+    if (blockIndex < section.blocks.length - 1) {
+      setBlockIndex((i) => i + 1);
+      return;
+    }
+    if (sectionIndex < plan.length - 1) {
+      setSectionIndex((i) => i + 1);
+      setBlockIndex(0);
+      return;
+    }
+    setFinished(true);
+  }
+
+  if (openGroup) {
+    return (
+      <TrainingGroupDetailScreen
+        group={openGroup}
+        onBack={() => setOpenGroupKey(null)}
+      />
+    );
+  }
+
+  return (
+    <TrainingOverviewScreen
+      workoutId={workoutId}
+      section={section}
+      sectionIndex={sectionIndex}
+      totalSections={plan.length}
+      block={block}
+      blockIndex={blockIndex}
+      totalBlocks={section.blocks.length}
+      blockKey={`${sectionIndex}-${blockIndex}`}
+      onOpenGroup={setOpenGroupKey}
+      onNext={handleNext}
+    />
+  );
+}

--- a/components/training/TrainingOverviewScreen.tsx
+++ b/components/training/TrainingOverviewScreen.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import {
+  formatCountdown,
+  type TrainingBlock,
+  type TrainingSection,
+} from "@/lib/trainingMode";
+import { armTrainingSignal, fireTrainingSignal } from "./trainingSignal";
+import { TrainingGroupCard } from "./TrainingGroupCard";
+import { useTrainingTimer } from "./useTrainingTimer";
+
+// Screen 1: one shared timer for the whole block (not per group - the
+// slowest group is what everyone waits on), the block's parallel groups as
+// tap targets below it, and one button that advances every group together.
+export function TrainingOverviewScreen({
+  workoutId,
+  section,
+  sectionIndex,
+  totalSections,
+  block,
+  blockIndex,
+  totalBlocks,
+  blockKey,
+  onOpenGroup,
+  onNext,
+}: {
+  workoutId: string;
+  section: TrainingSection;
+  sectionIndex: number;
+  totalSections: number;
+  block: TrainingBlock;
+  blockIndex: number;
+  totalBlocks: number;
+  blockKey: string;
+  onOpenGroup: (key: string) => void;
+  onNext: () => void;
+}) {
+  const { status, remainingMs, durationMin, start, setMinutes } =
+    useTrainingTimer(blockKey, block.suggestedDurationMin, fireTrainingSignal);
+  const [editing, setEditing] = useState(false);
+  const [draftMinutes, setDraftMinutes] = useState(String(durationMin));
+
+  function openEditor() {
+    if (status !== "idle") return;
+    setDraftMinutes(String(durationMin));
+    setEditing(true);
+  }
+
+  function commitDraft() {
+    const parsed = Math.round(Number(draftMinutes));
+    if (Number.isFinite(parsed) && parsed > 0) setMinutes(parsed);
+    setEditing(false);
+  }
+
+  function handleStart() {
+    armTrainingSignal();
+    start();
+  }
+
+  function handlePrzerwa() {
+    armTrainingSignal();
+    fireTrainingSignal();
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col overflow-y-auto bg-neutral-950 text-white">
+      <header className="flex items-center justify-between gap-3 px-4 pt-[max(1.25rem,env(safe-area-inset-top))]">
+        <Link
+          href={`/app/workouts/${workoutId}`}
+          aria-label="Zakończ tryb treningu"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-2xl text-neutral-400 hover:bg-white/10 hover:text-white active:bg-white/10"
+        >
+          ×
+        </Link>
+        <div className="min-w-0 text-center">
+          <p className="text-sm font-semibold text-neutral-400">
+            Sekcja {sectionIndex + 1} z {totalSections}
+          </p>
+          <h1 className="truncate text-lg font-bold tracking-tight">
+            {section.label}
+          </h1>
+        </div>
+        <div className="w-11 shrink-0" aria-hidden="true" />
+      </header>
+
+      <p className="mt-1 text-center text-sm font-medium text-neutral-500">
+        Ćwiczenie {blockIndex + 1} z {totalBlocks}
+      </p>
+
+      <div className="mt-6 flex flex-col items-center px-5">
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              autoFocus
+              value={draftMinutes}
+              onChange={(e) => setDraftMinutes(e.target.value)}
+              onBlur={commitDraft}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitDraft();
+              }}
+              aria-label="Czas bloku w minutach"
+              className="w-40 rounded-2xl border border-white/25 bg-white/10 py-3 text-center font-mono text-6xl font-bold tabular-nums text-white outline-none focus:border-emerald-400"
+            />
+            <button
+              type="button"
+              onClick={commitDraft}
+              className="rounded-full bg-emerald-500 px-4 py-3 text-base font-bold text-neutral-950 active:bg-emerald-400"
+            >
+              Gotowe
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={openEditor}
+            disabled={status !== "idle"}
+            aria-label="Ustaw czas bloku"
+            className={`font-mono text-7xl font-bold tabular-nums transition-colors sm:text-8xl ${
+              status === "completed" ? "text-amber-400" : "text-white"
+            }`}
+          >
+            {formatCountdown(remainingMs)}
+          </button>
+        )}
+
+        <div className="mt-2 h-6" role="status" aria-live="polite">
+          {status === "completed" && (
+            <p className="animate-pulse text-lg font-semibold text-amber-400">
+              Czas minął!
+            </p>
+          )}
+          {status === "idle" && !editing && (
+            <p className="text-sm text-neutral-500">
+              Stuknij czas, aby go zmienić
+            </p>
+          )}
+        </div>
+
+        <div className="mt-4 flex w-full max-w-sm gap-3">
+          {status === "idle" && (
+            <button
+              type="button"
+              onClick={handleStart}
+              className="flex-1 rounded-2xl bg-emerald-500 py-4 text-xl font-bold text-neutral-950 transition-colors active:bg-emerald-400"
+            >
+              Start
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handlePrzerwa}
+            className="flex-1 rounded-2xl border-2 border-white/30 py-4 text-xl font-bold text-white transition-colors active:bg-white/10"
+          >
+            Przerwa
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-8 flex-1 space-y-3 px-5 pb-5">
+        {block.groups.map((group) => (
+          <TrainingGroupCard
+            key={group.key}
+            group={group}
+            onOpen={() => onOpenGroup(group.key)}
+          />
+        ))}
+      </div>
+
+      <div className="sticky bottom-0 border-t border-white/10 bg-neutral-950 px-5 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <button
+          type="button"
+          onClick={onNext}
+          className="w-full rounded-2xl bg-white py-4 text-xl font-bold text-neutral-950 transition-colors active:bg-neutral-200"
+        >
+          Następne ćwiczenie →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/training/trainingSignal.ts
+++ b/components/training/trainingSignal.ts
@@ -1,0 +1,69 @@
+"use client";
+
+// The coach-facing whistle: a short beep pattern plus a vibration buzz
+// where supported. Reused for two triggers - a block's timer hitting 00:00,
+// and a manual "Przerwa" tap - same signal either way.
+//
+// Autoplay policies block a *new* AudioContext (or a suspended one) from
+// making sound unless it's created/resumed inside a user gesture. The timer
+// completion fires later from a setInterval/visibilitychange callback,
+// which is never itself a gesture - so armTrainingSignal() must be called
+// from the Start/Przerwa tap handlers to create (or resume) the shared
+// context while there's still a real gesture on the stack, and
+// fireTrainingSignal() just reuses whatever that produced.
+let sharedAudioContext: AudioContext | null = null;
+
+function getAudioContextConstructor(): typeof AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const withWebkit = window as typeof window & {
+    webkitAudioContext?: typeof AudioContext;
+  };
+  return window.AudioContext ?? withWebkit.webkitAudioContext ?? null;
+}
+
+export function armTrainingSignal(): void {
+  const Ctor = getAudioContextConstructor();
+  if (!Ctor) return;
+  if (!sharedAudioContext) {
+    sharedAudioContext = new Ctor();
+  }
+  if (sharedAudioContext.state === "suspended") {
+    void sharedAudioContext.resume();
+  }
+}
+
+function beep(
+  ctx: AudioContext,
+  startTime: number,
+  frequency: number,
+  duration: number,
+) {
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+  oscillator.type = "square";
+  oscillator.frequency.value = frequency;
+  // Short envelope instead of a hard on/off, so the beep doesn't click.
+  gain.gain.setValueAtTime(0, startTime);
+  gain.gain.linearRampToValueAtTime(0.35, startTime + 0.02);
+  gain.gain.setValueAtTime(0.35, startTime + duration - 0.03);
+  gain.gain.linearRampToValueAtTime(0, startTime + duration);
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+  oscillator.start(startTime);
+  oscillator.stop(startTime + duration);
+}
+
+export function fireTrainingSignal(): void {
+  const ctx = sharedAudioContext;
+  if (ctx) {
+    if (ctx.state === "suspended") void ctx.resume();
+    const now = ctx.currentTime;
+    beep(ctx, now, 880, 0.18);
+    beep(ctx, now + 0.24, 880, 0.18);
+    beep(ctx, now + 0.48, 880, 0.32);
+  }
+
+  if (typeof navigator !== "undefined" && "vibrate" in navigator) {
+    navigator.vibrate([200, 100, 200, 100, 400]);
+  }
+}

--- a/components/training/useTrainingTimer.ts
+++ b/components/training/useTrainingTimer.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { computeTimerTick } from "@/lib/trainingMode";
+
+export type TrainingTimerStatus = "idle" | "running" | "completed";
+
+const TICK_MS = 1000;
+
+/**
+ * A single block's countdown. Coaches pocket the phone for the whole block,
+ * so this cannot drive the display by accumulating setInterval ticks -
+ * background tabs throttle or fully suspend timers, which would drift or
+ * freeze. Instead it captures an absolute target timestamp on start() and,
+ * on every tick (interval or visibilitychange), compares that target
+ * against Date.now() via computeTimerTick - correct regardless of how many
+ * ticks were actually delivered while hidden.
+ *
+ * Resets to idle on every new blockKey: the timer never auto-runs, each
+ * block needs its own explicit Start tap while the coach sets out cones.
+ */
+export function useTrainingTimer(
+  blockKey: string,
+  suggestedDurationMin: number,
+  onComplete: () => void,
+) {
+  const [durationMin, setDurationMin] = useState(suggestedDurationMin);
+  const [status, setStatus] = useState<TrainingTimerStatus>("idle");
+  const [remainingMs, setRemainingMs] = useState(suggestedDurationMin * 60_000);
+
+  const targetAtRef = useRef<number | null>(null);
+  const firedRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
+  useEffect(() => {
+    setDurationMin(suggestedDurationMin);
+    setStatus("idle");
+    setRemainingMs(suggestedDurationMin * 60_000);
+    targetAtRef.current = null;
+    firedRef.current = false;
+  }, [blockKey, suggestedDurationMin]);
+
+  const tick = useCallback(() => {
+    const targetAt = targetAtRef.current;
+    if (targetAt === null) return;
+    const { remainingMs: nextRemaining, justCompleted } = computeTimerTick({
+      targetAt,
+      now: Date.now(),
+      alreadyFired: firedRef.current,
+    });
+    setRemainingMs(nextRemaining);
+    if (justCompleted) {
+      firedRef.current = true;
+      setStatus("completed");
+      onCompleteRef.current();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status !== "running") return;
+    const interval = setInterval(tick, TICK_MS);
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible") tick();
+    }
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [status, tick]);
+
+  const start = useCallback(() => {
+    targetAtRef.current = Date.now() + durationMin * 60_000;
+    firedRef.current = false;
+    setStatus("running");
+    // Covers a 0-minute (or already-elapsed) duration: without this, the
+    // display would still read the old value until the next interval tick.
+    tick();
+  }, [durationMin, tick]);
+
+  // Only meaningful before Start - callers are expected to gate this on
+  // status === "idle" the same way the overview screen's tap target does.
+  const setMinutes = useCallback((minutes: number) => {
+    setDurationMin(minutes);
+    setRemainingMs(minutes * 60_000);
+  }, []);
+
+  return { status, remainingMs, durationMin, start, setMinutes };
+}

--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -582,6 +582,12 @@ export function WorkoutBuilder({
         <div className="flex shrink-0 flex-col items-end gap-3">
           <SaveIndicator state={saveState} />
           <div className="flex flex-wrap items-start justify-end gap-2">
+            <Link
+              href={`/app/workouts/${workout.id}/train`}
+              className="rounded-full bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+            >
+              Rozpocznij trening
+            </Link>
             <DownloadPdfButton workout={workout} items={pdfItems} />
             <ShareWorkoutButton shareId={workout.share_id} />
             {canDelete && (

--- a/lib/trainingMode.test.ts
+++ b/lib/trainingMode.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTrainingPlan,
+  computeTimerTick,
+  formatCountdown,
+} from "./trainingMode";
+import type { Exercise, Position, WorkoutItem } from "./supabase/types";
+
+function makeExercise(overrides: Partial<Exercise> & { id: string }): Exercise {
+  return {
+    author_id: null,
+    board_field_mode: null,
+    board_state: null,
+    category_id: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    description: null,
+    difficulty: null,
+    duration_min: null,
+    equipment: [],
+    is_public: true,
+    media_url: null,
+    sport_id: null,
+    steps: [],
+    team_id: null,
+    title: "Ćwiczenie",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeItem(
+  overrides: Partial<WorkoutItem> & { id: string; exercise_id: string },
+): WorkoutItem {
+  return {
+    assigned_to: null,
+    duration_min: 10,
+    position: 0,
+    section: "main",
+    workout_id: "workout-1",
+    ...overrides,
+  };
+}
+
+function makePosition(
+  overrides: Partial<Position> & { id: string; code: string },
+): Position {
+  return {
+    label: overrides.code,
+    sort_order: 0,
+    sport_id: 1,
+    ...overrides,
+  };
+}
+
+describe("buildTrainingPlan", () => {
+  it("returns an empty plan for a workout with no items", () => {
+    expect(
+      buildTrainingPlan({
+        items: [],
+        exercisesById: {},
+        positionsByExerciseId: {},
+        sportSlugById: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it("only includes sections that have items, in section order", () => {
+    const items = [
+      makeItem({
+        id: "i1",
+        exercise_id: "e1",
+        section: "cooldown",
+        position: 0,
+      }),
+      makeItem({ id: "i2", exercise_id: "e1", section: "warmup", position: 0 }),
+    ];
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById: { e1: makeExercise({ id: "e1" }) },
+      positionsByExerciseId: {},
+      sportSlugById: {},
+    });
+    expect(plan.map((s) => s.section)).toEqual(["warmup", "cooldown"]);
+  });
+
+  it("collapses a section with no positional split into one whole-team group, one block per item", () => {
+    const items = [
+      makeItem({ id: "i1", exercise_id: "e1", position: 0, duration_min: 8 }),
+      makeItem({ id: "i2", exercise_id: "e2", position: 1, duration_min: 12 }),
+    ];
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById: {
+        e1: makeExercise({ id: "e1", title: "Trucht" }),
+        e2: makeExercise({ id: "e2", title: "Rozciąganie" }),
+      },
+      positionsByExerciseId: {},
+      sportSlugById: {},
+    });
+
+    expect(plan).toHaveLength(1);
+    const [section] = plan;
+    expect(section.blocks).toHaveLength(2);
+    expect(section.blocks[0].groups).toEqual([
+      expect.objectContaining({ key: "team", positions: [], itemId: "i1" }),
+    ]);
+    expect(section.blocks[0].suggestedDurationMin).toBe(8);
+    expect(section.blocks[1].groups[0].exercise.title).toBe("Rozciąganie");
+    expect(section.blocks[1].suggestedDurationMin).toBe(12);
+  });
+
+  it("treats an untagged exercise and one explicitly tagged TEAM as the same whole-team group", () => {
+    const team = makePosition({ id: "p-team", code: "TEAM", sort_order: 100 });
+    const items = [
+      makeItem({ id: "i1", exercise_id: "e1", position: 0 }),
+      makeItem({ id: "i2", exercise_id: "e2", position: 1 }),
+    ];
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById: {
+        e1: makeExercise({ id: "e1" }),
+        e2: makeExercise({ id: "e2" }),
+      },
+      positionsByExerciseId: { e2: [team] },
+      sportSlugById: {},
+    });
+
+    expect(plan[0].blocks).toHaveLength(2);
+    expect(plan[0].blocks[0].groups[0].key).toBe("team");
+    expect(plan[0].blocks[1].groups[0].key).toBe("team");
+  });
+
+  it("splits a section into parallel groups by position tag, zipped block by block", () => {
+    const ol = makePosition({ id: "p-ol", code: "OL", sort_order: 10 });
+    const wr = makePosition({ id: "p-wr", code: "WR", sort_order: 40 });
+    const db = makePosition({ id: "p-db", code: "DB", sort_order: 90 });
+
+    const items = [
+      makeItem({
+        id: "ol-1",
+        exercise_id: "e-ol-1",
+        position: 0,
+        duration_min: 10,
+      }),
+      makeItem({
+        id: "wr-1",
+        exercise_id: "e-wr-1",
+        position: 1,
+        duration_min: 8,
+      }),
+      makeItem({
+        id: "db-1",
+        exercise_id: "e-db-1",
+        position: 2,
+        duration_min: 8,
+      }),
+      makeItem({
+        id: "ol-2",
+        exercise_id: "e-ol-2",
+        position: 3,
+        duration_min: 6,
+      }),
+      makeItem({
+        id: "wr-2",
+        exercise_id: "e-wr-2",
+        position: 4,
+        duration_min: 6,
+      }),
+      makeItem({
+        id: "db-2",
+        exercise_id: "e-db-2",
+        position: 5,
+        duration_min: 6,
+      }),
+    ];
+    const exercisesById = Object.fromEntries(
+      items.map((item) => [
+        item.exercise_id,
+        makeExercise({ id: item.exercise_id }),
+      ]),
+    );
+
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById,
+      positionsByExerciseId: {
+        "e-ol-1": [ol],
+        "e-ol-2": [ol],
+        "e-wr-1": [wr],
+        "e-wr-2": [wr],
+        "e-db-1": [db],
+        "e-db-2": [db],
+      },
+      sportSlugById: {},
+    });
+
+    expect(plan[0].blocks).toHaveLength(2);
+    // Ordered by the position's own sort_order: OL (10), WR (40), DB (90).
+    expect(plan[0].blocks[0].groups.map((g) => g.key)).toEqual([
+      "OL",
+      "WR",
+      "DB",
+    ]);
+    expect(plan[0].blocks[0].groups.map((g) => g.itemId)).toEqual([
+      "ol-1",
+      "wr-1",
+      "db-1",
+    ]);
+    // OL is 10, the other two are 8 - the block waits on the slowest group.
+    expect(plan[0].blocks[0].suggestedDurationMin).toBe(10);
+    expect(plan[0].blocks[1].suggestedDurationMin).toBe(6);
+  });
+
+  it("keeps a multi-position tag combo as its own group, distinct from either position alone", () => {
+    const ol = makePosition({ id: "p-ol", code: "OL", sort_order: 10 });
+    const dl = makePosition({ id: "p-dl", code: "DL", sort_order: 60 });
+    const items = [
+      makeItem({ id: "i1", exercise_id: "e1", position: 0 }),
+      makeItem({ id: "i2", exercise_id: "e2", position: 1 }),
+    ];
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById: {
+        e1: makeExercise({ id: "e1" }),
+        e2: makeExercise({ id: "e2" }),
+      },
+      positionsByExerciseId: { e1: [ol], e2: [ol, dl] },
+      sportSlugById: {},
+    });
+
+    const keys = plan[0].blocks[0].groups.map((g) => g.key);
+    expect(keys).toEqual(["OL", "DL+OL"]);
+  });
+
+  it("stops a shorter group from contributing once it runs out, without affecting the other group", () => {
+    const ol = makePosition({ id: "p-ol", code: "OL", sort_order: 10 });
+    const wr = makePosition({ id: "p-wr", code: "WR", sort_order: 40 });
+    const items = [
+      makeItem({
+        id: "ol-1",
+        exercise_id: "e-ol-1",
+        position: 0,
+        duration_min: 5,
+      }),
+      makeItem({
+        id: "ol-2",
+        exercise_id: "e-ol-2",
+        position: 1,
+        duration_min: 5,
+      }),
+      makeItem({
+        id: "wr-1",
+        exercise_id: "e-wr-1",
+        position: 2,
+        duration_min: 5,
+      }),
+    ];
+    const exercisesById = Object.fromEntries(
+      items.map((item) => [
+        item.exercise_id,
+        makeExercise({ id: item.exercise_id }),
+      ]),
+    );
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById,
+      positionsByExerciseId: {
+        "e-ol-1": [ol],
+        "e-ol-2": [ol],
+        "e-wr-1": [wr],
+      },
+      sportSlugById: {},
+    });
+
+    expect(plan[0].blocks).toHaveLength(2);
+    expect(plan[0].blocks[0].groups.map((g) => g.key)).toEqual(["OL", "WR"]);
+    expect(plan[0].blocks[1].groups.map((g) => g.key)).toEqual(["OL"]);
+  });
+
+  it("falls back to DEFAULT_ITEM_DURATION_MIN when every group in a block has no duration set", () => {
+    const items = [
+      makeItem({ id: "i1", exercise_id: "e1", duration_min: null }),
+    ];
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById: { e1: makeExercise({ id: "e1" }) },
+      positionsByExerciseId: {},
+      sportSlugById: {},
+    });
+    expect(plan[0].blocks[0].suggestedDurationMin).toBe(10);
+  });
+
+  it("falls back to a placeholder exercise when the referenced exercise row is missing", () => {
+    const items = [makeItem({ id: "i1", exercise_id: "gone" })];
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById: {},
+      positionsByExerciseId: {},
+      sportSlugById: {},
+    });
+    expect(plan[0].blocks[0].groups[0].exercise.title).toBe(
+      "Ćwiczenie niedostępne",
+    );
+  });
+
+  it("resolves board elements and sport slug for the group detail view", () => {
+    const items = [makeItem({ id: "i1", exercise_id: "e1" })];
+    const plan = buildTrainingPlan({
+      items,
+      exercisesById: {
+        e1: makeExercise({
+          id: "e1",
+          sport_id: 7,
+          board_field_mode: "full",
+          board_state: [
+            { id: "el-1", type: "point", kind: "cone", x: 1, y: 2, label: "" },
+          ],
+        }),
+      },
+      positionsByExerciseId: {},
+      sportSlugById: { 7: "american_football" },
+    });
+    const { exercise } = plan[0].blocks[0].groups[0];
+    expect(exercise.sportSlug).toBe("american_football");
+    expect(exercise.boardFieldMode).toBe("full");
+    expect(exercise.boardElements).toEqual([
+      { id: "el-1", type: "point", kind: "cone", x: 1, y: 2, label: "" },
+    ]);
+  });
+});
+
+describe("formatCountdown", () => {
+  it("formats whole minutes with :00 seconds", () => {
+    expect(formatCountdown(10 * 60_000)).toBe("10:00");
+  });
+
+  it("zero-pads seconds under 10", () => {
+    expect(formatCountdown(65_000)).toBe("1:05");
+  });
+
+  it("does not pad minutes", () => {
+    expect(formatCountdown(9 * 60_000 + 5_000)).toBe("9:05");
+  });
+
+  it("clamps negative remaining time to 0:00", () => {
+    expect(formatCountdown(-500)).toBe("0:00");
+  });
+});
+
+describe("computeTimerTick", () => {
+  it("reports time remaining before the target and does not complete", () => {
+    const result = computeTimerTick({
+      targetAt: 10_000,
+      now: 4_000,
+      alreadyFired: false,
+    });
+    expect(result).toEqual({ remainingMs: 6_000, justCompleted: false });
+  });
+
+  it("completes exactly once at the target instant", () => {
+    const result = computeTimerTick({
+      targetAt: 10_000,
+      now: 10_000,
+      alreadyFired: false,
+    });
+    expect(result).toEqual({ remainingMs: 0, justCompleted: true });
+  });
+
+  it("clamps to 0 and still completes when far past the target - the backgrounded-tab case", () => {
+    // A tab backgrounded well past the block's duration: the next tick, on
+    // resume, jumps straight from "not fired" to "just completed" without
+    // ever having observed the intermediate seconds.
+    const result = computeTimerTick({
+      targetAt: 10_000,
+      now: 10_000 + 30 * 60_000,
+      alreadyFired: false,
+    });
+    expect(result).toEqual({ remainingMs: 0, justCompleted: true });
+  });
+
+  it("never re-fires completion once already fired", () => {
+    const result = computeTimerTick({
+      targetAt: 10_000,
+      now: 20_000,
+      alreadyFired: true,
+    });
+    expect(result).toEqual({ remainingMs: 0, justCompleted: false });
+  });
+});

--- a/lib/trainingMode.ts
+++ b/lib/trainingMode.ts
@@ -1,0 +1,257 @@
+import { boardElementsOf } from "@/lib/exercises";
+import type { BoardElement } from "@/lib/board/types";
+import type {
+  Exercise,
+  Position,
+  WorkoutItem,
+  WorkoutSection,
+} from "@/lib/supabase/types";
+import {
+  DEFAULT_ITEM_DURATION_MIN,
+  SECTION_LABELS,
+  SECTION_ORDER,
+} from "@/lib/workouts";
+
+// Seeded once per sport as the explicit "no split" tag (see
+// supabase/migrations/20260727210405_exercise_scope_positions_and_sport_fix.sql).
+// An exercise tagged TEAM collapses into the same group as an untagged one -
+// both mean "whole team", not a position-specific track.
+const TEAM_POSITION_CODE = "TEAM";
+const TEAM_GROUP_KEY = "team";
+// Sorts before any real position's sort_order (10, 20, ... in the seed data),
+// so a stray whole-team block in an otherwise split section still leads.
+const TEAM_GROUP_SORT_ORDER = -1;
+
+export interface TrainingExercise {
+  id: string;
+  title: string;
+  description: string | null;
+  steps: string[];
+  boardElements: BoardElement[] | null;
+  boardFieldMode: string | null;
+  sportSlug: string | null;
+}
+
+export interface TrainingGroup {
+  /** Stable identity for a group across every block in its section - sorted
+   *  position codes joined with "+", or TEAM_GROUP_KEY for the whole team. */
+  key: string;
+  /** Empty for the whole-team group. */
+  positions: Position[];
+  itemId: string;
+  durationMin: number | null;
+  exercise: TrainingExercise;
+}
+
+export interface TrainingBlock {
+  groups: TrainingGroup[];
+  /** Longest group duration in this block, falling back to
+   *  DEFAULT_ITEM_DURATION_MIN when nothing in the block has one set - the
+   *  whole block waits on its slowest group, so the timer follows the max. */
+  suggestedDurationMin: number;
+}
+
+export interface TrainingSection {
+  section: WorkoutSection;
+  label: string;
+  blocks: TrainingBlock[];
+}
+
+export type TrainingPlan = TrainingSection[];
+
+const UNAVAILABLE_EXERCISE: TrainingExercise = {
+  id: "",
+  title: "Ćwiczenie niedostępne",
+  description: null,
+  steps: [],
+  boardElements: null,
+  boardFieldMode: null,
+  sportSlug: null,
+};
+
+function toTrainingExercise(
+  exercise: Exercise | undefined,
+  sportSlugById: Record<number, string>,
+): TrainingExercise {
+  if (!exercise) return UNAVAILABLE_EXERCISE;
+  return {
+    id: exercise.id,
+    title: exercise.title,
+    description: exercise.description,
+    steps: exercise.steps,
+    boardElements: boardElementsOf(exercise),
+    boardFieldMode: exercise.board_field_mode,
+    sportSlug:
+      exercise.sport_id !== null
+        ? (sportSlugById[exercise.sport_id] ?? null)
+        : null,
+  };
+}
+
+function groupKeyFor(positions: Position[]): {
+  key: string;
+  positions: Position[];
+  sortOrder: number;
+} {
+  const tagged = positions
+    .filter((position) => position.code !== TEAM_POSITION_CODE)
+    .sort((a, b) => a.sort_order - b.sort_order);
+  if (tagged.length === 0) {
+    return {
+      key: TEAM_GROUP_KEY,
+      positions: [],
+      sortOrder: TEAM_GROUP_SORT_ORDER,
+    };
+  }
+  return {
+    key: tagged
+      .map((position) => position.code)
+      .sort()
+      .join("+"),
+    positions: tagged,
+    sortOrder: tagged[0].sort_order,
+  };
+}
+
+/**
+ * Reconstructs the section's ordered "blocks" from its flat, position-sorted
+ * workout_items: items are partitioned by their derived position-tag group
+ * (preserving each group's own relative order), then zipped index-wise
+ * across groups. A section with a single group (no positional split, or
+ * every item tagged for the whole team) zips down to one block per item -
+ * identical to a plain sequential walk. Groups of uneven length just stop
+ * contributing to later blocks once they run out, instead of padding.
+ */
+function buildSectionBlocks(
+  items: WorkoutItem[],
+  exercisesById: Record<string, Exercise>,
+  positionsByExerciseId: Record<string, Position[]>,
+  sportSlugById: Record<number, string>,
+): TrainingBlock[] {
+  const sorted = items.slice().sort((a, b) => a.position - b.position);
+
+  const groupOrder: string[] = [];
+  const itemsByGroup = new Map<string, WorkoutItem[]>();
+  const positionsByGroup = new Map<string, Position[]>();
+  const sortOrderByGroup = new Map<string, number>();
+
+  for (const item of sorted) {
+    const { key, positions, sortOrder } = groupKeyFor(
+      positionsByExerciseId[item.exercise_id] ?? [],
+    );
+    if (!itemsByGroup.has(key)) {
+      groupOrder.push(key);
+      itemsByGroup.set(key, []);
+      positionsByGroup.set(key, positions);
+      sortOrderByGroup.set(key, sortOrder);
+    }
+    itemsByGroup.get(key)!.push(item);
+  }
+
+  const orderedGroupKeys = groupOrder
+    .slice()
+    .sort((a, b) => sortOrderByGroup.get(a)! - sortOrderByGroup.get(b)!);
+
+  const blockCount = Math.max(
+    0,
+    ...orderedGroupKeys.map((key) => itemsByGroup.get(key)!.length),
+  );
+
+  const blocks: TrainingBlock[] = [];
+  for (let i = 0; i < blockCount; i++) {
+    const groups: TrainingGroup[] = [];
+    for (const key of orderedGroupKeys) {
+      const item = itemsByGroup.get(key)![i];
+      if (!item) continue;
+      groups.push({
+        key,
+        positions: positionsByGroup.get(key)!,
+        itemId: item.id,
+        durationMin: item.duration_min,
+        exercise: toTrainingExercise(
+          exercisesById[item.exercise_id],
+          sportSlugById,
+        ),
+      });
+    }
+    const suggestedDurationMin = Math.max(
+      0,
+      ...groups.map((group) => group.durationMin ?? 0),
+    );
+    blocks.push({
+      groups,
+      suggestedDurationMin:
+        suggestedDurationMin > 0
+          ? suggestedDurationMin
+          : DEFAULT_ITEM_DURATION_MIN,
+    });
+  }
+  return blocks;
+}
+
+export function buildTrainingPlan(params: {
+  items: WorkoutItem[];
+  exercisesById: Record<string, Exercise>;
+  positionsByExerciseId: Record<string, Position[]>;
+  sportSlugById: Record<number, string>;
+}): TrainingPlan {
+  const { items, exercisesById, positionsByExerciseId, sportSlugById } = params;
+
+  const itemsBySection = new Map<WorkoutSection, WorkoutItem[]>();
+  for (const section of SECTION_ORDER) itemsBySection.set(section, []);
+  for (const item of items) itemsBySection.get(item.section)?.push(item);
+
+  const plan: TrainingPlan = [];
+  for (const section of SECTION_ORDER) {
+    const sectionItems = itemsBySection.get(section) ?? [];
+    if (sectionItems.length === 0) continue;
+    plan.push({
+      section,
+      label: SECTION_LABELS[section],
+      blocks: buildSectionBlocks(
+        sectionItems,
+        exercisesById,
+        positionsByExerciseId,
+        sportSlugById,
+      ),
+    });
+  }
+  return plan;
+}
+
+// mm:ss, minutes unpadded (drills run single-digit to low-double-digit
+// minutes, never hour-scale) - "9:05", "10:00".
+export function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(remainingMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+export interface TimerTickResult {
+  remainingMs: number;
+  /** True only the instant remaining first hits 0 for this run - stays
+   *  false after, even though remainingMs keeps reading 0. */
+  justCompleted: boolean;
+}
+
+/**
+ * Pure core of the countdown, kept apart from the React hook that owns
+ * state/effects/DOM listeners. A backgrounded or throttled tab can skip any
+ * number of ticks; this only ever compares two absolute instants, so it
+ * doesn't matter how long the gap between calls was - the very next call
+ * (from a resumed interval or a visibilitychange handler) reports the true
+ * remaining time and fires completion exactly once, even if "now" lands
+ * long after the target.
+ */
+export function computeTimerTick(params: {
+  targetAt: number;
+  now: number;
+  alreadyFired: boolean;
+}): TimerTickResult {
+  const remainingMs = Math.max(0, params.targetAt - params.now);
+  return {
+    remainingMs,
+    justCompleted: remainingMs === 0 && !params.alreadyFired,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds **Tryb treningu** (training mode): a phone-first, read-only view for running a workout on the field — the live successor to the PDF. Entry point is a new "Rozpocznij trening" button on the workout detail page, alongside "Pobierz PDF" and "Udostępnij", opening `/app/workouts/[id]/train`.
- Walks the workout's sections in order (Rozgrzewka → Część główna → Ćwiczenia pozycyjne → Schłodzenie); within a section, exercises are grouped into parallel tracks derived from their existing position tags (`exercise_positions`/`positions`) — untagged or `TEAM`-tagged exercises collapse into a single "Cała drużyna" group, everything else groups by its tag set (e.g. `OL`, `WR`, `DL+OL`). No schema changes, no writes — purely derived from data that already exists.
- One shared countdown per block (not per group): suggested duration is the longest group duration in that block, editable by tapping the time, started only on an explicit "Start" tap. A "Przerwa" button blows the same sound+vibration whistle on demand for a water break.
- Tapping a group's card opens its detail screen: position tags, exercise name, description, numbered steps, and a read-only, click-to-expand board diagram (reusing `BoardView`/`BoardViewLoader`, honoring `board_field_mode`, cleanly absent when `board_state` is null).
- The timer keeps correct time while the phone is pocketed: it tracks an absolute target timestamp captured at Start and recomputes against `Date.now()` on every tick *and* on `visibilitychange`, instead of accumulating `setInterval` ticks — so a backgrounded/suspended tab still shows the true remaining time and fires the completion signal (Web Audio beep + Vibration API where supported) on return, even if it was asleep past the deadline. It never auto-advances; the coach taps "Następne ćwiczenie" themselves.
- Dark, high-contrast, large-tap-target UI throughout — built for one-handed, arm's-length outdoor use, not the rest of the app's light/dark theme.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (18 new unit tests in `lib/trainingMode.test.ts` covering the position-tag grouping/blocking logic and the timer's absolute-timestamp completion math, e.g. "still completes exactly once after a 30-minute gap with no intermediate ticks").
- Walked the full flow end-to-end in a real browser against real exercise/board data (all 4 sections, position splits, an uneven-length group running out, a multi-tag combo group, board expand/collapse, empty-board case) and specifically exercised the backgrounded-timer case: started a timer, fast-forwarded the clock past its duration with zero intermediate ticks, simulated the tab going hidden then visible, and confirmed the countdown reads the true elapsed time and the completion signal (vibration + Web Audio) fires exactly once on return.
- This sandbox's network policy blocks direct egress to the project's Supabase host, so the login-based flow itself couldn't be driven by a browser from here — verification instead rendered the real component tree against real data pulled straight from the project via the Supabase MCP connection. I've also seeded a real example workout ("Trening: tryb treningu (QA)") on the `Tester team` in the actual project, built for this — position splits, uneven group lengths, board diagrams, the works — so it's easy to click through by hand on the deployed preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkCri7bYwoDFVVQrPwByPV)_