### PR TITLE
Fix training-mode pause, action-row overflow, and dead space

### DIFF
--- a/components/training/TrainingCompleteScreen.tsx
+++ b/components/training/TrainingCompleteScreen.tsx
@@ -8,7 +8,7 @@ export function TrainingCompleteScreen({
   workoutTitle: string;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-neutral-950 px-6 text-center text-white">
+    <div className="fixed inset-x-0 top-0 z-50 flex h-dvh flex-col items-center justify-center gap-3 bg-neutral-950 px-6 text-center text-white">
       <p className="text-sm font-semibold tracking-wide text-emerald-400 uppercase">
         Trening zakończony
       </p>

--- a/components/training/TrainingGroupDetailScreen.tsx
+++ b/components/training/TrainingGroupDetailScreen.tsx
@@ -25,7 +25,7 @@ export function TrainingGroupDetailScreen({
     exercise.boardElements !== null && exercise.boardElements.length > 0;
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col overflow-y-auto bg-neutral-950 text-white">
+    <div className="fixed inset-x-0 top-0 z-50 flex h-dvh flex-col overflow-y-auto bg-neutral-950 text-white">
       <header className="flex items-center gap-3 px-5 pt-[max(1.25rem,env(safe-area-inset-top))] pb-2">
         <button
           type="button"

--- a/components/training/TrainingMode.tsx
+++ b/components/training/TrainingMode.tsx
@@ -27,7 +27,7 @@ export function TrainingMode({
 
   if (plan.length === 0) {
     return (
-      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-neutral-950 px-6 text-center text-white">
+      <div className="fixed inset-x-0 top-0 z-50 flex h-dvh flex-col items-center justify-center gap-4 bg-neutral-950 px-6 text-center text-white">
         <h1 className="text-2xl font-bold tracking-tight text-balance">
           {workoutTitle}
         </h1>

--- a/components/training/TrainingOverviewScreen.tsx
+++ b/components/training/TrainingOverviewScreen.tsx
@@ -37,7 +37,7 @@ export function TrainingOverviewScreen({
   onOpenGroup: (key: string) => void;
   onNext: () => void;
 }) {
-  const { status, remainingMs, durationMin, start, setMinutes } =
+  const { status, remainingMs, durationMin, start, pause, resume, setMinutes } =
     useTrainingTimer(blockKey, block.suggestedDurationMin, fireTrainingSignal);
   const [editing, setEditing] = useState(false);
   const [draftMinutes, setDraftMinutes] = useState(String(durationMin));
@@ -59,13 +59,8 @@ export function TrainingOverviewScreen({
     start();
   }
 
-  function handlePrzerwa() {
-    armTrainingSignal();
-    fireTrainingSignal();
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex flex-col overflow-y-auto bg-neutral-950 text-white">
+    <div className="fixed inset-x-0 top-0 z-50 flex h-dvh flex-col overflow-y-auto bg-neutral-950 text-white">
       <header className="flex items-center justify-between gap-3 px-4 pt-[max(1.25rem,env(safe-area-inset-top))]">
         <Link
           href={`/app/workouts/${workoutId}`}
@@ -151,17 +146,19 @@ export function TrainingOverviewScreen({
               Start
             </button>
           )}
-          <button
-            type="button"
-            onClick={handlePrzerwa}
-            className="flex-1 rounded-2xl border-2 border-white/30 py-4 text-xl font-bold text-white transition-colors active:bg-white/10"
-          >
-            Przerwa
-          </button>
+          {(status === "running" || status === "paused") && (
+            <button
+              type="button"
+              onClick={status === "running" ? pause : resume}
+              className="flex-1 rounded-2xl border-2 border-white/30 py-4 text-xl font-bold text-white transition-colors active:bg-white/10"
+            >
+              {status === "running" ? "Pauza" : "Wznów"}
+            </button>
+          )}
         </div>
       </div>
 
-      <div className="mt-8 flex-1 space-y-3 px-5 pb-5">
+      <div className="mt-8 flex flex-1 flex-col justify-center space-y-3 px-5 pb-5">
         {block.groups.map((group) => (
           <TrainingGroupCard
             key={group.key}

--- a/components/training/trainingSignal.ts
+++ b/components/training/trainingSignal.ts
@@ -1,16 +1,15 @@
 "use client";
 
 // The coach-facing whistle: a short beep pattern plus a vibration buzz
-// where supported. Reused for two triggers - a block's timer hitting 00:00,
-// and a manual "Przerwa" tap - same signal either way.
+// where supported. Fires when a block's timer hits 00:00.
 //
 // Autoplay policies block a *new* AudioContext (or a suspended one) from
 // making sound unless it's created/resumed inside a user gesture. The timer
 // completion fires later from a setInterval/visibilitychange callback,
 // which is never itself a gesture - so armTrainingSignal() must be called
-// from the Start/Przerwa tap handlers to create (or resume) the shared
-// context while there's still a real gesture on the stack, and
-// fireTrainingSignal() just reuses whatever that produced.
+// from the Start tap handler to create (or resume) the shared context while
+// there's still a real gesture on the stack, and fireTrainingSignal() just
+// reuses whatever that produced.
 let sharedAudioContext: AudioContext | null = null;
 
 function getAudioContextConstructor(): typeof AudioContext | null {

--- a/components/training/useTrainingTimer.ts
+++ b/components/training/useTrainingTimer.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { computeTimerTick } from "@/lib/trainingMode";
 
-export type TrainingTimerStatus = "idle" | "running" | "completed";
+export type TrainingTimerStatus = "idle" | "running" | "paused" | "completed";
 
 const TICK_MS = 1000;
 
@@ -15,6 +15,13 @@ const TICK_MS = 1000;
  * on every tick (interval or visibilitychange), compares that target
  * against Date.now() via computeTimerTick - correct regardless of how many
  * ticks were actually delivered while hidden.
+ *
+ * pause() freezes remainingMs and drops the target instead of just halting
+ * the interval, so a backgrounded tab has nothing left to recompute while
+ * paused. resume() mints a brand-new target from that frozen value rather
+ * than shifting the old target by however long the pause lasted - it never
+ * needs to know how long the phone was locked for, so pausing and
+ * backgrounding can never fight each other.
  *
  * Resets to idle on every new blockKey: the timer never auto-runs, each
  * block needs its own explicit Start tap while the coach sets out cones.
@@ -79,6 +86,31 @@ export function useTrainingTimer(
     tick();
   }, [durationMin, tick]);
 
+  // Only meaningful while running - callers are expected to gate this on
+  // status === "running" the same way the overview screen's tap target does.
+  const pause = useCallback(() => {
+    if (status !== "running") return;
+    const targetAt = targetAtRef.current;
+    if (targetAt !== null) {
+      const { remainingMs: frozenRemaining } = computeTimerTick({
+        targetAt,
+        now: Date.now(),
+        alreadyFired: firedRef.current,
+      });
+      setRemainingMs(frozenRemaining);
+    }
+    targetAtRef.current = null;
+    setStatus("paused");
+  }, [status]);
+
+  // Only meaningful while paused - callers are expected to gate this on
+  // status === "paused" the same way the overview screen's tap target does.
+  const resume = useCallback(() => {
+    if (status !== "paused") return;
+    targetAtRef.current = Date.now() + remainingMs;
+    setStatus("running");
+  }, [status, remainingMs]);
+
   // Only meaningful before Start - callers are expected to gate this on
   // status === "idle" the same way the overview screen's tap target does.
   const setMinutes = useCallback((minutes: number) => {
@@ -86,5 +118,5 @@ export function useTrainingTimer(
     setRemainingMs(minutes * 60_000);
   }, []);
 
-  return { status, remainingMs, durationMin, start, setMinutes };
+  return { status, remainingMs, durationMin, start, pause, resume, setMinutes };
 }

--- a/components/workouts/WorkoutBuilder.tsx
+++ b/components/workouts/WorkoutBuilder.tsx
@@ -579,9 +579,9 @@ export function WorkoutBuilder({
           )}
         </div>
 
-        <div className="flex shrink-0 flex-col items-end gap-3">
+        <div className="flex w-full shrink-0 flex-col items-end gap-3 sm:w-auto">
           <SaveIndicator state={saveState} />
-          <div className="flex flex-wrap items-start justify-end gap-2">
+          <div className="flex w-full flex-wrap items-start justify-end gap-2 sm:w-auto">
             <Link
               href={`/app/workouts/${workout.id}/train`}
               className="rounded-full bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"


### PR DESCRIPTION
## Summary

Three field-tested rough edges in training mode, all in one PR:

- **Real pause/resume for the block timer.** The in-block control used to be a manual whistle trigger mislabeled "Przerwa" — it never actually paused the countdown. `useTrainingTimer` now has a genuine `paused` status: `pause()` computes `remaining = target - Date.now()`, freezes it in state, and drops the target; `resume()` mints a **new** `target = Date.now() + remaining` rather than shifting the old target forward. That's deliberate — pause state is just a frozen number, so a phone locking while paused is a complete no-op (nothing recomputes while there's no `target` and no running interval/visibilitychange listener). The button now reads "Pauza" while running and "Wznów" while paused, and is hidden entirely when idle or completed. It doesn't touch `onComplete` (whistle-on-zero) or `onNext` ("Następne ćwiczenie" / the shared next-exercise advance) at all.
- **Action row overflow on the workout detail page.** "Rozpocznij trening" / "Pobierz PDF" / "Udostępnij" / "Usuń" already had `flex-wrap`, but its ancestor containers were shrink-to-fit with no definite width — a wrapping flex container with an intrinsic (auto) size computes its *max-content* size as if nothing wraps, so at ~360–390px it just ran off the right edge instead of actually wrapping. Giving the row an explicit `w-full` (`sm:w-auto` above the `sm` breakpoint) gives it a real width to wrap against. "Rozpocznij trening" stays the prominent primary action; the three secondary buttons now wrap cleanly with zero horizontal overflow.
- **Dead space at the bottom of training mode.** All four full-screen training views used `fixed inset-0`, whose effective height is ambiguous across mobile browsers as the address bar collapses/expands. Switched to `fixed inset-x-0 top-0 h-dvh` so height is pinned to the dynamic viewport explicitly instead of derived from `top/bottom` inset resolution. Also centered the overview screen's group-card list within its `flex-1` slot (`flex flex-col justify-center`) so a block with just one or two groups no longer leaves a large empty band above the sticky "Następne ćwiczenie" footer — it now sits balanced in the available space, and gracefully falls back to normal top-to-bottom flow once there's enough content to fill it.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (70 tests), and `pnpm build` all pass.
- Changes 2 and 3 (pure layout) were visually verified: rendered the exact changed markup at 360px and 390px viewports in a real Chromium instance and confirmed zero `scrollWidth` overflow at both widths, plus visual screenshots showing the action row wrapping without clipping and the training-mode group list now centered instead of leaving a dead band. No leftover test scaffolding — verification was done and torn down entirely within this session, nothing shipped in the diff.
- **Change 1 (pause/resume) is not verified here.** The logic is wired per spec (freeze-on-pause, mint-fresh-target-on-resume, no dependency on measuring paused-elapsed time), and typecheck/lint/tests pass, but the actual proof — pause → lock the screen → wait → unlock → resume → remaining time still correct — needs a real Android device and isn't something CI or a preview screenshot can confirm. That's Kamil's on-device check.

## Test plan

- [ ] On Kamil's Android device: start a block timer, tap Pauza, lock the screen, wait, unlock, tap Wznów — remaining time should be exactly what it was when paused (not fast-forwarded or reset).
- [ ] Confirm Pauza/Wznów never advances the block, resets state, or triggers the whistle/next-exercise flow.
- [ ] On a ~360–390px phone: open a workout's detail page and confirm all four action buttons are visible with no horizontal scrolling/clipping.
- [ ] On a phone in training mode, confirm no large empty band at the bottom of the screen, and no visible jump when the browser's address bar collapses/expands while scrolling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmnSGeyLieY6WQESvwVpDt)_