### PR TITLE
Add portrait "Zagrywka" field mode for AF plays

### DIFF
--- a/components/board/fields/AmericanFootballField.tsx
+++ b/components/board/fields/AmericanFootballField.tsx
@@ -12,6 +12,9 @@ const ENDZONE_COLOR = "#15532d";
 const TOTAL_YARDS = 120; // 100-yard field + two 10-yard end zones
 const ENDZONE_YARDS = 10;
 const REDZONE_WORKING_YARDS = 25; // yards of live field kept in view past the goal line
+const FIELD_WIDTH_YARDS = 160 / 3; // 53 1/3 yd sideline-to-sideline
+const PLAY_LOS_FRACTION = 0.75; // how far down the canvas the LOS sits - lower third, most height left above it for routes
+const PLAY_REFERENCE_YARDS = 30; // depth reference grid drawn above the LOS; routes may run on past it onto clean turf
 
 export const AF_FULL_WIDTH = 1200;
 export const AF_FULL_HEIGHT = 520;
@@ -23,6 +26,11 @@ export const AF_REDZONE_WIDTH = Math.round(
 );
 export const AF_REDZONE_HEIGHT = AF_FULL_HEIGHT;
 
+// Portrait play-diagram canvas: tall enough for a route tree above the LOS
+// while the field's full width still runs edge-to-edge horizontally.
+export const AF_PLAY_WIDTH = 620;
+export const AF_PLAY_HEIGHT = 820;
+
 export function AmericanFootballField({
   modeId,
   width,
@@ -33,6 +41,8 @@ export function AmericanFootballField({
       <Rect x={0} y={0} width={width} height={height} fill={TURF_COLOR} />
       {modeId === "redzone" ? (
         <RedZoneSection width={width} height={height} />
+      ) : modeId === "play" ? (
+        <PlayField width={width} height={height} />
       ) : (
         <FullField width={width} height={height} />
       )}
@@ -274,6 +284,80 @@ function RedZoneSection({ width, height }: { width: number; height: number }) {
       />
       {marks}
       <GoalPost x={MARGIN} centerY={height / 2} dir={-1} />
+    </Group>
+  );
+}
+
+// A zoomed line-of-scrimmage canvas for drawing a single play, not the full
+// field rotated: no end zones, no goalposts. Downfield is up - the LOS sits
+// low in the frame so a formation has room below it and routes have most of
+// the canvas to run into above it. The field's full WIDTH (not its length)
+// runs edge-to-edge horizontally, so the yard-line/hash-mark grain is
+// rotated 90° from FullField/RedZoneSection: yard lines are horizontal
+// (constant y) and hash marks sit at two vertical insets.
+function PlayField({ width, height }: { width: number; height: number }) {
+  const playW = width - MARGIN * 2;
+  const playH = height - MARGIN * 2;
+  const pxPerYard = playW / FIELD_WIDTH_YARDS;
+  const hashInset = playW * 0.3;
+  const losY = MARGIN + playH * PLAY_LOS_FRACTION;
+
+  const marks = [];
+  for (let yard = 0; yard <= PLAY_REFERENCE_YARDS; yard += 5) {
+    const y = losY - yard * pxPerYard;
+    if (y - MARGIN < 20) break;
+    if (yard !== 0) {
+      marks.push(
+        <Line
+          key={`pl-${yard}`}
+          points={[MARGIN, y, width - MARGIN, y]}
+          stroke={LINE_COLOR}
+          strokeWidth={LINE_WIDTH * 0.7}
+          opacity={0.75}
+        />,
+        <Text
+          key={`pn-${yard}`}
+          x={MARGIN + 6}
+          y={y - 18}
+          text={String(yard)}
+          fontSize={16}
+          fontStyle="bold"
+          fill={LINE_COLOR}
+        />,
+      );
+    }
+    marks.push(
+      <Line
+        key={`ph1-${yard}`}
+        points={[MARGIN + hashInset, y - 4, MARGIN + hashInset, y + 4]}
+        stroke={LINE_COLOR}
+        strokeWidth={2}
+      />,
+      <Line
+        key={`ph2-${yard}`}
+        points={[
+          width - MARGIN - hashInset,
+          y - 4,
+          width - MARGIN - hashInset,
+          y + 4,
+        ]}
+        stroke={LINE_COLOR}
+        strokeWidth={2}
+      />,
+    );
+  }
+
+  return (
+    <Group>
+      {marks}
+      {/* Line of scrimmage - drawn last so it stays crisp above the fainter
+          reference grid, at full LINE_WIDTH like the other modes' goal
+          line / major yard lines. */}
+      <Line
+        points={[MARGIN, losY, width - MARGIN, losY]}
+        stroke={LINE_COLOR}
+        strokeWidth={LINE_WIDTH}
+      />
     </Group>
   );
 }

--- a/components/plays/PlayForm.tsx
+++ b/components/plays/PlayForm.tsx
@@ -11,7 +11,7 @@ import { TacticsBoardLoader } from "@/components/board/TacticsBoardLoader";
 import { audienceEquals, defaultAudience, type Audience } from "@/lib/audience";
 import type { BoardElement } from "@/lib/board/types";
 import { pickDefaultSportId } from "@/lib/board/sports/registry";
-import { UNIT_LABELS, UNIT_OPTIONS } from "@/lib/plays";
+import { DEFAULT_PLAY_FIELD_MODE, UNIT_LABELS, UNIT_OPTIONS } from "@/lib/plays";
 import { createClient } from "@/lib/supabase/client";
 import type { Json, Play, PlayUnit, Sport } from "@/lib/supabase/types";
 
@@ -88,10 +88,15 @@ export function PlayForm(props: PlayFormProps) {
 
   const boardHandleRef = useRef<TacticsBoardHandle | null>(null);
   const initialBoardElements = useRef(boardElementsOf(initial)).current;
-  // No override here: null/undefined lets the board fall back to the
-  // active sport's own defaultFieldModeId (same as BoardView's fieldModeId
-  // ?? config.defaultFieldModeId), same as a play never forces a diagram.
-  const initialFieldModeId = useRef(initial?.board_field_mode).current;
+  // A brand-new play opens on its own DEFAULT_PLAY_FIELD_MODE ("play" - the
+  // portrait LOS-zoom canvas), not the sport's defaultFieldModeId, which
+  // still serves exercises. Editing an existing play keeps honouring
+  // whatever mode it was actually saved with, falling back to the sport
+  // default (same as BoardView's fieldModeId ?? config.defaultFieldModeId)
+  // for plays saved before this mode existed.
+  const initialFieldModeId = useRef(
+    props.mode === "create" ? DEFAULT_PLAY_FIELD_MODE : initial?.board_field_mode,
+  ).current;
   // No sport picker in phase 1 - resolved the same way the board itself
   // defaults a sport, and fixed for the life of this form.
   const sportId = useRef(
@@ -267,9 +272,10 @@ export function PlayForm(props: PlayFormProps) {
       <div>
         <span className={labelClasses}>Diagram (opcjonalnie)</span>
         <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-500">
-          Tablica otwiera się w domyślnym widoku boiska dla tej dyscypliny —
-          widok możesz zmienić w dowolnym momencie. Zagrywkę można zapisać też
-          bez rysunku, jako samą nazwę i notatki.
+          {props.mode === "create"
+            ? "Tablica otwiera się w pionowym widoku „Zagrywka”, dopasowanym do rysowania tras — w każdej chwili możesz przełączyć na całe boisko lub strefę końcową."
+            : "Tablica otwiera się w zapisanym widoku boiska — widok możesz zmienić w dowolnym momencie."}{" "}
+          Zagrywkę można zapisać też bez rysunku, jako samą nazwę i notatki.
         </p>
         <div className="mt-3">
           <TacticsBoardLoader

--- a/lib/board/sports/americanFootball.tsx
+++ b/lib/board/sports/americanFootball.tsx
@@ -1,6 +1,8 @@
 import {
   AF_FULL_HEIGHT,
   AF_FULL_WIDTH,
+  AF_PLAY_HEIGHT,
+  AF_PLAY_WIDTH,
   AF_REDZONE_HEIGHT,
   AF_REDZONE_WIDTH,
   AmericanFootballField,
@@ -33,7 +35,15 @@ export const americanFootballConfig: SportBoardConfig = {
       width: AF_REDZONE_WIDTH,
       height: AF_REDZONE_HEIGHT,
     },
+    {
+      id: "play",
+      label: "Zagrywka",
+      width: AF_PLAY_WIDTH,
+      height: AF_PLAY_HEIGHT,
+    },
   ],
+  // Exercises keep defaulting to "full" here - plays override their own
+  // default to "play" in PlayForm (see DEFAULT_PLAY_FIELD_MODE in lib/plays).
   defaultFieldModeId: "full",
   FieldComponent: AmericanFootballField,
   tools: [

--- a/lib/plays.ts
+++ b/lib/plays.ts
@@ -8,6 +8,17 @@ export const UNIT_LABELS: Record<PlayUnit, string> = {
   special_teams: "Zespoły specjalne",
 };
 
+// Plays are schematic (not tied to an actual field position), and drawn
+// vertically per standard playbook convention: LOS across, routes going up.
+// "play" ("Zagrywka") is the AF field mode built for exactly that (see
+// lib/board/sports/americanFootball.tsx / AmericanFootballField.tsx) - a
+// portrait LOS-zoom canvas, not the sport's own defaultFieldModeId (which
+// stays "full" for exercises). Passed as TacticsBoard's initialFieldModeId,
+// which already falls back to the active sport's own defaultFieldModeId
+// when this id isn't one of its modes - safe to reuse as-is once other
+// sports arrive.
+export const DEFAULT_PLAY_FIELD_MODE = "play";
+
 // Mirrors plays_delete (supabase/migrations/20260813143718_create_plays_table.sql):
 // owner, or the team's head coach. Kept here and tested so a future RLS
 // change that isn't mirrored here fails loudly instead of quietly showing


### PR DESCRIPTION
## Summary

Coaches draw American-football plays vertically on paper — line of scrimmage across, routes going up — which is standard playbook convention. This adds that as a new, additive AF field mode ("play" / "Zagrywka"), and makes it the default view for a brand-new play. The two existing landscape modes ("full" / "redzone") that the ~26 existing AF exercise diagrams are drawn on are left **byte-for-byte untouched**.

- `components/board/fields/AmericanFootballField.tsx`
  - New exported dimension constants `AF_PLAY_WIDTH` / `AF_PLAY_HEIGHT` (620×820, portrait).
  - New `PlayField` render branch for `modeId === "play"` — a zoomed line-of-scrimmage canvas, not the full field rotated:
    - Downfield is **up**; full field width runs horizontally.
    - The **LOS sits at 75% down the canvas** (squarely in the lower third), leaving ~25% of height below for the offensive backfield and ~75% above for routes.
    - Horizontal reference yard lines every 5 yards above the LOS (up to 30 yd), subtle (reduced width/opacity, mirroring `RedZoneSection`'s style), with upright yard numbers — never rotated text.
    - Hash marks as short ticks at the same `× 0.3` inset ratio `FullField`/`RedZoneSection` already use, just rotated 90° (vertical ticks at two inset columns instead of horizontal ticks at two inset rows).
    - No end zones, no goalposts.
  - `FullField`, `RedZoneSection`, and `GoalPost` are **pure additions around** — not one line of their bodies changed (verified in the diff).
- `lib/board/sports/americanFootball.tsx`: registers the new `"play"` field mode (label "Zagrywka"). `defaultFieldModeId` stays `"full"` — exercises are unaffected.
- `lib/plays.ts` / `components/plays/PlayForm.tsx`: a brand-new play's board now defaults to `"play"` via a reintroduced `DEFAULT_PLAY_FIELD_MODE` constant (this time pointing at a real LOS-zoom mode, unlike the earlier `"redzone"` default that a prior fix removed). Editing an existing play still honours its saved `board_field_mode`, falling back to the sport default for plays saved before this mode existed — unchanged from before. The in-editor mode switcher is untouched, so a coach can still pick "Całe boisko" or "Strefa końcowa" per play (e.g. special teams).

No database/migration/RLS changes — purely frontend rendering + a default-mode wiring change.

## Design choices for review (Kamil's call)

- Canvas: **620×820px** portrait.
- LOS placement: **75% down** the canvas (lower third band is 66.7%–100%).
- Depth reference grid: every 5 yards, up to 30 yards above the LOS, then clean turf beyond that so routes aren't visually capped.
- Hash inset: same `0.3` ratio already used by the two landscape modes, just rotated onto the width axis (which now carries the sideline-to-sideline dimension).

These are easy single-constant tweaks (`PLAY_LOS_FRACTION`, `PLAY_REFERENCE_YARDS`, `AF_PLAY_WIDTH/HEIGHT` in `AmericanFootballField.tsx`) if the proportions should shift after an on-device look.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` all green.
- Visual check done via a temporary, Supabase-free local preview harness (mounted the real board components directly with a fake in-memory `Sport`, no auth/DB touched, removed before committing) — confirmed:
  - A new play opens on the portrait "Zagrywka" field, LOS in the lower third, upright text, no console errors/warnings.
  - A board with no saved mode (mirroring an exercise or a pre-existing play) still defaults to "Całe boisko" ("full"), unchanged.
  - The raw "full" and "redzone" renders looked visually identical to before.
- Did not touch Supabase, RLS, the `plays` table, migrations, or the plays list/filters. No production test data was created; the only local artifacts (a temporary `app/dev-preview` route and `.env.local` with a placeholder, non-resolving Supabase URL) were deleted before this commit — confirmed via `git status` showing only the 4 intended files.

## Test plan

- [ ] Open `/app/plays/new` — board should open on "Zagrywka" (portrait), LOS visible in the lower third.
- [ ] Switch modes via the in-editor toggle — "Całe boisko" and "Strefa końcowa" should render exactly as before.
- [ ] Open an existing AF exercise diagram — confirm it renders pixel-identical to before (nothing shifted).
- [ ] Edit an existing play saved before this change — confirm it still opens on its previous mode (or "Całe boisko" if none was saved).

---
_Generated by [Claude Code](https://claude.ai/code/session_012KXKnvKrGxKMdGPa6y9ApH)_